### PR TITLE
Improve the Database shutdown procedure

### DIFF
--- a/bfffs/src/common/cleaner.rs
+++ b/bfffs/src/common/cleaner.rs
@@ -15,7 +15,10 @@ use futures::{
     stream::self,
 };
 use std::sync::Arc;
-use tokio::runtime::Handle;
+use tokio::{
+    runtime::Handle,
+    task::JoinHandle
+};
 
 struct SyncCleaner {
     /// Handle to the DML.
@@ -87,6 +90,7 @@ impl SyncCleaner {
 ///
 /// Cleans old Zones by moving their data to empty zones and erasing them.
 pub struct Cleaner {
+    jh: JoinHandle<()>,
     tx: Option<mpsc::Sender<oneshot::Sender<()>>>
 }
 
@@ -114,37 +118,37 @@ impl Cleaner {
     pub fn new(handle: Handle, idml: Arc<IDML>, thresh: Option<f32>) -> Self
     {
         let (tx, rx) = mpsc::channel(1);
-        Cleaner::run(handle, idml, thresh.unwrap_or(Cleaner::DEFAULT_THRESHOLD),
-                     rx);
-        Cleaner{tx: Some(tx)}
+        let jh = Cleaner::run(handle, idml,
+                              thresh.unwrap_or(Cleaner::DEFAULT_THRESHOLD), rx);
+        Cleaner{jh, tx: Some(tx)}
     }
 
     // Start a task that will clean the system in the background, whenever
     // requested.
     fn run(handle: Handle, idml: Arc<IDML>, thresh: f32,
            rx: mpsc::Receiver<oneshot::Sender<()>>)
+        -> JoinHandle<()>
     {
         handle.spawn(async move {
             let sync_cleaner = SyncCleaner::new(idml, thresh);
-            rx.map(|tx| Ok(tx))
-            .try_for_each(move |tx| {
+            rx.for_each(move |tx| {
                 sync_cleaner.clean_now()
                     .map_err(Error::unhandled)
                     .map_ok(move |_| {
                         // Ignore errors.  An error here indicates that the
                         // client doesn't want to be notified.
                         let _result = tx.send(());
-                    })
+                    }).map(drop)
             }).await
-        });
+        })
     }
 
     // Shutdown the Cleaner's background task
-    pub fn shutdown(&mut self) -> impl Future<Output=Result<(), ()>> + Send {
+    pub async fn shutdown(mut self) {
         // Ignore return value.  An error indicates that the Cleaner is already
         // shut down.
-        let _ = self.tx.take();
-        future::ok::<(), ()>(())
+        drop(self.tx.take());
+        self.jh.await.unwrap();
     }
 }
 

--- a/bfffs/tests/common/clean_zone.rs
+++ b/bfffs/tests/common/clean_zone.rs
@@ -130,9 +130,9 @@ test_suite! {
                  statvfs.f_bfree, statvfs.f_blocks);
         assert!(rt.block_on(db.check()).unwrap());
         drop(fs);
-        let mut owned_db = Arc::try_unwrap(db)
+        let owned_db = Arc::try_unwrap(db)
         .ok().expect("Unwrapping Database failed");
-        rt.block_on(owned_db.shutdown()).unwrap();
+        rt.block_on(owned_db.shutdown());
     }
 
     /// A regression test for bug d5b4dab35d9be12ff1505e886ed5ca8ad4b6a526

--- a/bfffs/tests/common/database.rs
+++ b/bfffs/tests/common/database.rs
@@ -284,7 +284,7 @@ test_suite! {
         let file = t!(fs::File::create(&filename));
         t!(file.set_len(len));
         drop(file);
-        let mut db = rt.block_on(async move {
+        let db = rt.block_on(async move {
             Pool::create_cluster(None, 1, None, 0, &[filename])
             .map_err(|_| unreachable!())
             .and_then(|cluster| {
@@ -301,6 +301,6 @@ test_suite! {
                 })
             }).await
         }).unwrap();
-        rt.block_on(db.shutdown()).unwrap();
+        rt.block_on(db.shutdown());
     }
 }

--- a/bfffs/tests/common/fs.rs
+++ b/bfffs/tests/common/fs.rs
@@ -2718,10 +2718,10 @@ test_suite! {
         fn shutdown(mut self) {
             self.fs.inactive(self.root);
             drop(self.fs);
-            let mut db = Arc::try_unwrap(self.db.take().unwrap())
+            let db = Arc::try_unwrap(self.db.take().unwrap())
                 .ok().expect("Arc::try_unwrap");
             let mut rt = self.rt.take().unwrap();
-            rt.block_on(db.shutdown()).unwrap();
+            rt.block_on(db.shutdown());
         }
 
         fn step(&mut self) {


### PR DESCRIPTION
* Make Database::shutdown a destructor.  There's no way to restart a
  database once it's been shut down, so we may as well destroy it.  This
  also prevents any errors that may happen from shutting it down twice,
  or using it after shutdown.

* Remove some oneshots.  They're no longer needed, since Tokio-0.2's
  spawn method returns a JoinHandle.

* Make Cleaner::shutdown wait until the cleaner task completes.

Fixes #21