### PR TITLE
Tokio 0.2 cleanup

### DIFF
--- a/bfffs-fio/src/lib.rs
+++ b/bfffs-fio/src/lib.rs
@@ -7,9 +7,7 @@ use bfffs::common::{
     database::TreeID,
     device_manager::DevManager,
     fs::{FileData, Fs},
-    Error,
 };
-use futures::{future, FutureExt};
 use lazy_static::lazy_static;
 use memoffset::offset_of;
 use std::{
@@ -212,11 +210,7 @@ pub unsafe extern "C" fn fio_bfffs_init(td: *mut thread_data) -> libc::c_int
             }
             let handle = rt.handle().clone();
             let r = rt.block_on(async move {
-                if let Ok(fut) = dev_manager.import_by_name(pool, handle) {
-                    fut.boxed()
-                } else {
-                    future::err(Error::ENOENT).boxed()
-                }.await
+                dev_manager.import_by_name(pool, handle).await
             });
             if let Ok(db) = r {
                 let adb = Arc::new(db);

--- a/bfffs/src/bin/bfffs.rs
+++ b/bfffs/src/bin/bfffs.rs
@@ -47,7 +47,7 @@ pub fn main(args: &clap::ArgMatches) {
             eprintln!("Error: pool not found");
             exit(1);
         }).await
-    }).unwrap());
+    }));
     rt.block_on(async {
         db.check().await
     }).unwrap();
@@ -86,11 +86,12 @@ fn dump_tree<P: AsRef<Path>>(poolname: String, disks: &[P]) {
     let handle = rt.handle().clone();
     let db = Arc::new(rt.block_on(async move {
         dev_manager.import_by_name(poolname, handle)
+        .await
         .unwrap_or_else(|_e| {
             eprintln!("Error: pool not found");
             exit(1);
-        }).await
-    }).unwrap());
+        })
+    }));
     // For now, hardcode tree_id to 0
     let tree_id = TreeID::Fs(0);
     db.dump(&mut std::io::stdout(), tree_id).unwrap()

--- a/bfffs/src/common/cleaner.rs
+++ b/bfffs/src/common/cleaner.rs
@@ -98,7 +98,6 @@ impl Cleaner {
     /// The returned `Receiver` will deliver notification when cleaning is
     /// complete.  However, there is no requirement to poll it.  The client may
     /// drop it, and cleaning will continue in the background.
-    // TODO: return the Tokio JoinHandle instead of using a oneshot
     pub fn clean(&self) -> oneshot::Receiver<()> {
         let (tx, rx) = oneshot::channel();
         if let Err(e) = self.tx.as_ref().unwrap().clone().try_send(tx) {

--- a/bfffs/src/common/ddml/ddml.rs
+++ b/bfffs/src/common/ddml/ddml.rs
@@ -116,7 +116,7 @@ impl DDML {
         // 4) Decompress
         let len = drp.asize() as usize * BYTES_PER_LBA;
         let dbs = DivBufShared::uninitialized(len);
-        Box::new(
+        Box::pin(
             // Read
             self.pool.read(dbs.try_mut().unwrap(), drp.pba)
             .and_then(move |_| {

--- a/bfffs/src/common/fs.rs
+++ b/bfffs/src/common/fs.rs
@@ -75,17 +75,17 @@ mod htable {
         where T: HTItem
     {
         dataset.get(key)
-        .then(move |r| {
+        .map(move |r| {
             match r {
                 Ok(fsvalue) => {
                     match T::from_table(fsvalue) {
                         HTValue::Single(old) => {
                             if old.same(aux, &name) {
                                 // Found the right item
-                                future::ok(old).boxed()
+                                Ok(old)
                             } else {
                                 // Hash collision
-                                future::err(T::ENOTFOUND).boxed()
+                                Err(T::ENOTFOUND)
                             }
                         },
                         HTValue::Bucket(old) => {
@@ -94,21 +94,21 @@ mod htable {
                                 x.same(aux, &name)
                             }) {
                                 // Found the right one
-                                future::ok(v).boxed()
+                                Ok(v)
                             } else {
                                 // A 3 (or more) way hash collision.  The
                                 // item we're looking up isn't found.
-                                future::err(T::ENOTFOUND).boxed()
+                                Err(T::ENOTFOUND)
                             }
                         },
                         HTValue::None => {
-                            future::err(T::ENOTFOUND).boxed()
+                            Err(T::ENOTFOUND)
                         },
                         HTValue::Other(x) =>
                             panic!("Unexpected value {:?} for key {:?}", x, key)
                     }
                 },
-                Err(e) => future::err(e).boxed()
+                Err(e) => Err(e)
             }
         })
     }

--- a/bfffs/src/common/fs_tree.rs
+++ b/bfffs/src/common/fs_tree.rs
@@ -414,10 +414,9 @@ pub struct BlobExtAttr<A: Addr> {
 }
 
 impl<A: Addr> BlobExtAttr<A> {
-    fn flush(self) -> Pin<Box<dyn Future<Output=Result<ExtAttr<A>, Error>>
-        + Send>>
+    fn flush(self) -> ExtAttr<A>
     {
-        future::ok(ExtAttr::Blob(self)).boxed()
+        ExtAttr::Blob(self)
     }
 }
 
@@ -444,7 +443,7 @@ impl<'a, A: Addr> ExtAttr<A> {
     {
         match self {
             ExtAttr::Inline(iea) => iea.flush(dml, txg),
-            ExtAttr::Blob(bea) => bea.flush(),
+            ExtAttr::Blob(bea) => future::ok(bea.flush()).boxed()
         }
     }
 

--- a/bfffs/src/common/pool.rs
+++ b/bfffs/src/common/pool.rs
@@ -61,7 +61,7 @@ enum Rpc {
 /// thread, it owns a `Cluster` and serves RPC requests from its own and other
 /// threads.
 ///
-/// TODO: Since the upgrade to Tokio 0.3, all Futures beneath Cluster are now
+/// TODO: Since the upgrade to Tokio 0.2, all Futures beneath Cluster are now
 /// Send + Sync.  So it would be possible to make Cluster Send + Sync, too.
 /// Consider eliminating ClusterServer.
 struct ClusterServer {
@@ -187,7 +187,6 @@ impl Future for ClusterProxyWrite
     type Output = Result<LbaT, Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        // TODO: can this be replaced by self.rx.poll(cx) ?
         match Pin::new(&mut self.rx).poll(cx) {
             Poll::Ready(Ok(r)) => {
                 match r {

--- a/bfffs/src/common/tree/node.rs
+++ b/bfffs/src/common/tree/node.rs
@@ -70,7 +70,6 @@ pub trait Value: Clone + Debug + DeserializeOwned + PartialEq + Send +
     Serialize + TypicalSize + 'static
 {
     /// Prepare this `Value` to be written to disk
-    // TODO: return an infalliable Future instead of a TryFuture
     // LCOV_EXCL_START   unreachable code
     fn flush<D>(self, _dml: &D, _txg: TxgT)
         -> Pin<Box<dyn Future<Output=Result<Self, Error>> + Send>>

--- a/bfffs/src/common/tree/tree/mod.rs
+++ b/bfffs/src/common/tree/tree/mod.rs
@@ -1924,8 +1924,8 @@ impl<A, D, K, V> Tree<A, D, K, V>
                 // Cache.
                 let key = elem.key;
                 let dml3 = dml.clone();
-                let fut = elem.ptr.as_mem().xlock().and_then(move |guard|
-                {
+                let fut = elem.ptr.as_mem().xlock()
+                .then(move |guard| {
                     drop(guard);
                     Tree::flush_r(dml3, int_compressor, leaf_compressor,
                                   *elem.ptr.into_node(), txg)

--- a/bfffs/tests/common/device_manager.rs
+++ b/bfffs/tests/common/device_manager.rs
@@ -83,7 +83,7 @@ test_suite! {
         }
         let handle = rt.handle().clone();
         let _db = rt.block_on(async move {
-            dm.import_by_name("test_device_manager", handle).unwrap()
+            dm.import_by_name("test_device_manager", handle)
             .await
         }).unwrap();
     }


### PR DESCRIPTION
Several small cleanups since upgrading to Tokio 0.2

* Simplify BlobExtAttr::flush
* Return an infalliable future from Node::xlock
* Return an infalliable future from Tree::read_root
* Return an infalliable future from Tree::write_root
* Replace a Box::new(future) with Box::pin(future)
* Simplify fs::htable::get
* When mounting a file system, delete dying inodes in the background
* Simplify DevManager::import_by_name, now that all Futures are Send
* Fix some comments

Fixes #17 