### PR TITLE
Remove ClusterServer/ClusterProxy

### DIFF
--- a/bfffs-fio/src/lib.rs
+++ b/bfffs-fio/src/lib.rs
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn fio_bfffs_init(td: *mut thread_data) -> libc::c_int
 {
     let mut fs = FS.lock().unwrap();
     if fs.is_none() {
-        let mut rt = RUNTIME.lock().unwrap();
+        let rt = RUNTIME.lock().unwrap();
         let opts = (*td).eo as *mut BfffsOptions;
         if opts as isize != -1 {
             let (pool, vdevs) = {
@@ -209,9 +209,7 @@ pub unsafe extern "C" fn fio_bfffs_init(td: *mut thread_data) -> libc::c_int
                 dev_manager.taste(borrowed_vdev);
             }
             let handle = rt.handle().clone();
-            let r = rt.block_on(async move {
-                dev_manager.import_by_name(pool, handle).await
-            });
+            let r = dev_manager.import_by_name(pool, handle);
             if let Ok(db) = r {
                 let adb = Arc::new(db);
                 // For now, hardcode tree_id to 0

--- a/bfffs-fuse/src/bin/bfffsd/main.rs
+++ b/bfffs-fuse/src/bin/bfffsd/main.rs
@@ -67,7 +67,7 @@ fn main() {
             **name == poolname
         }).nth(0).unwrap().1;
 
-    let mut rt = Builder::new()
+    let rt = Builder::new()
         .threaded_scheduler()
         .enable_io()
         .enable_time()
@@ -75,9 +75,7 @@ fn main() {
         .unwrap();
     let handle = rt.handle().clone();
     let handle2 = rt.handle().clone();
-    let db = Arc::new(rt.block_on(async move {
-        dev_manager.import_by_uuid(uuid, handle).await
-    }).unwrap());
+    let db = Arc::new(dev_manager.import_by_uuid(uuid, handle).unwrap());
     // For now, hardcode tree_id to 0
     let tree_id = TreeID::Fs(0);
     let db2 = db.clone();

--- a/bfffs/src/common/database/database.rs
+++ b/bfffs/src/common/database/database.rs
@@ -551,7 +551,6 @@ impl Database {
         future::join(self.syncer.shutdown(),
                      self.cleaner.shutdown())
         .await;
-        self.inner.idml.shutdown();
     }
 
     /// Finish the current transaction group and start a new one.
@@ -706,10 +705,7 @@ mod database {
 
     #[test]
     fn shutdown() {
-        let mut idml = IDML::default();
-        idml.expect_shutdown()
-            .once()
-            .return_const(());
+        let idml = IDML::default();
         let forest = Tree::default();
 
         let mut rt = basic_runtime();

--- a/bfffs/src/common/ddml/ddml.rs
+++ b/bfffs/src/common/ddml/ddml.rs
@@ -13,6 +13,7 @@ use metrohash::MetroHash64;
 use std::{
     borrow,
     hash::Hasher,
+    iter,
     pin::Pin,
     sync::{Arc, Mutex}
 };
@@ -71,38 +72,29 @@ impl DDML {
     }
 
     /// List all closed zones in the `DDML` in no particular order
+    // TODO: convert from a Stream to an Iterator
     pub fn list_closed_zones(&self)
         -> impl Stream<Item=Result<ClosedZone, Error>> + Send
     {
-        struct State {
-            pool: Arc<Pool>,
-            cluster: ClusterT,
-            zid: ZoneT
-        };
-
-        let initial = Some(State{pool: self.pool.clone(), cluster: 0, zid: 0});
-        stream::try_unfold(initial, |state| async {
-            if let Some(s) = state {
-                let fut = s.pool.find_closed_zone(s.cluster, s.zid)
-                .map_ok(|r| {
-                    match r {
-                        (Some(pclz), Some((c, z))) => {
-                            let next = State{pool: s.pool, cluster: c, zid: z};
-                            Some((Some(pclz), Some(next)))
-                        },
-                        (Some(_), None) => unreachable!(),  // LCOV_EXCL_LINE
-                        (None, Some((c, z))) => {
-                            let next = State{pool: s.pool, cluster: c, zid: z};
-                            Some((None, Some(next)))
-                        },
-                        (None, None) => Some((None, None))
-                    }
-                }); // LCOV_EXCL_LINE   kcov false negative
-                fut.await
-            } else {
-                Ok(None)
+        let mut next = (0, 0);
+        let pool = self.pool.clone();
+        let iter = iter::from_fn(move || {
+            loop {
+                match pool.find_closed_zone(next.0, next.1) {
+                    (Some(pclz), Some((c, z))) => {
+                        next = (c, z);
+                        break Some(pclz);
+                    },
+                    (Some(_), None) => unreachable!(),  // LCOV_EXCL_LINE
+                    (None, Some((c, z))) => {
+                        next = (c, z);
+                        continue;
+                    },
+                    (None, None) => {break None;}
+                }
             }
-        }).try_filter_map(future::ok)
+        }).map(Ok);
+        stream::iter(iter)
     }
 
     /// Read a record from disk
@@ -547,29 +539,23 @@ mod ddml {
         let clz0_1 = clz0.clone();
         pool.expect_find_closed_zone()
             .with(eq(0), eq(0))
-            .return_once(move |_, _| {
-                let next = Some((0, 11));
-                Box::pin(future::ok((Some(clz0_1), next)))
-            });
+            .return_once(move |_, _| (Some(clz0_1), Some((0, 11))));
 
         let clz1 = ClosedZone{pba: PBA::new(0, 30), freed_blocks: 6, zid: 1,
             total_blocks: 10, txgs: TxgT::from(2)..TxgT::from(3)};
         let clz1_1 = clz1.clone();
         pool.expect_find_closed_zone()
             .with(eq(0), eq(11))
-            .return_once(move |_, _| {
-                let next = Some((0, 31));
-                Box::pin(future::ok((Some(clz1_1), next)))
-            });
+            .return_once(move |_, _| (Some(clz1_1), Some((0, 31))));
 
         pool.expect_find_closed_zone()
             .with(eq(0), eq(31))
-            .return_once(|_, _| Box::pin(future::ok((None, Some((1, 0))))));
+            .return_once(|_, _| (None, Some((1, 0))));
 
         // The second cluster has no closed zones
         pool.expect_find_closed_zone()
             .with(eq(1), eq(0))
-            .return_once(|_, _| Box::pin(future::ok((None, Some((2, 0))))));
+            .return_once(|_, _| (None, Some((2, 0))));
 
         // The third cluster has one closed zone
         let clz2 = ClosedZone{pba: PBA::new(2, 10), freed_blocks: 5, zid: 2,
@@ -577,12 +563,11 @@ mod ddml {
         let clz2_1 = clz2.clone();
         pool.expect_find_closed_zone()
             .with(eq(2), eq(0))
-            .return_once(move |_, _|
-            Box::pin(future::ok((Some(clz2_1), Some((2, 11))))));
+            .return_once(move |_, _| (Some(clz2_1), Some((2, 11))));
 
         pool.expect_find_closed_zone()
             .with(eq(2), eq(11))
-            .return_once(|_, _| Box::pin(future::ok((None, None))));
+            .return_once(|_, _| (None, None));
 
         let ddml = DDML::new(pool, Arc::new(Mutex::new(cache)));
 

--- a/bfffs/src/common/ddml/ddml.rs
+++ b/bfffs/src/common/ddml/ddml.rs
@@ -213,11 +213,6 @@ impl DDML {
         self.put_common(cacheref, compression, txg)
     }
 
-    /// Shutdown all background tasks.
-    pub fn shutdown(&self) {
-        self.pool.shutdown()
-    }
-
     /// Return approximately the usable storage space in LBAs.
     pub fn size(&self) -> LbaT {
         self.pool.size()
@@ -321,7 +316,6 @@ mock! {
                          txg: TxgT)
             -> Pin<Box<dyn Future<Output=Result<DRP, Error>> + Send>>
             where T: borrow::Borrow<dyn CacheRef>;
-        pub fn shutdown(&self);
         pub fn size(&self) -> LbaT;
         pub fn write_label(&self, labeller: LabelWriter)
             -> Pin<Box<dyn Future<Output=Result<(), Error>> + Send>>;

--- a/bfffs/src/common/idml/idml.rs
+++ b/bfffs/src/common/idml/idml.rs
@@ -213,9 +213,9 @@ impl<'a> IDML {
     }
 
     pub fn list_closed_zones(&self)
-        -> impl Stream<Item=Result<ClosedZone, Error>> + Send
+        -> impl Iterator<Item=ClosedZone> + Send
     {
-        futures::stream::iter(self.ddml.list_closed_zones().map(Ok))
+        self.ddml.list_closed_zones()
     }
 
     /// Return a list of all active (not deleted) indirect Records that have
@@ -559,7 +559,7 @@ mock!{
         pub fn flush(&self, idx: u32, txg: TxgT)
             -> Pin<Box<dyn Future<Output=Result<(), Error>> + Send>>;
         pub fn list_closed_zones(&self)
-            -> Pin<Box<dyn Stream<Item=Result<ClosedZone, Error>> + Send>>;
+            -> impl Iterator<Item=ClosedZone> + Send;
         pub fn open(ddml: Arc<DDML>, cache: Arc<Mutex<Cache>>,
                      mut label_reader: LabelReader) -> (Self, LabelReader);
         pub fn size(&self) -> LbaT;

--- a/bfffs/src/common/idml/idml.rs
+++ b/bfffs/src/common/idml/idml.rs
@@ -215,7 +215,7 @@ impl<'a> IDML {
     pub fn list_closed_zones(&self)
         -> impl Stream<Item=Result<ClosedZone, Error>> + Send
     {
-        self.ddml.list_closed_zones()
+        futures::stream::iter(self.ddml.list_closed_zones().map(Ok))
     }
 
     /// Return a list of all active (not deleted) indirect Records that have

--- a/bfffs/src/common/idml/idml.rs
+++ b/bfffs/src/common/idml/idml.rs
@@ -328,11 +328,6 @@ impl<'a> IDML {
             })  // LCOV_EXCL_LINE   kcov false negative
     }
 
-    /// Shutdown all background tasks.
-    pub fn shutdown(&self) {
-        self.ddml.shutdown()
-    }
-
     /// Return approximately the usable storage space in LBAs.
     pub fn size(&self) -> LbaT {
         self.ddml.size()
@@ -567,7 +562,6 @@ mock!{
             -> Pin<Box<dyn Stream<Item=Result<ClosedZone, Error>> + Send>>;
         pub fn open(ddml: Arc<DDML>, cache: Arc<Mutex<Cache>>,
                      mut label_reader: LabelReader) -> (Self, LabelReader);
-        pub fn shutdown(&self);
         pub fn size(&self) -> LbaT;
         // Return a static reference instead of a RwLockReadFut because it makes
         // the expectations easier to write

--- a/bfffs/src/common/pool.rs
+++ b/bfffs/src/common/pool.rs
@@ -332,10 +332,6 @@ impl Pool {
         Box::pin(fut)
     }
 
-    /// Shutdown all background tasks.
-    // TODO: remove this function, since it no longer does anything
-    pub fn shutdown(&self) {}
-
     /// Return approximately the Pool's usable storage space in LBAs.
     pub fn size(&self) -> LbaT {
         self.stats.size()

--- a/bfffs/tests/common/clean_zone.rs
+++ b/bfffs/tests/common/clean_zone.rs
@@ -43,21 +43,17 @@ test_suite! {
             t!(file.set_len(*self.devsize));
             drop(file);
             let zone_size = NonZeroU64::new(*self.zone_size);
-            let db = rt.block_on(async move {
-                let cluster = Pool::create_cluster(None, 1, zone_size, 0,
-                                                   &[filename])
-                    .await.unwrap();
-                let pool = Pool::create(String::from("test_fs"), vec![cluster])
-                    .await.unwrap();
-                let cache = Arc::new(
-                    Mutex::new(
-                        Cache::with_capacity(32_000_000)
-                    )
-                );
-                let ddml = Arc::new(DDML::new(pool, cache.clone()));
-                let idml = IDML::create(ddml, cache);
-                Arc::new(Database::create(Arc::new(idml), handle))
-            });
+            let cluster = Pool::create_cluster(None, 1, zone_size, 0,
+                                               &[filename]);
+            let pool = Pool::create(String::from("test_fs"), vec![cluster]);
+            let cache = Arc::new(
+                Mutex::new(
+                    Cache::with_capacity(32_000_000)
+                )
+            );
+            let ddml = Arc::new(DDML::new(pool, cache.clone()));
+            let idml = IDML::create(ddml, cache);
+            let db = Arc::new(Database::create(Arc::new(idml), handle));
             let handle = rt.handle().clone();
             let (db, tree_id) = rt.block_on(async move {
                 let tree_id = db.new_fs(Vec::new())

--- a/bfffs/tests/common/ddml.rs
+++ b/bfffs/tests/common/ddml.rs
@@ -11,7 +11,7 @@ test_suite! {
         TxgT
     };
     use divbuf::{DivBuf, DivBufShared};
-    use futures::{TryFutureExt, future};
+    use futures::TryFutureExt;
     use galvanic_test::*;
     use pretty_assertions::assert_eq;
     use std::{
@@ -32,18 +32,12 @@ test_suite! {
             let filename = tempdir.path().join("vdev");
             let file = t!(fs::File::create(&filename));
             t!(file.set_len(len));
-            let mut rt = basic_runtime();
-            let pool = rt.block_on(async {
-                let cs = NonZeroU64::new(1);
-                let clusters = vec![
-                    Pool::create_cluster(cs, 1, None, 0, &[filename][..])
-                ];
-                future::try_join_all(clusters)
-                    .map_err(|_| unreachable!())
-                    .and_then(|clusters|
-                        Pool::create("TestPool".to_string(), clusters)
-                    ).await
-            }).unwrap();
+            let rt = basic_runtime();
+            let cs = NonZeroU64::new(1);
+            let clusters = vec![
+                Pool::create_cluster(cs, 1, None, 0, &[filename][..])
+            ];
+            let pool = Pool::create("TestPool".to_string(), clusters);
             let cache = Cache::with_capacity(1_000_000_000);
             (rt, DDML::new(pool, Arc::new(Mutex::new(cache))))
         }

--- a/bfffs/tests/common/idml.rs
+++ b/bfffs/tests/common/idml.rs
@@ -276,11 +276,8 @@ test_suite! {
                 idml3.txg()
                 .then(move |txg| {
                     let idml5 = idml3.clone();
-                    idml3.list_closed_zones()
-                    .take(1)
-                    .try_for_each(move  |cz| {
-                        idml5.clean_zone(cz, *txg).boxed()
-                    })
+                    let cz = idml3.list_closed_zones().next().unwrap();
+                    idml5.clean_zone(cz, *txg)
                 })
             }).and_then(move |_| {
                 idml4.check()

--- a/bfffs/tests/common/idml.rs
+++ b/bfffs/tests/common/idml.rs
@@ -13,7 +13,7 @@ test_suite! {
     use bfffs::common::idml::*;
     use bfffs::common::label::*;
     use bfffs::common::vdev_file::*;
-    use futures::{TryFutureExt, future};
+    use futures::TryFutureExt;
     use galvanic_test::*;
     use pretty_assertions::assert_eq;
     use std::{
@@ -119,17 +119,11 @@ test_suite! {
                 t!(file.set_len(len));
             }
             let paths = [filename.clone()];
-            let mut rt = basic_runtime();
-            let pool = rt.block_on(async {
-                let cs = NonZeroU64::new(1);
-                let cluster = Pool::create_cluster(cs, 1, None, 0, &paths);
-                let clusters = vec![cluster];
-                future::try_join_all(clusters)
-                .map_err(|_| unreachable!())
-                .and_then(|clusters|
-                    Pool::create(POOLNAME.to_string(), clusters)
-                ).await
-            }).unwrap();
+            let rt = basic_runtime();
+            let cs = NonZeroU64::new(1);
+            let cluster = Pool::create_cluster(cs, 1, None, 0, &paths);
+            let clusters = vec![cluster];
+            let pool = Pool::create(POOLNAME.to_string(), clusters);
             let cache = Arc::new(Mutex::new(Cache::with_capacity(1000)));
             let ddml = Arc::new(DDML::new(pool, cache.clone()));
             let idml = Arc::new(IDML::create(ddml, cache));
@@ -157,14 +151,12 @@ test_suite! {
         let _idml = rt.block_on(async {
             VdevFile::open(path)
             .and_then(|(leaf, reader)| {
-                    let block = VdevBlock::new(leaf);
-                    let (vr, lr) = raid::open(None, vec![(block, reader)]);
-                    cluster::Cluster::open(vr)
-                    .map_ok(move |cluster| (cluster, lr))
-            }).and_then(move |(cluster, reader)|{
-                let proxy = ClusterProxy::new(cluster);
-                Pool::open(None, vec![(proxy, reader)])
-            }).map_ok(|(pool, reader)| {
+                let block = VdevBlock::new(leaf);
+                let (vr, lr) = raid::open(None, vec![(block, reader)]);
+                cluster::Cluster::open(vr)
+                .map_ok(move |cluster| (cluster, lr))
+            }).map_ok(move |(cluster, reader)|{
+                let (pool, reader) = Pool::open(None, vec![(cluster, reader)]);
                 let cache = cache::Cache::with_capacity(1_000_000);
                 let arc_cache = Arc::new(Mutex::new(cache));
                 let ddml = Arc::new(ddml::DDML::open(pool, arc_cache.clone()));
@@ -219,7 +211,6 @@ test_suite! {
         StreamExt,
         TryFutureExt,
         TryStreamExt,
-        future,
         stream
     };
     use galvanic_test::*;
@@ -246,18 +237,12 @@ test_suite! {
                 t!(file.set_len(len));
             }
             let paths = [filename];
-            let mut rt = basic_runtime();
-            let pool = rt.block_on(async {
-                let cs = NonZeroU64::new(1);
-                let lpz = NonZeroU64::new(LBA_PER_ZONE);
-                let cluster = Pool::create_cluster(cs, 1, lpz, 0, &paths);
-                let clusters = vec![cluster];
-                future::try_join_all(clusters)
-                .map_err(|_| unreachable!())
-                .and_then(|clusters|
-                    Pool::create(POOLNAME.to_string(), clusters)
-                ).await
-            }).unwrap();
+            let rt = basic_runtime();
+            let cs = NonZeroU64::new(1);
+            let lpz = NonZeroU64::new(LBA_PER_ZONE);
+            let cluster = Pool::create_cluster(cs, 1, lpz, 0, &paths);
+            let clusters = vec![cluster];
+            let pool = Pool::create(POOLNAME.to_string(), clusters);
             let cache = Arc::new(Mutex::new(Cache::with_capacity(1_000_000)));
             let ddml = Arc::new(DDML::new(pool, cache.clone()));
             let idml = IDML::create(ddml, cache);


### PR DESCRIPTION
Now that all BFFFs futures are Send, there's no need for these structs.
Removing them considerably simplifies the code, and speeds up fio
benchmarks, too.  Previously, the oneshot used to communicated between
ClusterProxy/ClusterServer consumed an inordinate amount of CPU time.
    
Fixes #15
