### PR TITLE
Change the default record size to 128 kB

### DIFF
--- a/bfffs/src/common/fs.rs
+++ b/bfffs/src/common/fs.rs
@@ -2189,7 +2189,10 @@ fn setup() -> (tokio::runtime::Runtime, Database, TreeID) {
             let source = PropertySource::Default;
             future::ok((prop, source)).boxed()
         });
-    let tree_id = rt.block_on(db.new_fs(Vec::new())).unwrap();
+    // Use a small recordsize for most tests, because it's faster to test
+    // conditions that require multiple records.
+    let props = vec![Property::RecordSize(12)];
+    let tree_id = rt.block_on(db.new_fs(props)).unwrap();
     (rt, db, tree_id)
 }
 
@@ -2249,7 +2252,7 @@ fn create() {
             key.is_inode() &&
             value.as_inode().unwrap().size == 0 &&
             value.as_inode().unwrap().nlink == 1 &&
-            value.as_inode().unwrap().file_type == FileType::Reg(12) &&
+            value.as_inode().unwrap().file_type == FileType::Reg(17) &&
             value.as_inode().unwrap().perm == 0o644 &&
             value.as_inode().unwrap().uid == 123 &&
             value.as_inode().unwrap().gid == 456

--- a/bfffs/src/common/property.rs
+++ b/bfffs/src/common/property.rs
@@ -27,7 +27,7 @@ pub enum Property {
     ///
     /// Units are in bytes, log base 2.  So `RecordSize(16)` means 16KB records.
     /// BFFFS will usually divide files into blocks of this many bytes.  But the
-    /// record size is only advisory.  The default is 4KB.
+    /// record size is only advisory.  The default is 128KB.
     RecordSize(u8),
 }
 
@@ -35,7 +35,7 @@ impl Property {
     pub fn default_value(name: PropertyName) -> Self {
         match name {
             PropertyName::Atime => Property::Atime(true),
-            PropertyName::RecordSize => Property::RecordSize(12), // 4KB
+            PropertyName::RecordSize => Property::RecordSize(17), // 128KB
             PropertyName::Invalid => panic!("Invalid props have no values")
         }
     }


### PR DESCRIPTION
This provides much better performance than the original 4kB.  I only set
it at 4 kB to start with because that makes some types of bugs appear
more quickly, such as those that involve large metadata trees.