### PR TITLE
Fix "bfffs debug dump"

### DIFF
--- a/bfffs/src/common/database/database.rs
+++ b/bfffs/src/common/database/database.rs
@@ -309,6 +309,7 @@ impl Database {
     {
         let mut rt = runtime::Builder::new()
             .basic_scheduler()
+            .enable_io()
             .build()
             .unwrap();
         rt.block_on(async {

--- a/bfffs/src/common/tree/tree/mod.rs
+++ b/bfffs/src/common/tree/tree/mod.rs
@@ -745,6 +745,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
         let rrf3 = rrf.clone();
         let mut rt = runtime::Builder::new()
             .basic_scheduler()
+            .enable_io()
             .build()
             .unwrap();
         let fut = self.read()


### PR DESCRIPTION
With Tokio 0.2, the "enable_io" is necessary.  But I can't figure out
why the fs::t::dump test didn't fail.  It should be doing I/O, too.