### PR TITLE
Replace many uses of try_for_each with try_for_each_concurrent

### DIFF
--- a/bfffs/src/common/cleaner.rs
+++ b/bfffs/src/common/cleaner.rs
@@ -43,6 +43,9 @@ impl SyncCleaner {
         let idml2 = self.idml.clone();
         self.select_zones()
         .and_then(move |zones| {
+            // Limit concurrency to 1.  To minimize HDD seeks, it's better to
+            // clean one at a time.  Any in-zone concurrency can be managed by
+            // IDM:::clean_zone.
             stream::iter(zones.into_iter())
             .map(Ok)
             .try_for_each(move |zone| {

--- a/bfffs/src/common/tree/tree/mod.rs
+++ b/bfffs/src/common/tree/tree/mod.rs
@@ -2102,7 +2102,7 @@ impl<D, K, V> Tree<ddml::DRP, D, K, V>
             .and_then(move |nodes| {
                 stream::iter(nodes.into_iter())
                 .map(Ok)
-                .try_for_each(move |node| {
+                .try_for_each_concurrent(None, move |node| {
                     // TODO: consider attempting to rewrite multiple nodes
                     // at once, so as not to spend so much time traversing
                     // the tree


### PR DESCRIPTION
try_for_each_concurrent is new in Futures 0.3.  This should allow for
faster deleting or truncating of large files, and faster cleaning of
direct trees.  No benchmarks though.

Fixes #25