### PR TITLE
Eliminate contention on Database::fs_trees

### DIFF
--- a/bfffs/src/lib.rs
+++ b/bfffs/src/lib.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::module_inception)]
 
 // error: reached the type-length limit while instantiating std::pin::Pin...
-#![type_length_limit="3193873"]
+#![type_length_limit="3198763"]
 // error: trait bounds overflowed in Database::sync_transaction_priv
 #![recursion_limit="256"]
 


### PR DESCRIPTION
Prior to PR #54 (background flush), there was almost no contention on
this structure, because it was almost never held during I/O.  But
Tree::flush needs to hold it.  This commit converts it from a Mutex to
an RwLock.