### PR TITLE
Add tracing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,7 +70,6 @@ dependencies = [
  "divbuf",
  "downcast",
  "enum-primitive-derive",
- "env_logger",
  "fixedbitset",
  "futures",
  "futures-locks",
@@ -73,7 +81,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "libc",
- "log 0.4.11",
  "metrohash",
  "mockall",
  "mockall_double",
@@ -92,6 +99,9 @@ dependencies = [
  "time",
  "tokio",
  "tokio-file",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -106,6 +116,7 @@ dependencies = [
  "libc",
  "memoffset",
  "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -116,7 +127,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "clap",
  "divbuf",
- "env_logger",
  "fuse",
  "futures",
  "libc",
@@ -124,6 +134,7 @@ dependencies = [
  "predicates",
  "time",
  "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -210,7 +221,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -268,19 +279,6 @@ dependencies = [
  "num-traits",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
-dependencies = [
- "atty",
- "humantime",
- "log 0.4.11",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -443,7 +441,7 @@ dependencies = [
  "futures-task",
  "futures-util",
  "once_cell",
- "pin-project",
+ "pin-project 1.0.1",
  "pin-utils",
 ]
 
@@ -460,7 +458,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project 1.0.1",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -504,15 +502,6 @@ name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
 
 [[package]]
 name = "iovec"
@@ -580,6 +569,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -813,11 +811,31 @@ checksum = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 
 [[package]]
 name = "pin-project"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+dependencies = [
+ "pin-project-internal 0.4.27",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.0.1",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -836,6 +854,12 @@ name = "pin-project-lite"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -890,7 +914,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a029430f0d744bc3d15dd474d591bed2402b645d024583082b9f63bb936dac6"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "difference",
 ]
 
@@ -923,12 +947,6 @@ checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1045,6 +1063,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1117,15 @@ dependencies = [
  "linked-hash-map",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1163,15 +1200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,7 +1249,7 @@ dependencies = [
  "mio",
  "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.7",
  "signal-hook-registry",
  "slab",
  "winapi 0.3.9",
@@ -1246,6 +1274,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite 0.2.4",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project 0.4.27",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log 0.4.11",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+dependencies = [
+ "ansi_term 0.12.1",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1315,15 +1413,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/bfffs-fio/Cargo.toml
+++ b/bfffs-fio/Cargo.toml
@@ -18,5 +18,10 @@ libc = "0.2.44"
 memoffset = "0.5.1"
 tokio = { version = "0.2.7", features = ["rt-threaded", "sync", "time"] }
 
+[dependencies.tracing-subscriber]
+version = "0.2.15"
+default-features = false
+features = [ "ansi", "env-filter", "fmt", "tracing-log" ]
+
 [lib]
 crate-type = ["cdylib"]

--- a/bfffs-fio/src/lib.rs
+++ b/bfffs-fio/src/lib.rs
@@ -21,6 +21,7 @@ use std::{
     sync::{Arc, Mutex, RwLock},
 };
 use tokio::runtime::{Builder, Runtime};
+use tracing_subscriber::EnvFilter;
 
 mod ffi;
 
@@ -89,6 +90,10 @@ pub static INITIALIZE: extern "C" fn() = rust_ctor;
 #[no_mangle]
 pub extern "C" fn rust_ctor()
 {
+    tracing_subscriber::fmt()
+        .pretty()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
     unsafe {
         OPTIONS = Some([
             fio_option::new(

--- a/bfffs-fuse/Cargo.toml
+++ b/bfffs-fuse/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 bfffs = { path = "../bfffs" }
 cfg-if = "1.0"
-env_logger = "0.5"
 fuse = "0.3.1"
 futures = "0.3.0"
 libc = "0.2.44"
@@ -18,6 +17,11 @@ tokio = { version = "0.2.7", features = ["rt-threaded", "signal", "stream", "syn
 version = "2"
 default-features = false
 features=  [ "suggestions", "color", "wrap_help" ]
+
+[dependencies.tracing-subscriber]
+version = "0.2.15"
+default-features = false
+features = [ "ansi", "env-filter", "fmt", "tracing-log" ]
 
 [dev-dependencies]
 divbuf = { git = "https://github.com/asomers/divbuf.git", rev = "0a72fb5"}

--- a/bfffs-fuse/src/bin/bfffsd/main.rs
+++ b/bfffs-fuse/src/bin/bfffsd/main.rs
@@ -17,13 +17,17 @@ use tokio::{
     runtime::Builder,
     signal::unix::{signal, SignalKind},
 };
+use tracing_subscriber::EnvFilter;
 
 mod fs;
 
 use crate::fs::FuseFs;
 
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt()
+        .pretty()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
     let app = clap::App::new("bfffsd")
         .version(crate_version!())
         .arg(clap::Arg::with_name("option")

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -39,6 +39,8 @@ serde_yaml = "0.8.6"
 time = "0.1"
 tokio = { version = "0.2.7", features = ["rt-threaded", "sync", "time"] }
 tokio-file = { git = "https://github.com/asomers/tokio-file", rev = "5dbb35cb4cbb5ff55faa6063426af1a04c363ad6" }
+tracing = "0.1.5"
+tracing-futures = "0.2.4"
 uuid = { version = "0.8", features = ["serde", "v4"]}
 
 [dependencies.clap]
@@ -48,13 +50,11 @@ features=  [ "suggestions", "color", "wrap_help" ]
 
 [dev-dependencies]
 chashmap = "2"
-env_logger = "0.5"
 futures-test = "0.3.7"
 galvanic-test = "0.2"
 glob = "0.2"
 histogram = "0.6"
 itertools = "0.7.1"
-log = "0.4"
 mockall = "0.9.0"
 num_cpus = "1"
 permutohedron = "0.2"
@@ -62,3 +62,8 @@ pretty_assertions = "0.5"
 rand = "0.7"
 rand_xorshift = "0.2"
 tempfile = "3"
+
+[dev-dependencies.tracing-subscriber]
+version = "0.2.15"
+default-features = false
+features = [ "ansi", "env-filter", "fmt", "tracing-log" ]

--- a/bfffs/src/common/dataset/dataset.rs
+++ b/bfffs/src/common/dataset/dataset.rs
@@ -73,7 +73,7 @@ impl<K: Key, V: Value> Dataset<K, V> {
     fn range<R, T>(&self, range: R) -> RangeQuery<K, T, V>
         where K: Borrow<T>,
               R: RangeBounds<T> + 'static,
-              T: Ord + Clone + Send + 'static
+              T: Debug + Ord + Clone + Send + 'static
     {
         self.tree.range(range)
     }
@@ -81,7 +81,7 @@ impl<K: Key, V: Value> Dataset<K, V> {
     fn range<R, T>(&self, _range: R) -> RangeQuery<K, T, V>
         where K: Borrow<T>,
               R: RangeBounds<T> + 'static,
-              T: Ord + Clone + Send + 'static
+              T: Debug + Ord + Clone + Send + 'static
     {
         // Should never be called.  In test mode, use DatasetMock::range
         // instead.
@@ -155,7 +155,7 @@ impl<K: Key, V: Value> ReadDataset<K, V> for ReadOnlyDataset<K, V> {
     fn range<R, T>(&self, range: R) -> RangeQuery<K, T, V>
         where K: Borrow<T>,
               R: RangeBounds<T> + 'static,
-              T: Ord + Clone + Send + 'static
+              T: Debug + Ord + Clone + Send + 'static
     {
         self.dataset.range(range)
     }
@@ -234,7 +234,7 @@ impl<K: Key, V: Value> ReadDataset<K, V> for ReadWriteDataset<K, V> {
     fn range<R, T>(&self, range: R) -> RangeQuery<K, T, V>
         where K: Borrow<T>,
               R: RangeBounds<T> + 'static,
-              T: Ord + Clone + Send + 'static
+              T: Debug + Ord + Clone + Send + 'static
     {
         self.dataset.range(range)
     }

--- a/bfffs/src/common/dataset/dataset_mock.rs
+++ b/bfffs/src/common/dataset/dataset_mock.rs
@@ -34,7 +34,7 @@ mock! {
         fn range<R, T>(&self, range: R) -> RangeQuery<K, T, V>
             where K: Borrow<T>,
                   R: RangeBounds<T> + 'static,
-                  T: Ord + Clone + Send + 'static;
+                  T: Debug + Ord + Clone + Send + 'static;
     }
 }
 
@@ -75,7 +75,7 @@ mock! {
         fn range<R, T>(&self, range: R) -> RangeQuery<K, T, V>
             where K: Borrow<T>,
                   R: RangeBounds<T> + 'static,
-                  T: Ord + Clone + Send + 'static;
+                  T: Debug + Ord + Clone + Send + 'static;
     }
 }
 

--- a/bfffs/src/common/dataset/mod.rs
+++ b/bfffs/src/common/dataset/mod.rs
@@ -16,6 +16,7 @@ use divbuf::DivBuf;
 use futures::Future;
 use std::{
     borrow::Borrow,
+    fmt::Debug,
     ops::RangeBounds,
     pin::Pin
 };
@@ -48,5 +49,5 @@ pub trait ReadDataset<K: Key, V: Value> {
     fn range<R, T>(&self, range: R) -> RangeQuery<K, T, V>
         where K: Borrow<T>,
               R: RangeBounds<T> + 'static,
-              T: Ord + Clone + Send + 'static;
+              T: Debug + Ord + Clone + Send + 'static;
 }

--- a/bfffs/src/common/fs.rs
+++ b/bfffs/src/common/fs.rs
@@ -25,6 +25,7 @@ use futures::{
 use std::{
     cmp,
     ffi::{OsStr, OsString},
+    fmt::Debug,
     mem,
     os::unix::ffi::OsStrExt,
     pin::Pin,
@@ -2186,7 +2187,7 @@ fn setup() -> (tokio::runtime::Runtime, Database, TreeID) {
 /// return
 fn mock_range_query<K, T, V>(items: Vec<(K, V)>) -> RangeQuery<K, T, V>
     where K: Key + Borrow<T>,
-          T: Ord + Clone + Send,
+          T: Debug + Ord + Clone + Send,
           V: Value
 {
     let mut rq = RangeQuery::new();

--- a/bfffs/src/common/tree/tree_mock.rs
+++ b/bfffs/src/common/tree/tree_mock.rs
@@ -14,6 +14,7 @@ use futures::{
 use mockall::mock;
 use std::{
     borrow::Borrow,
+    fmt::Debug,
     io,
     ops::{Range, RangeBounds},
     pin::Pin,
@@ -67,7 +68,7 @@ mock! {
         pub fn range<R, T>(&self, range: R) -> RangeQuery<A, D, K, T, V>
             where K: Borrow<T>,
                   R: RangeBounds<T> + 'static,
-                  T: Ord + Clone + Send + 'static;
+                  T: Debug + Ord + Clone + Send + 'static;
         pub fn range_delete<R, T>(&self, range: R, txg: TxgT)
             -> Pin<Box<dyn Future<Output=Result<(), Error>> + Send>>
             where K: Borrow<T>,

--- a/bfffs/tests/common/fs.rs
+++ b/bfffs/tests/common/fs.rs
@@ -2543,7 +2543,7 @@ test_suite! {
         common::pool::*,
     };
     use galvanic_test::*;
-    use log::*;
+    use tracing::*;
     use pretty_assertions::assert_eq;
     use rand::{
         Rng,
@@ -2562,6 +2562,7 @@ test_suite! {
     };
     use tempfile::Builder;
     use tokio::runtime::Runtime;
+    use tracing_subscriber::EnvFilter;
 
     #[derive(Clone, Copy, Debug)]
     pub enum Op {
@@ -2768,9 +2769,12 @@ test_suite! {
                     zone_size: u64) -> TortureTest
     {
         setup(&mut self) {
-            static ENV_LOGGER: Once = Once::new();
-            ENV_LOGGER.call_once(|| {
-                env_logger::init();
+            static TRACINGSUBSCRIBER: Once = Once::new();
+            TRACINGSUBSCRIBER.call_once(|| {
+                tracing_subscriber::fmt()
+                    .pretty()
+                    .with_env_filter(EnvFilter::from_default_env())
+                    .init();
             });
 
             let mut rt = Runtime::new().unwrap();


### PR DESCRIPTION
The tracing crate is a replacement for log, intended for asynchronous
programs.  This commit introduces it, just for a single event at first.
But its use will grow over time.

Note that the #[instrument] macro works best with async functions, of
which bfffs has few.  When used with a normal function that returns a
future, the future must have .in_current_span() appended.