### PR TITLE
Simplify tree

### DIFF
--- a/bfffs-core/examples/fanout.rs
+++ b/bfffs-core/examples/fanout.rs
@@ -348,7 +348,7 @@ fn experiment<F>(nelems: u64, save: bool, mut f: F)
                 tree3.insert(key, value, txg)
             }).map_ok(drop)
         }).and_then(move |_| {
-            tree2.flush(txg)
+            tree2.clone().flush(txg)
         }).and_then(move |_| {
             let ridt_fut = idml4.ridt.range(..)
             .try_fold(0, |count, _| future::ok::<_, Error>(count + 1));
@@ -356,8 +356,8 @@ fn experiment<F>(nelems: u64, save: bool, mut f: F)
             .try_fold(0, |count, _| future::ok::<_, Error>(count + 1));
             future::try_join(ridt_fut, alloct_fut)
             .and_then(move |entries| {
-                future::try_join(idml4.ridt.flush(txg),
-                                 idml4.alloct.flush(txg))
+                future::try_join(idml4.ridt.clone().flush(txg),
+                                 idml4.alloct.clone().flush(txg))
                 .map_ok(move |_| entries)
             })
         })

--- a/bfffs-core/src/dataset/dataset.rs
+++ b/bfffs-core/src/dataset/dataset.rs
@@ -48,7 +48,7 @@ impl<K: Key, V: Value> Dataset<K, V> {
     fn insert(&self, txg: TxgT, k: K, v: V)
         -> impl Future<Output=Result<Option<V>, Error>>
     {
-        self.tree.insert(k, v, txg)
+        self.tree.clone().insert(k, v, txg)
     }
 
     fn last_key(&self) -> impl Future<Output=Result<Option<K>, Error>>

--- a/bfffs-core/src/dataset/dataset.rs
+++ b/bfffs-core/src/dataset/dataset.rs
@@ -98,7 +98,7 @@ impl<K: Key, V: Value> Dataset<K, V> {
     fn remove(&self, k: K, txg: TxgT)
         -> impl Future<Output=Result<Option<V>, Error>> + Send
     {
-        self.tree.remove(k, txg)
+        self.tree.clone().remove(k, txg)
     }
 
     fn remove_blob(&self, rid: RID, txg: TxgT)

--- a/bfffs-core/src/dataset/dataset.rs
+++ b/bfffs-core/src/dataset/dataset.rs
@@ -92,7 +92,7 @@ impl<K: Key, V: Value> Dataset<K, V> {
               R: Debug + Clone + RangeBounds<T> + Send + 'static,
               T: Debug + Ord + Clone + Send + 'static
     {
-        self.tree.range_delete(range, txg)
+        self.tree.clone().range_delete(range, txg)
     }
 
     fn remove(&self, k: K, txg: TxgT)

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -639,10 +639,10 @@ mod t {
     {
         let entry = RidtEntry{drp: *drp, refcount};
         let txg = TxgT::from(0);
-        idml.ridt.insert(rid, entry, txg)
+        idml.ridt.clone().insert(rid, entry, txg)
             .now_or_never().unwrap()
             .unwrap();
-        idml.alloct.insert(drp.pba(), rid, txg)
+        idml.alloct.clone().insert(drp.pba(), rid, txg)
             .now_or_never().unwrap()
             .unwrap();
     }
@@ -695,7 +695,7 @@ mod t {
         let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
         // Inject a record into the AllocT but not the RIDT
         let txg = TxgT::from(0);
-        idml.alloct.insert(drp.pba(), rid, txg)
+        idml.alloct.clone().insert(drp.pba(), rid, txg)
             .now_or_never().unwrap()
             .unwrap();
 
@@ -715,7 +715,7 @@ mod t {
         // Inject a record into the RIDT but not the AllocT
         let entry = RidtEntry{drp, refcount: 2};
         let txg = TxgT::from(0);
-        idml.ridt.insert(rid, entry, txg)
+        idml.ridt.clone().insert(rid, entry, txg)
             .now_or_never().unwrap()
             .unwrap();
 
@@ -736,10 +736,10 @@ mod t {
         // Inject a mismatched pair of records
         let entry = RidtEntry{drp, refcount: 2};
         let txg = TxgT::from(0);
-        idml.ridt.insert(rid, entry, txg)
+        idml.ridt.clone().insert(rid, entry, txg)
             .now_or_never().unwrap()
             .unwrap();
-        idml.alloct.insert(drp2.pba(), rid, txg)
+        idml.alloct.clone().insert(drp2.pba(), rid, txg)
             .now_or_never().unwrap()
             .unwrap();
 

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -217,8 +217,8 @@ impl<'a> IDML {
     pub fn flush(&self, idx: Option<u32>, txg: TxgT)
         -> impl Future<Output=Result<(), Error>> + Send
     {
-        let tfut = future::try_join(self.alloct.flush(txg),
-                                    self.ridt.flush(txg))
+        let tfut = future::try_join(self.alloct.clone().flush(txg),
+                                    self.ridt.clone().flush(txg))
             .map_ok(drop);
         if let Some(idx) = idx {
             let ddml2 = self.ddml.clone();

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -133,8 +133,8 @@ impl<'a> IDML {
     ///
     /// `true` on success, `false` on failure
     pub fn check(&self) -> impl Future<Output=Result<bool, Error>> {
-        future::try_join3(self.alloct.check(),
-                          self.ridt.check(),
+        future::try_join3(self.alloct.clone().check(),
+                          self.ridt.clone().check(),
                           self.check_ridt())
         .map_ok(|(x, y, z)| x && y && z)
     }

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -23,20 +23,6 @@ use tracing::instrument;
 use tracing_futures::Instrument;
 use super::*;
 
-/// Container for the IDML's private trees
-struct Trees {
-    /// Allocation table.  The reverse of `ridt`.
-    ///
-    /// Maps disk addresses back to record IDs.  Used for operations like
-    /// garbage collection and defragmentation.
-    // TODO: consider a lazy delete strategy to reduce the amount of tree
-    // activity on pop/delete by deferring alloct removals to the cleaner.
-    alloct: DTree<PBA, RID>,
-
-    /// Record indirection table.  Maps record IDs to disk addresses.
-    ridt: DTree<RID, RidtEntry>,
-}
-
 /// Indirect Data Management Layer for a single `Pool`
 pub struct IDML {
     cache: Arc<Mutex<Cache>>,
@@ -49,9 +35,20 @@ pub struct IDML {
     /// Current transaction group
     transaction: RwLock<TxgT>,
 
+    /// Allocation table.  The reverse of `ridt`.
+    ///
+    /// Maps disk addresses back to record IDs.  Used for operations like
+    /// garbage collection and defragmentation.
+    // TODO: consider a lazy delete strategy to reduce the amount of tree
+    // activity on pop/delete by deferring alloct removals to the cleaner.
     // Even though it has a single owner, the tree must be Arc so IDML methods
     // can be 'static
-    trees: Arc<Trees>
+    alloct: Arc<DTree<PBA, RID>>,
+
+    /// Record indirection table.  Maps record IDs to disk addresses.
+    // Even though it has a single owner, the tree must be Arc so IDML methods
+    // can be 'static
+    ridt: Arc<DTree<RID, RidtEntry>>,
 }
 
 // Some of these methods have no unit tests.  Their test coverage is provided
@@ -72,16 +69,18 @@ impl<'a> IDML {
     ///
     /// `true` on success, `false` on failure
     fn check_ridt(&self) -> impl Future<Output=Result<bool, Error>> {
-        let trees2 = self.trees.clone();
-        let trees3 = self.trees.clone();
+        let alloct2 = self.alloct.clone();
+        let alloct3 = self.alloct.clone();
+        let ridt2 = self.ridt.clone();
+        let ridt3 = self.ridt.clone();
         // Grab the TXG lock exclusively, just so other users can't modify the
         // RIDT or AllocT while we're checking them.  NB: it might be
         // preferable to use a dedicated lock for this instead.
         self.transaction.write()
         .then(move |txg_guard| {
-            let alloct_fut = trees2.alloct.range(..)
+            let alloct_fut = alloct2.range(..)
             .try_fold(true, move |passes, (pba, rid)| {
-                trees2.ridt.get(rid)
+                ridt2.get(rid)
                 .map_ok(move |v| {
                     passes & match v {
                         Some(ridt_entry) => {
@@ -102,9 +101,9 @@ impl<'a> IDML {
                     }
                 })
             });
-            let ridt_fut = trees3.ridt.range(..)
+            let ridt_fut = ridt3.range(..)
             .try_fold(true, move |passes, (rid, entry)| {
-                trees3.alloct.get(entry.drp.pba())
+                alloct3.get(entry.drp.pba())
                 .map_ok(move |v| {
                     passes & match v {
                         Some(_) => true,
@@ -134,8 +133,8 @@ impl<'a> IDML {
     ///
     /// `true` on success, `false` on failure
     pub fn check(&self) -> impl Future<Output=Result<bool, Error>> {
-        future::try_join3(self.trees.alloct.check(),
-                          self.trees.ridt.check(),
+        future::try_join3(self.alloct.check(),
+                          self.ridt.check(),
                           self.check_ridt())
         .map_ok(|(x, y, z)| x && y && z)
     }
@@ -152,8 +151,10 @@ impl<'a> IDML {
         //    do in the second.
         let end = PBA::new(zone.pba.cluster, zone.pba.lba + zone.total_blocks);
         let cache2 = self.cache.clone();
-        let trees2 = self.trees.clone();
-        let trees3 = self.trees.clone();
+        let alloct2 = self.alloct.clone();
+        let alloct3 = self.alloct.clone();
+        let ridt2 = self.ridt.clone();
+        let ridt3 = self.ridt.clone();
         let ddml2 = self.ddml.clone();
         #[cfg(debug_assertions)]
         let ddml3 = self.ddml.clone();
@@ -165,7 +166,8 @@ impl<'a> IDML {
         // 1, so as not to interfere too much with foreground tasks
         self.list_indirect_records(&zone)
         .try_for_each(move |record| {
-            IDML::move_record(&cache2, &trees2, &ddml2, record, txg)
+            IDML::move_record(&cache2, ridt2.clone(), alloct2.clone(), &ddml2,
+                record, txg)
             .map_ok(move |drp| {
                 // We shouldn't have moved the record into the same zone
                 debug_assert!(drp.pba().cluster != pba.cluster ||
@@ -175,13 +177,13 @@ impl<'a> IDML {
         }).and_then(move |_| {
             let txgs2 = zone.txgs.clone();
             let pba_range = pba..end;
-            let czfut = trees3.ridt.clean_zone(pba_range.clone(), txgs2, txg);
+            let czfut = ridt3.clean_zone(pba_range.clone(), txgs2, txg);
             // Finish alloct.range_delete before alloct.clean_zone, because the
             // range delete is likely to eliminate most if not all nodes that
             // need to be moved by clean_zone
-            let atfut = trees3.alloct.range_delete(pba_range.clone(), txg)
+            let atfut = alloct3.range_delete(pba_range.clone(), txg)
                 .and_then(move |_| {
-                    trees3.alloct.clean_zone(pba_range, zone.txgs, txg)
+                    alloct3.clean_zone(pba_range, zone.txgs, txg)
                 });
             future::try_join(czfut, atfut).map_ok(drop)
         }).map_ok(move |_| {
@@ -191,19 +193,21 @@ impl<'a> IDML {
     }
 
     pub fn create(ddml: Arc<DDML>, cache: Arc<Mutex<Cache>>) -> Self {
-        let alloct = DTree::<PBA, RID>::create(ddml.clone(), true, 16.5, 2.809);
+        let alloct = Arc::new(
+            DTree::<PBA, RID>::create(ddml.clone(), true, 16.5, 2.809)
+        );
         let next_rid = AtomicU64::new(0);
-        let ridt = DTree::<RID, RidtEntry>::create(ddml.clone(), true, 4.22,
-            3.73);
+        let ridt = Arc::new(
+            DTree::<RID, RidtEntry>::create(ddml.clone(), true, 4.22, 3.73)
+        );
         let transaction = RwLock::new(TxgT::from(0));
-        let trees = Arc::new(Trees{alloct, ridt});
-        IDML{cache, ddml, next_rid, transaction, trees}
+        IDML{cache, ddml, next_rid, transaction, alloct, ridt}
     }
 
     pub fn dump_trees(&self, f: &mut dyn io::Write) -> Result<(), Error>
     {
-        self.trees.ridt.dump(f)?;
-        self.trees.alloct.dump(f)
+        self.ridt.dump(f)?;
+        self.alloct.dump(f)
     }
 
     /// Flush the IDML's data to disk
@@ -213,8 +217,8 @@ impl<'a> IDML {
     pub fn flush(&self, idx: Option<u32>, txg: TxgT)
         -> impl Future<Output=Result<(), Error>> + Send
     {
-        let tfut = future::try_join(self.trees.alloct.flush(txg),
-                                    self.trees.ridt.flush(txg))
+        let tfut = future::try_join(self.alloct.flush(txg),
+                                    self.ridt.flush(txg))
             .map_ok(drop);
         if let Some(idx) = idx {
             let ddml2 = self.ddml.clone();
@@ -240,7 +244,7 @@ impl<'a> IDML {
         // Iterate through the AllocT to get indirect records from the target
         // zone.
         let end = PBA::new(zone.pba.cluster, zone.pba.lba + zone.total_blocks);
-        self.trees.alloct.range(zone.pba..end)
+        self.alloct.range(zone.pba..end)
             .map_ok(|(_pba, rid)| rid)
     }
 
@@ -256,17 +260,17 @@ impl<'a> IDML {
                  mut label_reader: LabelReader) -> (Self, LabelReader)
     {
         let l: Label = label_reader.deserialize().unwrap();
-        let alloct = DTree::open(ddml.clone(), true, l.alloct);
-        let ridt = DTree::open(ddml.clone(), true, l.ridt);
+        let alloct = Arc::new(DTree::open(ddml.clone(), true, l.alloct));
+        let ridt = Arc::new(DTree::open(ddml.clone(), true, l.ridt));
         let transaction = RwLock::new(l.txg);
         let next_rid = AtomicU64::new(l.next_rid);
-        let trees = Arc::new(Trees{alloct, ridt});
-        let idml = IDML{cache, ddml, next_rid, transaction, trees};
+        let idml = IDML{cache, ddml, next_rid, transaction, alloct, ridt};
         (idml, label_reader)
     }
 
     /// Rewrite the given direct Record and update its metadata.
-    fn move_record(cache: &Arc<Mutex<Cache>>, trees: &Arc<Trees>,
+    fn move_record(cache: &Arc<Mutex<Cache>>, ridt: Arc<DTree<RID, RidtEntry>>,
+                   alloct: Arc<DTree<PBA, RID>>,
                    ddml: &Arc<DDML>, rid: RID, txg: TxgT)
         -> impl Future<Output=Result<DRP, Error>> + Send
     {
@@ -275,8 +279,8 @@ impl<'a> IDML {
         let cache2 = cache.clone();
         let ddml2 = ddml.clone();
         let ddml3 = ddml.clone();
-        let trees2 = trees.clone();
-        trees.ridt.get(rid)
+        let ridt2 = ridt.clone();
+        ridt.get(rid)
             .and_then(move |v| {
                 let mut entry = v.expect(
                     "Inconsistency in alloct.  Entry not found in RIDT");
@@ -332,8 +336,8 @@ impl<'a> IDML {
                 };
                 fut.and_then(move |drp: DRP| {
                     entry.drp = drp;
-                    let ridt_fut = trees2.ridt.insert(rid, entry, txg);
-                    let alloct_fut = trees2.alloct.insert(drp.pba(), rid, txg);
+                    let ridt_fut = ridt2.insert(rid, entry, txg);
+                    let alloct_fut = alloct.insert(drp.pba(), rid, txg);
                     future::try_join(ridt_fut, alloct_fut)
                     .map_ok(move |_| drp)
                 })
@@ -376,8 +380,8 @@ impl<'a> IDML {
         debug_assert!(self.transaction.try_read().is_err(),
             "IDML::write_label must be called with the txg lock held");
         let next_rid = self.next_rid.load(Ordering::Relaxed);
-        let alloct = self.trees.alloct.serialize().unwrap();
-        let ridt = self.trees.ridt.serialize().unwrap();
+        let alloct = self.alloct.serialize().unwrap();
+        let ridt = self.ridt.serialize().unwrap();
         let label = Label {
             alloct,
             next_rid,
@@ -407,17 +411,18 @@ impl DML for IDML {
     {
         let cache2 = self.cache.clone();
         let ddml2 = self.ddml.clone();
-        let trees2 = self.trees.clone();
+        let alloct2 = self.alloct.clone();
+        let ridt2 = self.ridt.clone();
         let rid = *ridp;
-        let fut = self.trees.ridt.get(rid)
+        let fut = self.ridt.get(rid)
             .and_then(unwrap_or_enoent)
             .and_then(move |mut entry| {
                 entry.refcount -= 1;
                 if entry.refcount == 0 {
                     cache2.lock().unwrap().remove(&Key::Rid(rid));
                     let ddml_fut = ddml2.delete_direct(&entry.drp, txg);
-                    let alloct_fut = trees2.alloct.remove(entry.drp.pba(), txg);
-                    let ridt_fut = trees2.ridt.remove(rid, txg);
+                    let alloct_fut = alloct2.remove(entry.drp.pba(), txg);
+                    let ridt_fut = ridt2.remove(rid, txg);
                     Box::pin(
                         future::try_join3(ddml_fut, alloct_fut, ridt_fut)
                          .map_ok(|(_, old_rid, _old_ridt_entry)| {
@@ -425,7 +430,7 @@ impl DML for IDML {
                          })
                      )
                 } else {
-                    let ridt_fut = trees2.ridt.insert(rid, entry, txg)
+                    let ridt_fut = ridt2.insert(rid, entry, txg)
                         .map_ok(drop);
                     ridt_fut.boxed()
                 }
@@ -447,7 +452,7 @@ impl DML for IDML {
         }).unwrap_or_else(|| {
             let cache2 = self.cache.clone();
             let ddml2 = self.ddml.clone();
-            let fut = self.trees.ridt.get(rid)
+            let fut = self.ridt.get(rid)
                 .and_then(unwrap_or_enoent)
                 .and_then(move |entry| {
                     ddml2.get_direct(&entry.drp)
@@ -468,8 +473,9 @@ impl DML for IDML {
         let cache2 = self.cache.clone();
         let ddml2 = self.ddml.clone();
         let ddml3 = self.ddml.clone();
-        let trees2 = self.trees.clone();
-        let fut = self.trees.ridt.get(rid)
+        let alloct2 = self.alloct.clone();
+        let ridt2 = self.ridt.clone();
+        let fut = self.ridt.get(rid)
             .and_then(unwrap_or_enoent)
             .and_then(move |mut entry| {
                 entry.refcount -= 1;
@@ -485,8 +491,8 @@ impl DML for IDML {
                         }).unwrap_or_else(||{
                             ddml3.pop_direct::<T>(&entry.drp).boxed()
                         });
-                    let alloct_fut = trees2.alloct.remove(entry.drp.pba(), txg);
-                    let ridt_fut = trees2.ridt.remove(rid, txg);
+                    let alloct_fut = alloct2.remove(entry.drp.pba(), txg);
+                    let ridt_fut = ridt2.remove(rid, txg);
                         future::try_join3(bfut, alloct_fut, ridt_fut)
                         .map_ok(|(cacheable, old_rid, _old_ridt_entry)| {
                             assert!(old_rid.is_some());
@@ -501,7 +507,7 @@ impl DML for IDML {
                     }).unwrap_or_else(|| {
                         Box::pin(ddml2.get_direct::<T>(&entry.drp))
                     });
-                    let ridt_fut = trees2.ridt.insert(rid, entry, txg);
+                    let ridt_fut = ridt2.insert(rid, entry, txg);
                     future::try_join(bfut, ridt_fut)
                     .map_ok(|(cacheable, _)| cacheable).boxed()
                 }
@@ -521,14 +527,15 @@ impl DML for IDML {
         // 3) Add entry to the RIDT
         // 4) Add reverse entry to the AllocT
         let cache2 = self.cache.clone();
-        let trees2 = self.trees.clone();
+        let alloct2 = self.alloct.clone();
+        let ridt2 = self.ridt.clone();
         let rid = RID(self.next_rid.fetch_add(1, Ordering::Relaxed));
 
         let fut = self.ddml.put_direct(&cacheable.make_ref(), compression, txg)
         .and_then(move|drp| {
-            let alloct_fut = trees2.alloct.insert(drp.pba(), rid, txg);
+            let alloct_fut = alloct2.insert(drp.pba(), rid, txg);
             let rid_entry = RidtEntry::new(drp);
-            let ridt_fut = trees2.ridt.insert(rid, rid_entry, txg);
+            let ridt_fut = ridt2.insert(rid, rid_entry, txg);
             future::try_join(ridt_fut, alloct_fut)
             .map_ok(move |(old_rid_entry, old_alloc_entry)| {
                 assert!(old_rid_entry.is_none(), "RID was not unique");
@@ -632,10 +639,10 @@ mod t {
     {
         let entry = RidtEntry{drp: *drp, refcount};
         let txg = TxgT::from(0);
-        idml.trees.ridt.insert(rid, entry, txg)
+        idml.ridt.insert(rid, entry, txg)
             .now_or_never().unwrap()
             .unwrap();
-        idml.trees.alloct.insert(drp.pba(), rid, txg)
+        idml.alloct.insert(drp.pba(), rid, txg)
             .now_or_never().unwrap()
             .unwrap();
     }
@@ -688,7 +695,7 @@ mod t {
         let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
         // Inject a record into the AllocT but not the RIDT
         let txg = TxgT::from(0);
-        idml.trees.alloct.insert(drp.pba(), rid, txg)
+        idml.alloct.insert(drp.pba(), rid, txg)
             .now_or_never().unwrap()
             .unwrap();
 
@@ -708,7 +715,7 @@ mod t {
         // Inject a record into the RIDT but not the AllocT
         let entry = RidtEntry{drp, refcount: 2};
         let txg = TxgT::from(0);
-        idml.trees.ridt.insert(rid, entry, txg)
+        idml.ridt.insert(rid, entry, txg)
             .now_or_never().unwrap()
             .unwrap();
 
@@ -729,10 +736,10 @@ mod t {
         // Inject a mismatched pair of records
         let entry = RidtEntry{drp, refcount: 2};
         let txg = TxgT::from(0);
-        idml.trees.ridt.insert(rid, entry, txg)
+        idml.ridt.insert(rid, entry, txg)
             .now_or_never().unwrap()
             .unwrap();
-        idml.trees.alloct.insert(drp2.pba(), rid, txg)
+        idml.alloct.insert(drp2.pba(), rid, txg)
             .now_or_never().unwrap()
             .unwrap();
 
@@ -765,10 +772,10 @@ mod t {
             .now_or_never().unwrap()
             .unwrap();
         // Now verify the contents of the RIDT and AllocT
-        assert!(idml.trees.ridt.get(rid)
+        assert!(idml.ridt.get(rid)
                 .now_or_never().unwrap()
                 .unwrap().is_none());
-        let alloc_rec = idml.trees.alloct.get(drp.pba())
+        let alloc_rec = idml.alloct.get(drp.pba())
             .now_or_never().unwrap()
             .unwrap();
         assert!(alloc_rec.is_none());
@@ -787,13 +794,13 @@ mod t {
         idml.delete(&rid, TxgT::from(42))
             .now_or_never().unwrap().unwrap();
         // Now verify the contents of the RIDT and AllocT
-        let entry2 = idml.trees.ridt.get(rid)
+        let entry2 = idml.ridt.get(rid)
             .now_or_never().unwrap()
             .unwrap()
             .unwrap();
         assert_eq!(entry2.drp, drp);
         assert_eq!(entry2.refcount, 1);
-        let alloc_rec = idml.trees.alloct.get(drp.pba())
+        let alloc_rec = idml.alloct.get(drp.pba())
             .now_or_never().unwrap()
             .unwrap();
         assert_eq!(alloc_rec.unwrap(), rid);
@@ -957,18 +964,18 @@ mod t {
         let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
         inject_record(&idml, rid, &drp0, 1);
 
-        IDML::move_record(&idml.cache, &idml.trees, &idml.ddml, rid,
-            TxgT::from(0))
+        IDML::move_record(&idml.cache, idml.ridt.clone(), idml.alloct.clone(),
+            &idml.ddml, rid, TxgT::from(0))
         .now_or_never().unwrap().unwrap();
 
         // Now verify the RIDT and alloct entries
-        let entry = idml.trees.ridt.get(rid)
+        let entry = idml.ridt.get(rid)
             .now_or_never().unwrap()
             .unwrap()
             .unwrap();
         assert_eq!(entry.refcount, 1);
         assert_eq!(entry.drp, drp1_c);
-        let alloc_rec = idml.trees.alloct.get(drp1_c.pba())
+        let alloc_rec = idml.alloct.get(drp1_c.pba())
             .now_or_never().unwrap().unwrap();
         assert_eq!(alloc_rec.unwrap(), rid);
     }
@@ -1008,18 +1015,18 @@ mod t {
         let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
         inject_record(&idml, rid, &drp0, 1);
 
-        IDML::move_record(&idml.cache, &idml.trees, &idml.ddml, rid,
-            TxgT::from(0))
+        IDML::move_record(&idml.cache, idml.ridt.clone(), idml.alloct.clone(),
+            &idml.ddml, rid, TxgT::from(0))
             .now_or_never().unwrap().unwrap();
 
         // Now verify the RIDT and alloct entries
-        let entry = idml.trees.ridt.get(rid)
+        let entry = idml.ridt.get(rid)
             .now_or_never().unwrap()
             .unwrap()
             .unwrap();
         assert_eq!(entry.refcount, 1);
         assert_eq!(entry.drp, drp1_c);
-        let alloc_rec = idml.trees.alloct.get(drp1_c.pba())
+        let alloc_rec = idml.alloct.get(drp1_c.pba())
             .now_or_never().unwrap()
             .unwrap();
         assert_eq!(alloc_rec.unwrap(), rid);
@@ -1058,17 +1065,17 @@ mod t {
         let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
         inject_record(&idml, rid, &drp0, 1);
 
-        IDML::move_record(&idml.cache, &idml.trees, &idml.ddml, rid,
-            TxgT::from(0))
+        IDML::move_record(&idml.cache, idml.ridt.clone(), idml.alloct.clone(),
+            &idml.ddml, rid, TxgT::from(0))
             .now_or_never().unwrap().unwrap();
 
         // Now verify the RIDT and alloct entries
-        let entry = idml.trees.ridt.get(rid)
+        let entry = idml.ridt.get(rid)
             .now_or_never().unwrap()
             .unwrap().unwrap();
         assert_eq!(entry.refcount, 1);
         assert_eq!(entry.drp, drp1);
-        let alloc_rec = idml.trees.alloct.get(drp1.pba())
+        let alloc_rec = idml.alloct.get(drp1.pba())
             .now_or_never().unwrap()
             .unwrap();
         assert_eq!(alloc_rec.unwrap(), rid);
@@ -1098,10 +1105,10 @@ mod t {
             .now_or_never().unwrap()
             .unwrap();
         // Now verify the contents of the RIDT and AllocT
-        assert!(idml.trees.ridt.get(rid)
+        assert!(idml.ridt.get(rid)
                 .now_or_never().unwrap()
                 .unwrap().is_none());
-        let alloc_rec = idml.trees.alloct.get(drp.pba())
+        let alloc_rec = idml.alloct.get(drp.pba())
             .now_or_never().unwrap()
             .unwrap();
         assert!(alloc_rec.is_none());
@@ -1128,12 +1135,12 @@ mod t {
             .now_or_never().unwrap()
             .unwrap();
         // Now verify the contents of the RIDT and AllocT
-        let entry2 = idml.trees.ridt.get(rid)
+        let entry2 = idml.ridt.get(rid)
             .now_or_never().unwrap()
             .unwrap().unwrap();
         assert_eq!(entry2.drp, drp);
         assert_eq!(entry2.refcount, 1);
-        let alloc_rec = idml.trees.alloct.get(drp.pba())
+        let alloc_rec = idml.alloct.get(drp.pba())
             .now_or_never().unwrap()
             .unwrap();
         assert_eq!(alloc_rec.unwrap(), rid);
@@ -1166,10 +1173,10 @@ mod t {
             .now_or_never().unwrap()
             .unwrap();
         // Now verify the contents of the RIDT and AllocT
-        assert!(idml.trees.ridt.get(rid)
+        assert!(idml.ridt.get(rid)
                 .now_or_never().unwrap()
                 .unwrap().is_none());
-        let alloc_rec = idml.trees.alloct.get(drp.pba())
+        let alloc_rec = idml.alloct.get(drp.pba())
             .now_or_never().unwrap()
             .unwrap();
         assert!(alloc_rec.is_none());
@@ -1200,12 +1207,12 @@ mod t {
             .now_or_never().unwrap()
             .unwrap();
         // Now verify the contents of the RIDT and AllocT
-        let entry2 = idml.trees.ridt.get(rid)
+        let entry2 = idml.ridt.get(rid)
             .now_or_never().unwrap()
             .unwrap().unwrap();
         assert_eq!(entry2.drp, drp);
         assert_eq!(entry2.refcount, 1);
-        let alloc_rec = idml.trees.alloct.get(drp.pba())
+        let alloc_rec = idml.alloct.get(drp.pba())
             .now_or_never().unwrap()
             .unwrap();
         assert_eq!(alloc_rec.unwrap(), rid);
@@ -1236,13 +1243,13 @@ mod t {
         assert_eq!(rid, actual_rid);
 
         // Now verify the contents of the RIDT and AllocT
-        let ridt_fut = idml.trees.ridt.get(actual_rid);
+        let ridt_fut = idml.ridt.get(actual_rid);
         let entry = ridt_fut
             .now_or_never().unwrap()
             .unwrap().unwrap();
         assert_eq!(entry.refcount, 1);
         assert_eq!(entry.drp, drp);
-        let alloc_rec = idml.trees.alloct.get(drp.pba())
+        let alloc_rec = idml.alloct.get(drp.pba())
             .now_or_never().unwrap()
             .unwrap();
         assert_eq!(alloc_rec.unwrap(), actual_rid);

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -181,10 +181,10 @@ impl<'a> IDML {
             // Finish alloct.range_delete before alloct.clean_zone, because the
             // range delete is likely to eliminate most if not all nodes that
             // need to be moved by clean_zone
-            let atfut = alloct3.range_delete(pba_range.clone(), txg)
-                .and_then(move |_| {
-                    alloct3.clean_zone(pba_range, zone.txgs, txg)
-                });
+            let atfut = alloct3.clone().range_delete(pba_range.clone(), txg)
+            .and_then(move |_| {
+                alloct3.clean_zone(pba_range, zone.txgs, txg)
+            });
             future::try_join(czfut, atfut).map_ok(drop)
         }).map_ok(move |_| {
             #[cfg(debug_assertions)]

--- a/bfffs-core/src/lib.rs
+++ b/bfffs-core/src/lib.rs
@@ -16,7 +16,7 @@
 #![allow(clippy::module_inception)]
 
 // error: reached the type-length limit while instantiating std::pin::Pin...
-#![type_length_limit="3198763"]
+#![type_length_limit="3790758"]
 // error: trait bounds overflowed in Database::sync_transaction_priv
 #![recursion_limit="256"]
 

--- a/bfffs-core/src/tree/mod.rs
+++ b/bfffs-core/src/tree/mod.rs
@@ -33,7 +33,11 @@ cfg_if! {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(bound(deserialize = "A: DeserializeOwned"))]
 struct InnerOnDisk<A: Addr> {
-    height: u64,
+    // 8 bits of tree height is sufficient for a tree that can contain more data
+    // than will ever be created by mankind, even with fanout of 2.
+    height: u8,
+    // Makes the rest of the structure line up nicely in a hexdump
+    _reserved: [u8; 7],
     limits: Limits,
     root: A,
     txgs: Range<TxgT>,
@@ -43,9 +47,10 @@ struct InnerOnDisk<A: Addr> {
 impl<A: Addr + Default> Default for InnerOnDisk<A> {
     fn default() -> Self {
         InnerOnDisk {
-            height: u64::default(),
-            limits: Limits::default(),
-            root: A::default(),
+            height: Default::default(),
+            _reserved: Default::default(),
+            limits: Default::default(),
+            root: Default::default(),
             txgs: TxgT(0)..TxgT(1),
         }
     }

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -721,7 +721,6 @@ impl<A, D, K, V> Tree<A, D, K, V>
         //   can be deserialized into a BTreeMap<A, NodeData>.  Otherwise,
         //   extend its parent's representation.
         // * Last of all, print the root's representation.
-        let inner = self.i.clone();
         let rrf = Rc::new(RefCell::new(f));
         let rrf2 = rrf.clone();
         let rrf3 = rrf.clone();
@@ -732,12 +731,12 @@ impl<A, D, K, V> Tree<A, D, K, V>
             .unwrap();
         let fut = self.read()
             .then(move |tree_guard| {
-                tree_guard.rlock(&inner.dml)
+                tree_guard.rlock(&self.i.dml)
                 .and_then(move |guard| {
                     let mut f2 = rrf2.borrow_mut();
-                    let s = serde_yaml::to_string(&*inner).unwrap();
+                    let s = serde_yaml::to_string(&*self.i).unwrap();
                     writeln!(f2, "{}", &s).unwrap();
-                    Tree::dump_r(inner.dml.clone(), guard, rrf)
+                    Tree::dump_r(self.i.dml.clone(), guard, rrf)
                 }).map_ok(move |guard| {
                     let mut f3 = rrf3.borrow_mut();
                     let mut hmap = BTreeMap::new();

--- a/bfffs-core/src/tree/tree/tests/clean_zone.rs
+++ b/bfffs-core/src/tree/tree/tests/clean_zone.rs
@@ -97,7 +97,6 @@ fn basic() {
     let ddml = Arc::new(mock);
     let tree = Arc::new(Tree::<DRP, DDML, u32, f32>::from_str(ddml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -105,97 +104,99 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 8
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 8
-              end: 9
-            ptr:
-              Addr:
-                pba:
-                  cluster: 0
-                  lba: 2
-                compressed: false
-                lsize: 0
-                csize: 0
-                checksum: 0
-          - key: 4
-            txgs:
-              start: 20
-              end: 32
-            ptr:
-              Addr:
-                pba:
-                  cluster: 0
-                  lba: 4
-                compressed: false
-                lsize: 0
-                csize: 0
-                checksum: 0
-          - key: 8
-            txgs:
-              start: 8
-              end: 24
-            ptr:
-              Addr:
-                pba:
-                  cluster: 0
-                  lba: 101
-                compressed: false
-                lsize: 0
-                csize: 0
-                checksum: 0
-          - key: 12
-            txgs:
-              start: 21
-              end: 42
-            ptr:
-              Mem:  # In-memory Int node with a child in the target zone
-                Int:
-                  children:
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              6: 6.0
-                              7: 7.0
-                    - key: 16
-                      txgs:
-                        start: 21
-                        end: 22
-                      ptr:
-                        Addr:
-                          pba:
-                            cluster: 0
-                            lba: 102
-                          compressed: false
-                          lsize: 0
-                          csize: 0
-                          checksum: 0
-                    - key: 20   # Leaf node in TXG range but not in PBA range
-                      txgs:
-                        start: 29
-                        end: 30
-                      ptr:
-                        Addr:
-                          pba:
-                            cluster: 0
-                            lba: 200
-                          compressed: false
-                          lsize: 0
-                          csize: 0
-                          checksum: 0
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 8
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 8
+                end: 9
+              ptr:
+                Addr:
+                  pba:
+                    cluster: 0
+                    lba: 2
+                  compressed: false
+                  lsize: 0
+                  csize: 0
+                  checksum: 0
+            - key: 4
+              txgs:
+                start: 20
+                end: 32
+              ptr:
+                Addr:
+                  pba:
+                    cluster: 0
+                    lba: 4
+                  compressed: false
+                  lsize: 0
+                  csize: 0
+                  checksum: 0
+            - key: 8
+              txgs:
+                start: 8
+                end: 24
+              ptr:
+                Addr:
+                  pba:
+                    cluster: 0
+                    lba: 101
+                  compressed: false
+                  lsize: 0
+                  csize: 0
+                  checksum: 0
+            - key: 12
+              txgs:
+                start: 21
+                end: 42
+              ptr:
+                Mem:  # In-memory Int node with a child in the target zone
+                  Int:
+                    children:
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                6: 6.0
+                                7: 7.0
+                      - key: 16
+                        txgs:
+                          start: 21
+                          end: 22
+                        ptr:
+                          Addr:
+                            pba:
+                              cluster: 0
+                              lba: 102
+                            compressed: false
+                            lsize: 0
+                            csize: 0
+                            checksum: 0
+                      - key: 20   # Leaf node in TXG range but not in PBA range
+                        txgs:
+                          start: 29
+                          end: 30
+                        ptr:
+                          Addr:
+                            pba:
+                              cluster: 0
+                              lba: 200
+                            compressed: false
+                            lsize: 0
+                            csize: 0
+                            checksum: 0
 "#));
 
     let start = PBA::new(0, 100);
@@ -207,7 +208,6 @@ root:
     let clean_tree = format!("{}", tree);
     assert_eq!(clean_tree,
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -215,118 +215,120 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 8
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 8
-              end: 9
-            ptr:
-              Addr:
-                pba:
-                  cluster: 0
-                  lba: 2
-                compressed: false
-                lsize: 0
-                csize: 0
-                checksum: 0
-          - key: 4
-            txgs:
-              start: 20
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4
-                      txgs:
-                        start: 31
-                        end: 32
-                      ptr:
-                        Addr:
-                          pba:
-                            cluster: 0
-                            lba: 3
-                          compressed: false
-                          lsize: 0
-                          csize: 0
-                          checksum: 0
-                    - key: 6
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Addr:
-                          pba:
-                            cluster: 1
-                            lba: 0
-                          compressed: false
-                          lsize: 0
-                          csize: 0
-                          checksum: 0
-          - key: 8
-            txgs:
-              start: 8
-              end: 43
-            ptr:
-              Addr:
-                pba:
-                  cluster: 1
-                  lba: 2
-                compressed: false
-                lsize: 0
-                csize: 0
-                checksum: 0
-          - key: 12
-            txgs:
-              start: 21
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              6: 6.0
-                              7: 7.0
-                    - key: 16
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Addr:
-                          pba:
-                            cluster: 1
-                            lba: 1
-                          compressed: false
-                          lsize: 0
-                          csize: 0
-                          checksum: 0
-                    - key: 20
-                      txgs:
-                        start: 29
-                        end: 30
-                      ptr:
-                        Addr:
-                          pba:
-                            cluster: 0
-                            lba: 200
-                          compressed: false
-                          lsize: 0
-                          csize: 0
-                          checksum: 0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 8
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 8
+                end: 9
+              ptr:
+                Addr:
+                  pba:
+                    cluster: 0
+                    lba: 2
+                  compressed: false
+                  lsize: 0
+                  csize: 0
+                  checksum: 0
+            - key: 4
+              txgs:
+                start: 20
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4
+                        txgs:
+                          start: 31
+                          end: 32
+                        ptr:
+                          Addr:
+                            pba:
+                              cluster: 0
+                              lba: 3
+                            compressed: false
+                            lsize: 0
+                            csize: 0
+                            checksum: 0
+                      - key: 6
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Addr:
+                            pba:
+                              cluster: 1
+                              lba: 0
+                            compressed: false
+                            lsize: 0
+                            csize: 0
+                            checksum: 0
+            - key: 8
+              txgs:
+                start: 8
+                end: 43
+              ptr:
+                Addr:
+                  pba:
+                    cluster: 1
+                    lba: 2
+                  compressed: false
+                  lsize: 0
+                  csize: 0
+                  checksum: 0
+            - key: 12
+              txgs:
+                start: 21
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                6: 6.0
+                                7: 7.0
+                      - key: 16
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Addr:
+                            pba:
+                              cluster: 1
+                              lba: 1
+                            compressed: false
+                            lsize: 0
+                            csize: 0
+                            checksum: 0
+                      - key: 20
+                        txgs:
+                          start: 29
+                          end: 30
+                        ptr:
+                          Addr:
+                            pba:
+                              cluster: 0
+                              lba: 200
+                            compressed: false
+                            lsize: 0
+                            csize: 0
+                            checksum: 0"#);
 }
 
 // The Root node lies in the dirty zone
@@ -374,7 +376,6 @@ fn dirty_root() {
     let ddml = Arc::new(mock);
     let tree = Arc::new(Tree::<DRP, DDML, u32, f32>::from_str(ddml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -382,20 +383,22 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Addr:
-      pba:
-        cluster: 0
-        lba: 100
-      compressed: false
-      lsize: 0
-      csize: 0
-      checksum: 0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Addr:
+        pba:
+          cluster: 0
+          lba: 100
+        compressed: false
+        lsize: 0
+        csize: 0
+        checksum: 0
+  "#));
 
     let start = PBA::new(0, 100);
     let end = PBA::new(0, 200);

--- a/bfffs-core/src/tree/tree/tests/clean_zone.rs
+++ b/bfffs-core/src/tree/tree/tests/clean_zone.rs
@@ -95,7 +95,7 @@ fn basic() {
             Box::pin(future::ok(drp))
         });
     let ddml = Arc::new(mock);
-    let tree: Tree<DRP, DDML, u32, f32> = Tree::from_str(ddml, false, r#"
+    let tree = Arc::new(Tree::<DRP, DDML, u32, f32>::from_str(ddml, false, r#"
 ---
 height: 3
 limits:
@@ -196,12 +196,12 @@ root:
                           lsize: 0
                           csize: 0
                           checksum: 0
-"#);
+"#));
 
     let start = PBA::new(0, 100);
     let end = PBA::new(0, 200);
     let txgs = TxgT::from(20)..TxgT::from(30);
-    tree.clean_zone(start..end, txgs, TxgT::from(42))
+    tree.clone().clean_zone(start..end, txgs, TxgT::from(42))
     .now_or_never().unwrap()
     .unwrap();
     let clean_tree = format!("{}", tree);
@@ -372,7 +372,7 @@ fn dirty_root() {
             Box::pin(future::ok(drp))
         });
     let ddml = Arc::new(mock);
-    let tree: Tree<DRP, DDML, u32, f32> = Tree::from_str(ddml, false, r#"
+    let tree = Arc::new(Tree::<DRP, DDML, u32, f32>::from_str(ddml, false, r#"
 ---
 height: 2
 limits:
@@ -395,7 +395,7 @@ root:
       lsize: 0
       csize: 0
       checksum: 0
-"#);
+"#));
 
     let start = PBA::new(0, 100);
     let end = PBA::new(0, 200);

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -7979,7 +7979,7 @@ root:
 fn remove_last_key() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 1
 limits:
@@ -7998,8 +7998,8 @@ root:
       Leaf:
         items:
           0: 0.0
-"#);
-    let r = tree.remove(0, TxgT::from(42))
+"#));
+    let r = tree.clone().remove(0, TxgT::from(42))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(0.0)));
     assert_eq!(format!("{}", tree),
@@ -8026,7 +8026,7 @@ root:
 fn remove_from_leaf() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 1
 limits:
@@ -8047,8 +8047,8 @@ root:
           0: 0.0
           1: 1.0
           2: 2.0
-"#);
-    let r = tree.remove(1, TxgT::from(42))
+"#));
+    let r = tree.clone().remove(1, TxgT::from(42))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(1.0)));
     assert_eq!(format!("{}", tree),
@@ -8077,7 +8077,7 @@ root:
 fn remove_and_merge_down() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -8106,8 +8106,8 @@ root:
                     0: 0.0
                     1: 1.0
                     2: 2.0
-"#);
-    let r2 = tree.remove(1, TxgT::from(42))
+"#));
+    let r2 = tree.clone().remove(1, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -8136,7 +8136,7 @@ root:
 fn remove_and_merge_int_left() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -8258,8 +8258,8 @@ root:
                             items:
                               21: 21.0
                               22: 22.0
-                              23: 23.0"#);
-    let r2 = tree.remove(23, TxgT::from(42))
+                              23: 23.0"#));
+    let r2 = tree.clone().remove(23, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -8382,7 +8382,7 @@ root:
 fn remove_and_merge_int_right() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -8494,8 +8494,8 @@ root:
                           Leaf:
                             items:
                               21: 21.0
-                              22: 22.0"#);
-    let r2 = tree.remove(4, TxgT::from(42))
+                              22: 22.0"#));
+    let r2 = tree.clone().remove(4, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -8608,7 +8608,7 @@ root:
 fn remove_and_merge_leaf_left() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -8656,8 +8656,8 @@ root:
                   items:
                     5: 5.0
                     7: 7.0
-"#);
-    let r2 = tree.remove(7, TxgT::from(42))
+"#));
+    let r2 = tree.clone().remove(7, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -8705,7 +8705,7 @@ root:
 fn remove_and_merge_leaf_right() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -8754,8 +8754,8 @@ root:
                     5: 5.0
                     6: 6.0
                     7: 7.0
-"#);
-    let r2 = tree.remove(4, TxgT::from(42))
+"#));
+    let r2 = tree.clone().remove(4, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -8804,7 +8804,7 @@ root:
 fn remove_and_steal_int_left() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -8936,8 +8936,8 @@ root:
                             items:
                               24: 24.0
                               25: 25.0
-                              26: 26.0"#);
-    let r2 = tree.remove(26, TxgT::from(42))
+                              26: 26.0"#));
+    let r2 = tree.clone().remove(26, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -9078,7 +9078,7 @@ root:
 fn remove_and_steal_int_right() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -9210,8 +9210,8 @@ root:
                           Leaf:
                             items:
                               24: 24.0
-                              26: 26.0"#);
-    let r2 = tree.remove(14, TxgT::from(42))
+                              26: 26.0"#));
+    let r2 = tree.clone().remove(14, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -9352,7 +9352,7 @@ root:
 fn remove_and_steal_leaf_left() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -9403,8 +9403,8 @@ root:
                   items:
                     8: 8.0
                     9: 9.0
-"#);
-    let r2 = tree.remove(8, TxgT::from(42))
+"#));
+    let r2 = tree.clone().remove(8, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -9463,7 +9463,7 @@ root:
 fn remove_and_steal_leaf_right() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -9514,8 +9514,8 @@ root:
                     7: 7.0
                     8: 8.0
                     9: 9.0
-"#);
-    let r2 = tree.remove(4, TxgT::from(42))
+"#));
+    let r2 = tree.clone().remove(4, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -9575,7 +9575,9 @@ fn remove_nonexistent() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::new(dml, limits, false);
+    let tree = Arc::new(
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false)
+    );
     let r = tree.remove(3, TxgT::from(42))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(None));

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -7435,7 +7435,7 @@ root:
 #[test]
 fn range_empty_range() {
     let dml = Arc::new(MockDML::new());
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -7473,7 +7473,7 @@ root:
                   items:
                     3: 3.0
                     4: 4.0
-"#);
+"#));
     let r = tree.range(1..1)
         .try_collect()
         .now_or_never().unwrap();
@@ -7484,7 +7484,9 @@ root:
 #[test]
 fn range_empty_tree() {
     let dml = Arc::new(MockDML::new());
-    let tree = Tree::<u32, MockDML, u32, f32>::create(dml, false, 1.0, 1.0);
+    let tree = Arc::new(
+        Tree::<u32, MockDML, u32, f32>::create(dml, false, 1.0, 1.0)
+    );
     let r = tree.range(..)
         .try_collect()
         .now_or_never().unwrap();
@@ -7495,7 +7497,7 @@ fn range_empty_tree() {
 #[test]
 fn range_full() {
     let dml = Arc::new(MockDML::new());
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -7533,7 +7535,7 @@ root:
                   items:
                     3: 3.0
                     4: 4.0
-"#);
+"#));
     let r = tree.range(..)
         .try_collect()
         .now_or_never().unwrap();
@@ -7543,7 +7545,7 @@ root:
 #[test]
 fn range_exclusive_start() {
     let dml = Arc::new(MockDML::new());
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -7581,7 +7583,7 @@ root:
                   items:
                     3: 3.0
                     4: 4.0
-"#);
+"#));
     // A query that starts on a leaf
     let r = tree.range((Bound::Excluded(0), Bound::Excluded(4)))
         .try_collect()
@@ -7598,7 +7600,7 @@ root:
 #[test]
 fn range_leaf() {
     let dml = Arc::new(MockDML::new());
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 1
 limits:
@@ -7621,7 +7623,7 @@ root:
           2: 2.0
           3: 3.0
           4: 4.0
-"#);
+"#));
     let r = tree.range(1..3)
         .try_collect()
         .now_or_never().unwrap();
@@ -7631,7 +7633,7 @@ root:
 #[test]
 fn range_leaf_inclusive_end() {
     let dml = Arc::new(MockDML::new());
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 1
 limits:
@@ -7654,7 +7656,7 @@ root:
           2: 2.0
           3: 3.0
           4: 4.0
-"#);
+"#));
     let r = tree.range(3..=4)
         .try_collect()
         .now_or_never().unwrap();
@@ -7664,7 +7666,7 @@ root:
 #[test]
 fn range_nonexistent_between_two_leaves() {
     let dml = Arc::new(MockDML::new());
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -7702,7 +7704,7 @@ root:
                   items:
                     5: 5.0
                     6: 6.0
-"#);
+"#));
     let r = tree.range(2..4)
         .try_collect()
         .now_or_never().unwrap();
@@ -7712,7 +7714,7 @@ root:
 #[test]
 fn range_two_ints() {
     let dml = Arc::new(MockDML::new());
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -7766,7 +7768,7 @@ root:
                             items:
                               9: 9.0
                               10: 10.0
-"#);
+"#));
     let r = tree.range(1..10)
         .try_collect()
         .now_or_never().unwrap();
@@ -7776,7 +7778,7 @@ root:
 #[test]
 fn range_ends_between_two_leaves() {
     let dml = Arc::new(MockDML::new());
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -7814,7 +7816,7 @@ root:
                   items:
                     4: 4.0
                     5: 5.0
-"#);
+"#));
     let r = tree.range(0..3)
         .try_collect()
         .now_or_never().unwrap();
@@ -7824,7 +7826,7 @@ root:
 #[test]
 fn range_ends_before_node_but_after_parent_pointer() {
     let dml = Arc::new(MockDML::new());
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -7862,7 +7864,7 @@ root:
                   items:
                     6: 6.0
                     7: 7.0
-"#);
+"#));
     let r = tree.range(0..5)
         .try_collect()
         .now_or_never().unwrap();
@@ -7872,7 +7874,7 @@ root:
 #[test]
 fn range_starts_between_two_leaves() {
     let dml = Arc::new(MockDML::new());
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -7920,7 +7922,7 @@ root:
                   items:
                     5: 5.0
                     6: 6.0
-"#);
+"#));
     let r = tree.range(2..6)
         .try_collect()
         .now_or_never().unwrap();
@@ -7930,7 +7932,7 @@ root:
 #[test]
 fn range_two_leaves() {
     let dml = Arc::new(MockDML::new());
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -7968,7 +7970,7 @@ root:
                   items:
                     3: 3.0
                     4: 4.0
-"#);
+"#));
     let r = tree.range(1..4)
         .try_collect()
         .now_or_never().unwrap();

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -23,7 +23,6 @@ fn insert() {
     assert_eq!(r, Ok(None));
     assert_eq!(format!("{}", tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -31,15 +30,17 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 42
-    end: 43
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 42
+      end: 43
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0"#);
 }
 
 // When inserting into an int node's first child and the key is lower than the
@@ -50,7 +51,6 @@ fn insert_lower_than_parents_key() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -58,45 +58,46 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 67
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    67: 67.0
-                    68: 68.0
-                    69: 69.0
-          - key: 70
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    70: 70.0
-                    71: 71.0
-                    72: 72.0
-                    73: 73.0
-                    74: 74.0
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 67
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      67: 67.0
+                      68: 68.0
+                      69: 69.0
+            - key: 70
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      70: 70.0
+                      71: 71.0
+                      72: 72.0
+                      73: 73.0
+                      74: 74.0
 "#));
     assert!(tree.clone().insert(36, 36.0, TxgT::from(42))
             .now_or_never().unwrap()
             .is_ok());
     assert_eq!(format!("{}", tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -104,39 +105,41 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 36
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    36: 36.0
-                    67: 67.0
-                    68: 68.0
-                    69: 69.0
-          - key: 70
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    70: 70.0
-                    71: 71.0
-                    72: 72.0
-                    73: 73.0
-                    74: 74.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 36
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      36: 36.0
+                      67: 67.0
+                      68: 68.0
+                      69: 69.0
+            - key: 70
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      70: 70.0
+                      71: 71.0
+                      72: 72.0
+                      73: 73.0
+                      74: 74.0"#);
 }
 
 #[test]
@@ -145,7 +148,6 @@ fn insert_dup() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -153,22 +155,23 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
 "#));
     let r = tree.clone().insert(0, 100.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(0.0)));
     assert_eq!(format!("{}", tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -176,15 +179,17 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 42
-    end: 43
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 100.0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 42
+      end: 43
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 100.0"#);
 }
 
 /// When overwriting an existing value, don't split the leaf node, even if it's
@@ -195,7 +200,6 @@ fn insert_dup_no_split() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -203,26 +207,27 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
-          1: 1.0
-          2: 2.0
-          3: 3.0
-          4: 4.0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
+            1: 1.0
+            2: 2.0
+            3: 3.0
+            4: 4.0
+  "#));
     let r = tree.clone().insert(0, 100.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(0.0)));
     assert_eq!(format!("{}", tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -230,19 +235,21 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 42
-    end: 43
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 100.0
-          1: 1.0
-          2: 2.0
-          3: 3.0
-          4: 4.0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 42
+      end: 43
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 100.0
+            1: 1.0
+            2: 2.0
+            3: 3.0
+            4: 4.0"#);
 }
 
 /// Insert a key that splits a non-root interior node
@@ -252,7 +259,6 @@ fn insert_split_int() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -260,124 +266,125 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                              2: 2.0
-                    - key: 3
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-                              5: 5.0
-                    - key: 6
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              6: 6.0
-                              7: 7.0
-                              8: 8.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                              11: 11.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                              14: 14.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                              17: 17.0
-                    - key: 18
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              18: 18.0
-                              19: 19.0
-                              20: 20.0
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0
-                              23: 23.0"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                                2: 2.0
+                      - key: 3
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+                                5: 5.0
+                      - key: 6
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                6: 6.0
+                                7: 7.0
+                                8: 8.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                                11: 11.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                                14: 14.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                                17: 17.0
+                      - key: 18
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                18: 18.0
+                                19: 19.0
+                                20: 20.0
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0
+                                23: 23.0"#));
     let r2 = tree.clone().insert(24, 24.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -385,127 +392,129 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                              2: 2.0
-                    - key: 3
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-                              5: 5.0
-                    - key: 6
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              6: 6.0
-                              7: 7.0
-                              8: 8.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                              11: 11.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                              14: 14.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                              17: 17.0
-          - key: 18
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 18
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              18: 18.0
-                              19: 19.0
-                              20: 20.0
-                    - key: 21
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0
-                              23: 23.0
-                              24: 24.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                                2: 2.0
+                      - key: 3
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+                                5: 5.0
+                      - key: 6
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                6: 6.0
+                                7: 7.0
+                                8: 8.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                                11: 11.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                                14: 14.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                                17: 17.0
+            - key: 18
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 18
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                18: 18.0
+                                19: 19.0
+                                20: 20.0
+                      - key: 21
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0
+                                23: 23.0
+                                24: 24.0"#);
 }
 
 /// Insert a key that splits a sequentially-optimized non-root interior node
@@ -515,7 +524,6 @@ fn insert_split_int_sequential() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, true, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 8
@@ -523,136 +531,137 @@ limits:
   max_leaf_fanout: 8
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 3
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                    - key: 18
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              18: 18.0
-                              19: 19.0
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0
-                    - key: 24
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              24: 24.0
-                              25: 25.0
-                    - key: 27
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              27: 27.0
-                              28: 28.0
-                    - key: 30
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              30: 30.0
-                              31: 31.0"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 3
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                      - key: 18
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                18: 18.0
+                                19: 19.0
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0
+                      - key: 24
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                24: 24.0
+                                25: 25.0
+                      - key: 27
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                27: 27.0
+                                28: 28.0
+                      - key: 30
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                30: 30.0
+                                31: 31.0"#));
     let r2 = tree.clone().insert(33, 33.0, TxgT::from(42))
     .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 8
@@ -660,139 +669,141 @@ limits:
   max_leaf_fanout: 8
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 3
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                    - key: 18
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              18: 18.0
-                              19: 19.0
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0
-                    - key: 24
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              24: 24.0
-                              25: 25.0
-          - key: 27
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 27
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              27: 27.0
-                              28: 28.0
-                    - key: 30
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              30: 30.0
-                              31: 31.0
-                              33: 33.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 3
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                      - key: 18
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                18: 18.0
+                                19: 19.0
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0
+                      - key: 24
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                24: 24.0
+                                25: 25.0
+            - key: 27
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 27
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                27: 27.0
+                                28: 28.0
+                      - key: 30
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                30: 30.0
+                                31: 31.0
+                                33: 33.0"#);
 }
 
 /// Insert a key that splits a non-root leaf node
@@ -802,7 +813,6 @@ fn insert_split_leaf() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -810,45 +820,46 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-                    2: 2.0
-          - key: 3
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+            - key: 3
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+  "#));
     let r2 = tree.clone().insert(8, 8.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -856,47 +867,49 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-                    2: 2.0
-          - key: 3
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-                    5: 5.0
-          - key: 6
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+            - key: 3
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+            - key: 6
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0"#);
 }
 
 /// Insert a key that splits a sequentially-optimized non-root leaf node
@@ -906,7 +919,6 @@ fn insert_split_leaf_sequential() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, true, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 8
@@ -914,49 +926,50 @@ limits:
   max_leaf_fanout: 8
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-                    2: 2.0
-                    3: 3.0
-          - key: 4
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0
-                    9: 9.0
-                    10: 10.0
-                    11: 11.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+                      3: 3.0
+            - key: 4
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+                      9: 9.0
+                      10: 10.0
+                      11: 11.0
+  "#));
     let r2 = tree.clone().insert(12, 12.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 8
@@ -964,51 +977,53 @@ limits:
   max_leaf_fanout: 8
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-                    2: 2.0
-                    3: 3.0
-          - key: 4
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0
-                    9: 9.0
-          - key: 10
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-                    12: 12.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+                      3: 3.0
+            - key: 4
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+                      9: 9.0
+            - key: 10
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0"#);
 }
 
 /// Insert a key that splits the root IntNode
@@ -1018,7 +1033,6 @@ fn insert_split_root_int() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1026,76 +1040,77 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-                    2: 2.0
-          - key: 3
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-                    5: 5.0
-          - key: 6
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    9: 9.0
-                    10: 10.0
-                    11: 11.0
-          - key: 12
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    12: 12.0
-                    13: 13.0
-                    14: 14.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+            - key: 3
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+            - key: 6
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      9: 9.0
+                      10: 10.0
+                      11: 11.0
+            - key: 12
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      12: 12.0
+                      13: 13.0
+                      14: 14.0
+  "#));
     let r2 = tree.clone().insert(15, 15.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1103,86 +1118,88 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                              2: 2.0
-                    - key: 3
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-                              5: 5.0
-                    - key: 6
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              6: 6.0
-                              7: 7.0
-                              8: 8.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                              11: 11.0
-                    - key: 12
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                              14: 14.0
-                              15: 15.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                                2: 2.0
+                      - key: 3
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+                                5: 5.0
+                      - key: 6
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                6: 6.0
+                                7: 7.0
+                                8: 8.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                                11: 11.0
+                      - key: 12
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                                14: 14.0
+                                15: 15.0"#);
 }
 
 /// Insert a key that splits the root leaf node
@@ -1192,7 +1209,6 @@ fn insert_split_root_leaf() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1200,26 +1216,27 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
-          1: 1.0
-          2: 2.0
-          3: 3.0
-          4: 4.0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
+            1: 1.0
+            2: 2.0
+            3: 3.0
+            4: 4.0
+  "#));
     let r2 = tree.clone().insert(5, 5.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1227,36 +1244,38 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-                    2: 2.0
-          - key: 3
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-                    5: 5.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+            - key: 3
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0"#);
 }
 
 #[test]
@@ -1278,7 +1297,6 @@ fn get_deep() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1286,35 +1304,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+  "#));
     let r = tree.get(3).now_or_never().unwrap();
     assert_eq!(r, Ok(Some(3.0)))
 }
@@ -1343,7 +1363,6 @@ fn last_key() {
     let dml = Arc::new(MockDML::new());
     let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1351,35 +1370,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+  "#);
     let r = tree.last_key().now_or_never().unwrap();
     assert_eq!(r, Ok(Some(4)))
 }
@@ -1400,7 +1421,6 @@ fn range_delete() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1408,116 +1428,117 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              2: 2.0
-                    - key: 5
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              5: 5.0
-                              6: 6.0
-                              7: 7.0
-                    - key: 10
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              10: 10.0
-                              11: 11.0
-          - key: 15
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                    - key: 20
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              25: 25.0
-          - key: 30
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 31
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              31: 31.0
-                              32: 32.0
-                    - key: 37
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              37: 37.0
-                              40: 40.0
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                2: 2.0
+                      - key: 5
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                5: 5.0
+                                6: 6.0
+                                7: 7.0
+                      - key: 10
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                10: 10.0
+                                11: 11.0
+            - key: 15
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                      - key: 20
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                25: 25.0
+            - key: 30
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 31
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                31: 31.0
+                                32: 32.0
+                      - key: 37
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                37: 37.0
+                                40: 40.0
+  "#));
     let r = tree.clone().range_delete(11..=31, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1525,47 +1546,49 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-          - key: 5
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-                    10: 10.0
-          - key: 31
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    32: 32.0
-                    37: 37.0
-                    40: 40.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+            - key: 5
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+                      10: 10.0
+            - key: 31
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      32: 32.0
+                      37: 37.0
+                      40: 40.0"#);
 }
 
 // After removing keys, one node is in danger because it has too many children
@@ -1576,7 +1599,6 @@ fn range_delete_danger() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1584,114 +1606,115 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              2: 2.0
-                    - key: 5
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              5: 5.0
-                              6: 6.0
-                              7: 7.0
-                              8: 8.0
-                              9: 9.0
-                    - key: 10
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Addr: 110
-          - key: 15
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                    - key: 20
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              25: 25.0
-          - key: 30
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 31
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              31: 31.0
-                              32: 32.0
-                    - key: 37
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              37: 37.0
-                              40: 40.0
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                2: 2.0
+                      - key: 5
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                5: 5.0
+                                6: 6.0
+                                7: 7.0
+                                8: 8.0
+                                9: 9.0
+                      - key: 10
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Addr: 110
+            - key: 15
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                      - key: 20
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                25: 25.0
+            - key: 30
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 31
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                31: 31.0
+                                32: 32.0
+                      - key: 37
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                37: 37.0
+                                40: 40.0
+  "#));
     let r = tree.clone().range_delete(5..6, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1699,106 +1722,108 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              2: 2.0
-                    - key: 5
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              6: 6.0
-                              7: 7.0
-                              8: 8.0
-                              9: 9.0
-                    - key: 10
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Addr: 110
-          - key: 15
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                    - key: 20
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              25: 25.0
-          - key: 30
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 31
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              31: 31.0
-                              32: 32.0
-                    - key: 37
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              37: 37.0
-                              40: 40.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                2: 2.0
+                      - key: 5
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                6: 6.0
+                                7: 7.0
+                                8: 8.0
+                                9: 9.0
+                      - key: 10
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Addr: 110
+            - key: 15
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                      - key: 20
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                25: 25.0
+            - key: 30
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 31
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                31: 31.0
+                                32: 32.0
+                      - key: 37
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                37: 37.0
+                                40: 40.0"#);
 }
 
 // Delete a range that's exclusive on the left and right
@@ -1808,7 +1833,6 @@ fn range_delete_exc_exc() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1816,61 +1840,63 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-          - key: 4
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0
-          - key: 10
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-                    12: 12.0
-                    13: 13.0
-          - key: 20
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    20: 20.0
-                    21: 21.0
-                    22: 22.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+            - key: 4
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+            - key: 10
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+                      13: 13.0
+            - key: 20
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+  "#));
     let r = tree.clone().range_delete(
         (Bound::Excluded(4), Bound::Excluded(10)),
         TxgT::from(42))
@@ -1878,7 +1904,6 @@ root:
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1886,48 +1911,50 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-          - key: 4
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    10: 10.0
-                    11: 11.0
-                    12: 12.0
-                    13: 13.0
-          - key: 20
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    20: 20.0
-                    21: 21.0
-                    22: 22.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+            - key: 4
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+                      13: 13.0
+            - key: 20
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0"#);
 }
 
 // Delete a range that's exclusive on the left and inclusive on the right
@@ -1937,7 +1964,6 @@ fn range_delete_exc_inc() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1945,61 +1971,63 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-          - key: 4
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0
-          - key: 10
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-                    12: 12.0
-                    13: 13.0
-          - key: 20
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    20: 20.0
-                    21: 21.0
-                    22: 22.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+            - key: 4
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+            - key: 10
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+                      13: 13.0
+            - key: 20
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+  "#));
     let r = tree.clone().range_delete(
         (Bound::Excluded(4), Bound::Included(10)),
         TxgT::from(42))
@@ -2007,7 +2035,6 @@ root:
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2015,47 +2042,49 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-          - key: 4
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    11: 11.0
-                    12: 12.0
-                    13: 13.0
-          - key: 20
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    20: 20.0
-                    21: 21.0
-                    22: 22.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+            - key: 4
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      11: 11.0
+                      12: 12.0
+                      13: 13.0
+            - key: 20
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0"#);
 }
 
 // During range_delete_pass2, one node needs to be fixed three times.  The node
@@ -2072,7 +2101,6 @@ fn range_delete_fix_three_times() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 4
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -2080,289 +2108,290 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 8
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 664
-            txgs:
-              start: 1
-              end: 5
-            ptr:
-              Addr: 3977
-          - key: 728
-            txgs:
-              start: 1
-              end: 8
-            ptr:
-              Addr: 100728
-          - key: 832
-            txgs:
-              start: 4
-              end: 8
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 832
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 832
-                                txgs:
-                                  start: 7
-                                  end: 8
-                                ptr:
-                                  Addr: 4627
-                              - key: 836
-                                txgs:
-                                  start: 6
-                                  end: 7
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        838: 646
-                                        839: 647
-                                        1027: 1814
-                              - key: 1028
-                                txgs:
-                                  start: 7
-                                  end: 8
-                                ptr:
-                                  Addr: 1001028
-                              - key: 1054
-                                txgs:
-                                  start: 6
-                                  end: 7
-                                ptr:
-                                  Addr: 8892
-                    - key: 1090
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 1090
-                                txgs:
-                                  start: 7
-                                  end: 8
-                                ptr:
-                                  Addr: 101090
-                              - key: 1130
-                                txgs:
-                                  start: 6
-                                  end: 7
-                                ptr:
-                                  Addr: 8894
-                              - key: 1170
-                                txgs:
-                                  start: 7
-                                  end: 8
-                                ptr:
-                                  Addr: 108894
-                              - key: 1297
-                                txgs:
-                                  start: 6
-                                  end: 7
-                                ptr:
-                                  Addr: 8897
-                              - key: 1314
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4054
-                    - key: 1318
-                      txgs:
-                        start: 4
-                        end: 7
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 1318
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4055
-                              - key: 1322
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4056
-                              - key: 1326
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4057
-                              - key: 1330
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4058
-                              - key: 1334
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4059
-          - key: 1466
-            txgs:
-              start: 4
-              end: 8
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1498
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 1498
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4100
-                              - key: 1502
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4101
-                              - key: 1506
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4102
-                              - key: 1510
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4103
-                    - key: 1514
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 1514
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4104
-                              - key: 1530
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        1530: 2317
-                                        1535: 2322
-                                        1536: 984
-                              - key: 1537
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4109
-                    - key: 1540
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 1540
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4110
-                              - key: 1544
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4111
-                              - key: 1548
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4112
-          - key: 1552
-            txgs:
-              start: 4
-              end: 8
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1552
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Addr: 10020
-                    - key: 1568
-                      txgs:
-                        start: 4
-                        end: 7
-                      ptr:
-                        Addr: 9592
-                    - key: 1624
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Addr: 10022
-                    - key: 1640
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Addr: 10024
-                    - key: 1656
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Addr: 10025
-"#));
+  height: 4
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 8
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 664
+              txgs:
+                start: 1
+                end: 5
+              ptr:
+                Addr: 3977
+            - key: 728
+              txgs:
+                start: 1
+                end: 8
+              ptr:
+                Addr: 100728
+            - key: 832
+              txgs:
+                start: 4
+                end: 8
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 832
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 832
+                                  txgs:
+                                    start: 7
+                                    end: 8
+                                  ptr:
+                                    Addr: 4627
+                                - key: 836
+                                  txgs:
+                                    start: 6
+                                    end: 7
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          838: 646
+                                          839: 647
+                                          1027: 1814
+                                - key: 1028
+                                  txgs:
+                                    start: 7
+                                    end: 8
+                                  ptr:
+                                    Addr: 1001028
+                                - key: 1054
+                                  txgs:
+                                    start: 6
+                                    end: 7
+                                  ptr:
+                                    Addr: 8892
+                      - key: 1090
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 1090
+                                  txgs:
+                                    start: 7
+                                    end: 8
+                                  ptr:
+                                    Addr: 101090
+                                - key: 1130
+                                  txgs:
+                                    start: 6
+                                    end: 7
+                                  ptr:
+                                    Addr: 8894
+                                - key: 1170
+                                  txgs:
+                                    start: 7
+                                    end: 8
+                                  ptr:
+                                    Addr: 108894
+                                - key: 1297
+                                  txgs:
+                                    start: 6
+                                    end: 7
+                                  ptr:
+                                    Addr: 8897
+                                - key: 1314
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4054
+                      - key: 1318
+                        txgs:
+                          start: 4
+                          end: 7
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 1318
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4055
+                                - key: 1322
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4056
+                                - key: 1326
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4057
+                                - key: 1330
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4058
+                                - key: 1334
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4059
+            - key: 1466
+              txgs:
+                start: 4
+                end: 8
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1498
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 1498
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4100
+                                - key: 1502
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4101
+                                - key: 1506
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4102
+                                - key: 1510
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4103
+                      - key: 1514
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 1514
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4104
+                                - key: 1530
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          1530: 2317
+                                          1535: 2322
+                                          1536: 984
+                                - key: 1537
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4109
+                      - key: 1540
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 1540
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4110
+                                - key: 1544
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4111
+                                - key: 1548
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4112
+            - key: 1552
+              txgs:
+                start: 4
+                end: 8
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1552
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Addr: 10020
+                      - key: 1568
+                        txgs:
+                          start: 4
+                          end: 7
+                        ptr:
+                          Addr: 9592
+                      - key: 1624
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Addr: 10022
+                      - key: 1640
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Addr: 10024
+                      - key: 1656
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Addr: 10025
+  "#));
   let r = tree.clone().range_delete(1024..1536, TxgT::from(42))
     .now_or_never().unwrap();
   assert!(r.is_ok());
   assert_eq!(format!("{}", &tree),
 r#"---
-height: 4
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -2370,121 +2399,123 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 664
-            txgs:
-              start: 1
-              end: 5
-            ptr:
-              Addr: 3977
-          - key: 728
-            txgs:
-              start: 1
-              end: 8
-            ptr:
-              Addr: 100728
-          - key: 832
-            txgs:
-              start: 4
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 832
-                      txgs:
-                        start: 4
-                        end: 43
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 832
-                                txgs:
-                                  start: 7
-                                  end: 8
-                                ptr:
-                                  Addr: 4627
-                              - key: 836
-                                txgs:
-                                  start: 42
-                                  end: 43
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        838: 646
-                                        839: 647
-                                        1536: 984
-                              - key: 1537
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4109
-                              - key: 1540
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4110
-                              - key: 1544
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4111
-                              - key: 1548
-                                txgs:
-                                  start: 4
-                                  end: 5
-                                ptr:
-                                  Addr: 4112
-                    - key: 1552
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Addr: 10020
-                    - key: 1568
-                      txgs:
-                        start: 4
-                        end: 7
-                      ptr:
-                        Addr: 9592
-          - key: 1624
-            txgs:
-              start: 4
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1624
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Addr: 10022
-                    - key: 1640
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Addr: 10024
-                    - key: 1656
-                      txgs:
-                        start: 4
-                        end: 8
-                      ptr:
-                        Addr: 10025"#);
+  height: 4
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 664
+              txgs:
+                start: 1
+                end: 5
+              ptr:
+                Addr: 3977
+            - key: 728
+              txgs:
+                start: 1
+                end: 8
+              ptr:
+                Addr: 100728
+            - key: 832
+              txgs:
+                start: 4
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 832
+                        txgs:
+                          start: 4
+                          end: 43
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 832
+                                  txgs:
+                                    start: 7
+                                    end: 8
+                                  ptr:
+                                    Addr: 4627
+                                - key: 836
+                                  txgs:
+                                    start: 42
+                                    end: 43
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          838: 646
+                                          839: 647
+                                          1536: 984
+                                - key: 1537
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4109
+                                - key: 1540
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4110
+                                - key: 1544
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4111
+                                - key: 1548
+                                  txgs:
+                                    start: 4
+                                    end: 5
+                                  ptr:
+                                    Addr: 4112
+                      - key: 1552
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Addr: 10020
+                      - key: 1568
+                        txgs:
+                          start: 4
+                          end: 7
+                        ptr:
+                          Addr: 9592
+            - key: 1624
+              txgs:
+                start: 4
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1624
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Addr: 10022
+                      - key: 1640
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Addr: 10024
+                      - key: 1656
+                        txgs:
+                          start: 4
+                          end: 8
+                        ptr:
+                          Addr: 10025"#);
 }
 
 /// Do a range delete that causes two Nodes to merge and yet still underflow.
@@ -2495,7 +2526,6 @@ fn range_delete_merge_and_underflow() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -2503,77 +2533,78 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-                    3: 3.0
-          - key: 4
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-          - key: 7
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    7: 7.0
-                    8: 8.0
-                    9: 9.0
-          - key: 10
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-                    12: 12.0
-          - key: 13
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    13: 13.0
-                    14: 14.0
-                    15: 15.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+                      3: 3.0
+            - key: 4
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+            - key: 7
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      7: 7.0
+                      8: 8.0
+                      9: 9.0
+            - key: 10
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+            - key: 13
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      13: 13.0
+                      14: 14.0
+                      15: 15.0
+  "#));
     let r = tree.clone().range_delete(2..6, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert!(tree.clone().check().now_or_never().unwrap().unwrap());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -2581,49 +2612,51 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0
-                    9: 9.0
-          - key: 10
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-                    12: 12.0
-          - key: 13
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    13: 13.0
-                    14: 14.0
-                    15: 15.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+                      9: 9.0
+            - key: 10
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+            - key: 13
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      13: 13.0
+                      14: 14.0
+                      15: 15.0"#);
 }
 
 /// Do a range delete that causes Nodes to merge during pass2, causing an
@@ -2634,7 +2667,6 @@ fn range_delete_merge_and_parent_underflow() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -2642,111 +2674,112 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              2: 2.0
-                              3: 3.0
-                    - key: 4
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4: 4.0
-                              5: 5.0
-                              6: 6.0
-                    - key: 7
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              7: 7.0
-                              8: 8.0
-                              9: 9.0
-                    - key: 10
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 10010
-          - key: 20
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 20
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                              22: 22.0
-                    - key: 23
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 10023
-                    - key: 26
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 10026
-          - key: 30
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Addr: 300
-          - key: 40
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Addr: 10040
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                2: 2.0
+                                3: 3.0
+                      - key: 4
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4: 4.0
+                                5: 5.0
+                                6: 6.0
+                      - key: 7
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                7: 7.0
+                                8: 8.0
+                                9: 9.0
+                      - key: 10
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 10010
+            - key: 20
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 20
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                                22: 22.0
+                      - key: 23
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 10023
+                      - key: 26
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 10026
+            - key: 30
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Addr: 300
+            - key: 40
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Addr: 10040
+  "#));
     let r = tree.clone().range_delete(2..6, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -2754,76 +2787,78 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              6: 6.0
-                              7: 7.0
-                              8: 8.0
-                              9: 9.0
-                    - key: 10
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 10010
-                    - key: 20
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                              22: 22.0
-                    - key: 23
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 10023
-                    - key: 26
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 10026
-          - key: 30
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Addr: 300
-          - key: 40
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Addr: 10040"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                6: 6.0
+                                7: 7.0
+                                8: 8.0
+                                9: 9.0
+                      - key: 10
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 10010
+                      - key: 20
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                                22: 22.0
+                      - key: 23
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 10023
+                      - key: 26
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 10026
+            - key: 30
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Addr: 300
+            - key: 40
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Addr: 10040"#);
 }
 
 // Regression test for bug 9bdac7a, where Tree::range_delete caused the
@@ -2835,7 +2870,6 @@ fn range_delete_merge_descending_and_ascending() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2843,127 +2877,129 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 3
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 452
-            txgs:
-              start: 2
-              end: 3
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 452
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              462: 458
-                              494: 490
-                    - key: 1021
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1025: 835
-                              1027: 837
-          - key: 1245
-            txgs:
-              start: 2
-              end: 3
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1309
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1313: 1123
-                              1316: 1126
-                    - key: 1341
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1368: 1178
-                              1662: 518
-          - key: 1663
-            txgs:
-              start: 2
-              end: 3
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1663
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1663: 523
-                              1666: 547
-                    - key: 1687
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1687: 776
-                              1690: 779
-          - key: 1727
-            txgs:
-              start: 2
-              end: 3
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1727
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1727: 828
-                              1730: 832
-                    - key: 1759
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1759: 861
-                              1762: 864
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 3
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 452
+              txgs:
+                start: 2
+                end: 3
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 452
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                462: 458
+                                494: 490
+                      - key: 1021
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1025: 835
+                                1027: 837
+            - key: 1245
+              txgs:
+                start: 2
+                end: 3
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1309
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1313: 1123
+                                1316: 1126
+                      - key: 1341
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1368: 1178
+                                1662: 518
+            - key: 1663
+              txgs:
+                start: 2
+                end: 3
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1663
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1663: 523
+                                1666: 547
+                      - key: 1687
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1687: 776
+                                1690: 779
+            - key: 1727
+              txgs:
+                start: 2
+                end: 3
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1727
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1727: 828
+                                1730: 832
+                      - key: 1759
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1759: 861
+                                1762: 864
+  "#));
     assert!(tree.clone().check().now_or_never().unwrap().unwrap());
     let r = tree.clone().range_delete(1024..1536, TxgT::from(42))
         .now_or_never().unwrap();
@@ -2979,7 +3015,6 @@ fn range_delete_merge_left_child_twice() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 5
   max_int_fanout: 12
@@ -2987,86 +3022,87 @@ limits:
   max_leaf_fanout: 12
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 2
-    end: 15
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-                    2: 2.0
-                    3: 3.0
-                    4: 4.0
-          - key: 10
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-                    12: 12.0
-                    13: 13.0
-                    14: 14.0
-          - key: 20
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    20: 20.0
-                    21: 21.0
-                    22: 22.0
-                    23: 23.0
-                    24: 24.0
-          - key: 30
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    30: 30.0
-                    31: 31.0
-                    32: 32.0
-                    33: 33.0
-                    34: 34.0
-          - key: 40
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    40: 40.0
-                    41: 41.0
-                    42: 42.0
-                    43: 43.0
-                    44: 44.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 2
+      end: 15
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+                      3: 3.0
+                      4: 4.0
+            - key: 10
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+                      13: 13.0
+                      14: 14.0
+            - key: 20
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+                      23: 23.0
+                      24: 24.0
+            - key: 30
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      30: 30.0
+                      31: 31.0
+                      32: 32.0
+                      33: 33.0
+                      34: 34.0
+            - key: 40
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      40: 40.0
+                      41: 41.0
+                      42: 42.0
+                      43: 43.0
+                      44: 44.0
+  "#));
     let r = tree.clone().range_delete(12..23, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 5
   max_int_fanout: 12
@@ -3074,57 +3110,59 @@ limits:
   max_leaf_fanout: 12
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 2
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-                    2: 2.0
-                    3: 3.0
-                    4: 4.0
-          - key: 10
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-                    23: 23.0
-                    24: 24.0
-                    30: 30.0
-                    31: 31.0
-                    32: 32.0
-                    33: 33.0
-                    34: 34.0
-          - key: 40
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    40: 40.0
-                    41: 41.0
-                    42: 42.0
-                    43: 43.0
-                    44: 44.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 2
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+                      3: 3.0
+                      4: 4.0
+            - key: 10
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      23: 23.0
+                      24: 24.0
+                      30: 30.0
+                      31: 31.0
+                      32: 32.0
+                      33: 33.0
+                      34: 34.0
+            - key: 40
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      40: 40.0
+                      41: 41.0
+                      42: 42.0
+                      43: 43.0
+                      44: 44.0"#);
 }
 
 /// range_delete_pass1 results in two adjacent leaves with different parents
@@ -3136,7 +3174,6 @@ fn range_delete_merge_to_lca_twice() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 4
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -3144,200 +3181,201 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 10
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 10422
-            txgs:
-              start: 7
-              end: 10
-            ptr:
-              Addr: 1010422
-          - key: 10694
-            txgs:
-              start: 7
-              end: 9
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 10694
-                      txgs:
-                        start: 7
-                        end: 8
-                      ptr:
-                        Addr: 11632
-                    - key: 10710
-                      txgs:
-                        start: 7
-                        end: 9
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 10711
-                                txgs:
-                                  start: 7
-                                  end: 8
-                                ptr:
-                                  Addr: 11432
-                              - key: 10714
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        10714: 5916
-                                        11722: 3874
-                                        11725: 3877
-                              - key: 11730
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        10726: 5916
-                                        11727: 3874
-                                        11729: 3877
-                    - key: 11734
-                      txgs:
-                        start: 8
-                        end: 9
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 11734
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        10738: 5916
-                                        11739: 3874
-                                        11741: 3877
-                              - key: 11742
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        11742: 3927
-                                        11744: 3938
-                                        11781: 4342
-                              - key: 11782
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        11782: 4343
-                                        11784: 4345
-                                        11785: 4346
-                    - key: 11786
-                      txgs:
-                        start: 8
-                        end: 9
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 11786
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Addr: 7170
-                              - key: 11790
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Addr: 7171
-                              - key: 11794
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Addr: 7172
-                              - key: 11798
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Addr: 7173
-          - key: 11802
-            txgs:
-              start: 8
-              end: 10
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 11802
-                      txgs:
-                        start: 8
-                        end: 10
-                      ptr:
-                        Addr: 111802
-                    - key: 11865
-                      txgs:
-                        start: 8
-                        end: 9
-                      ptr:
-                        Addr: 7605
-                    - key: 11881
-                      txgs:
-                        start: 8
-                        end: 9
-                      ptr:
-                        Addr: 7606
-                    - key: 11897
-                      txgs:
-                        start: 8
-                        end: 9
-                      ptr:
-                        Addr: 7607
-                    - key: 12018
-                      txgs:
-                        start: 8
-                        end: 10
-                      ptr:
-                        Addr: 112018
-          - key: 12050
-            txgs:
-              start: 8
-              end: 9
-            ptr:
-              Addr: 7713
-          - key: 12114
-            txgs:
-              start: 8
-              end: 10
-            ptr:
-              Addr: 112144
-"#));
+  height: 4
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 10
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 10422
+              txgs:
+                start: 7
+                end: 10
+              ptr:
+                Addr: 1010422
+            - key: 10694
+              txgs:
+                start: 7
+                end: 9
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 10694
+                        txgs:
+                          start: 7
+                          end: 8
+                        ptr:
+                          Addr: 11632
+                      - key: 10710
+                        txgs:
+                          start: 7
+                          end: 9
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 10711
+                                  txgs:
+                                    start: 7
+                                    end: 8
+                                  ptr:
+                                    Addr: 11432
+                                - key: 10714
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          10714: 5916
+                                          11722: 3874
+                                          11725: 3877
+                                - key: 11730
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          10726: 5916
+                                          11727: 3874
+                                          11729: 3877
+                      - key: 11734
+                        txgs:
+                          start: 8
+                          end: 9
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 11734
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          10738: 5916
+                                          11739: 3874
+                                          11741: 3877
+                                - key: 11742
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          11742: 3927
+                                          11744: 3938
+                                          11781: 4342
+                                - key: 11782
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          11782: 4343
+                                          11784: 4345
+                                          11785: 4346
+                      - key: 11786
+                        txgs:
+                          start: 8
+                          end: 9
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 11786
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Addr: 7170
+                                - key: 11790
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Addr: 7171
+                                - key: 11794
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Addr: 7172
+                                - key: 11798
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Addr: 7173
+            - key: 11802
+              txgs:
+                start: 8
+                end: 10
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 11802
+                        txgs:
+                          start: 8
+                          end: 10
+                        ptr:
+                          Addr: 111802
+                      - key: 11865
+                        txgs:
+                          start: 8
+                          end: 9
+                        ptr:
+                          Addr: 7605
+                      - key: 11881
+                        txgs:
+                          start: 8
+                          end: 9
+                        ptr:
+                          Addr: 7606
+                      - key: 11897
+                        txgs:
+                          start: 8
+                          end: 9
+                        ptr:
+                          Addr: 7607
+                      - key: 12018
+                        txgs:
+                          start: 8
+                          end: 10
+                        ptr:
+                          Addr: 112018
+            - key: 12050
+              txgs:
+                start: 8
+                end: 9
+              ptr:
+                Addr: 7713
+            - key: 12114
+              txgs:
+                start: 8
+                end: 10
+              ptr:
+                Addr: 112144
+  "#));
     let r = tree.clone().range_delete(11264..11776, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 4
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -3345,143 +3383,145 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 10422
-            txgs:
-              start: 7
-              end: 10
-            ptr:
-              Addr: 1010422
-          - key: 10694
-            txgs:
-              start: 7
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 10694
-                      txgs:
-                        start: 7
-                        end: 8
-                      ptr:
-                        Addr: 11632
-                    - key: 10710
-                      txgs:
-                        start: 7
-                        end: 43
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 10711
-                                txgs:
-                                  start: 7
-                                  end: 8
-                                ptr:
-                                  Addr: 11432
-                              - key: 10714
-                                txgs:
-                                  start: 42
-                                  end: 43
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        10714: 5916
-                                        11781: 4342
-                                        11782: 4343
-                                        11784: 4345
-                                        11785: 4346
-                              - key: 11786
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Addr: 7170
-                    - key: 11790
-                      txgs:
-                        start: 8
-                        end: 43
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 11790
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Addr: 7171
-                              - key: 11794
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Addr: 7172
-                              - key: 11798
-                                txgs:
-                                  start: 8
-                                  end: 9
-                                ptr:
-                                  Addr: 7173
-                    - key: 11802
-                      txgs:
-                        start: 8
-                        end: 10
-                      ptr:
-                        Addr: 111802
-          - key: 11865
-            txgs:
-              start: 8
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 11865
-                      txgs:
-                        start: 8
-                        end: 9
-                      ptr:
-                        Addr: 7605
-                    - key: 11881
-                      txgs:
-                        start: 8
-                        end: 9
-                      ptr:
-                        Addr: 7606
-                    - key: 11897
-                      txgs:
-                        start: 8
-                        end: 9
-                      ptr:
-                        Addr: 7607
-                    - key: 12018
-                      txgs:
-                        start: 8
-                        end: 10
-                      ptr:
-                        Addr: 112018
-          - key: 12050
-            txgs:
-              start: 8
-              end: 9
-            ptr:
-              Addr: 7713
-          - key: 12114
-            txgs:
-              start: 8
-              end: 10
-            ptr:
-              Addr: 112144"#);
+  height: 4
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 10422
+              txgs:
+                start: 7
+                end: 10
+              ptr:
+                Addr: 1010422
+            - key: 10694
+              txgs:
+                start: 7
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 10694
+                        txgs:
+                          start: 7
+                          end: 8
+                        ptr:
+                          Addr: 11632
+                      - key: 10710
+                        txgs:
+                          start: 7
+                          end: 43
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 10711
+                                  txgs:
+                                    start: 7
+                                    end: 8
+                                  ptr:
+                                    Addr: 11432
+                                - key: 10714
+                                  txgs:
+                                    start: 42
+                                    end: 43
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          10714: 5916
+                                          11781: 4342
+                                          11782: 4343
+                                          11784: 4345
+                                          11785: 4346
+                                - key: 11786
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Addr: 7170
+                      - key: 11790
+                        txgs:
+                          start: 8
+                          end: 43
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 11790
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Addr: 7171
+                                - key: 11794
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Addr: 7172
+                                - key: 11798
+                                  txgs:
+                                    start: 8
+                                    end: 9
+                                  ptr:
+                                    Addr: 7173
+                      - key: 11802
+                        txgs:
+                          start: 8
+                          end: 10
+                        ptr:
+                          Addr: 111802
+            - key: 11865
+              txgs:
+                start: 8
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 11865
+                        txgs:
+                          start: 8
+                          end: 9
+                        ptr:
+                          Addr: 7605
+                      - key: 11881
+                        txgs:
+                          start: 8
+                          end: 9
+                        ptr:
+                          Addr: 7606
+                      - key: 11897
+                        txgs:
+                          start: 8
+                          end: 9
+                        ptr:
+                          Addr: 7607
+                      - key: 12018
+                        txgs:
+                          start: 8
+                          end: 10
+                        ptr:
+                          Addr: 112018
+            - key: 12050
+              txgs:
+                start: 8
+                end: 9
+              ptr:
+                Addr: 7713
+            - key: 12114
+              txgs:
+                start: 8
+                end: 10
+              ptr:
+                Addr: 112144"#);
 }
 
 /// Regression test for another bug similar to e6fd45d.  After pass1, Node
@@ -3494,7 +3534,6 @@ fn range_delete_merge_right_child_descending() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 4
   max_int_fanout: 10
@@ -3502,69 +3541,70 @@ limits:
   max_leaf_fanout: 10
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 2
-    end: 15
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 4898
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4903: 3431
-                    4993: 3521
-                    5045: 3573
-                    5583: 2277
-          - key: 5618
-            txgs:
-              start: 13
-              end: 14
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5618: 5459
-                    5623: 5464
-                    5624: 5465
-                    5625: 5466
-          - key: 5626
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5629: 5470
-                    5630: 5471
-                    5631: 5472
-                    5632: 7554
-          - key: 5634
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5635: 7557
-                    5637: 7559
-                    5638: 7560
-                    5642: 7564
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 2
+      end: 15
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 4898
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4903: 3431
+                      4993: 3521
+                      5045: 3573
+                      5583: 2277
+            - key: 5618
+              txgs:
+                start: 13
+                end: 14
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5618: 5459
+                      5623: 5464
+                      5624: 5465
+                      5625: 5466
+            - key: 5626
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5629: 5470
+                      5630: 5471
+                      5631: 5472
+                      5632: 7554
+            - key: 5634
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5635: 7557
+                      5637: 7559
+                      5638: 7560
+                      5642: 7564
+  "#));
     let r = tree.clone().range_delete(5120..5632, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 4
   max_int_fanout: 10
@@ -3572,38 +3612,40 @@ limits:
   max_leaf_fanout: 10
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 2
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 4898
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4903: 3431
-                    4993: 3521
-                    5045: 3573
-                    5632: 7554
-          - key: 5634
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5635: 7557
-                    5637: 7559
-                    5638: 7560
-                    5642: 7564"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 2
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 4898
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4903: 3431
+                      4993: 3521
+                      5045: 3573
+                      5632: 7554
+            - key: 5634
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5635: 7557
+                      5637: 7559
+                      5638: 7560
+                      5642: 7564"#);
 }
 
 /// Regression test for bug e6fd45d.  After range_delete_pass1, Node 2,7148 has
@@ -3617,7 +3659,6 @@ fn range_delete_merge_right_child_first() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 4
   max_int_fanout: 10
@@ -3625,126 +3666,127 @@ limits:
   max_leaf_fanout: 10
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 4
-    end: 15
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 7148
-            txgs:
-              start: 13
-              end: 15
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 7148
-                      txgs:
-                        start: 14
-                        end: 15
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              7153: 6699
-                              7156: 6702
-                              7164: 6710
-                              7173: 6719
-                    - key: 7252
-                      txgs:
-                        start: 13
-                        end: 1
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              7252: 6798
-                              7253: 6799
-                              7254: 6800
-                              7255: 6801
-                    - key: 7260
-                      txgs:
-                        start: 13
-                        end: 14
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              7260: 6806
-                              7265: 6811
-                              7266: 6812
-                              7267: 6813
-                    - key: 7268
-                      txgs:
-                        start: 14
-                        end: 15
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              7281: 6827
-                              7282: 6828
-                              7287: 6833
-                              7735: 5525
-          - key: 7736
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 7736
-                      txgs:
-                        start: 14
-                        end: 15
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              7736: 5527
-                              7737: 5538
-                              7738: 5540
-                              7739: 5543
-                    - key: 7744
-                      txgs:
-                        start: 14
-                        end: 15
-                      ptr:
-                        Addr: 1007744
-                    - key: 7752
-                      txgs:
-                        start: 14
-                        end: 15
-                      ptr:
-                        Addr: 1007752
-                    - key: 7760
-                      txgs:
-                        start: 14
-                        end: 15
-                      ptr:
-                        Addr: 1007760
-          - key: 7840
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Addr: 7693
-          - key: 8000
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Addr: 7692
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 4
+      end: 15
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 7148
+              txgs:
+                start: 13
+                end: 15
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 7148
+                        txgs:
+                          start: 14
+                          end: 15
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                7153: 6699
+                                7156: 6702
+                                7164: 6710
+                                7173: 6719
+                      - key: 7252
+                        txgs:
+                          start: 13
+                          end: 1
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                7252: 6798
+                                7253: 6799
+                                7254: 6800
+                                7255: 6801
+                      - key: 7260
+                        txgs:
+                          start: 13
+                          end: 14
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                7260: 6806
+                                7265: 6811
+                                7266: 6812
+                                7267: 6813
+                      - key: 7268
+                        txgs:
+                          start: 14
+                          end: 15
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                7281: 6827
+                                7282: 6828
+                                7287: 6833
+                                7735: 5525
+            - key: 7736
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 7736
+                        txgs:
+                          start: 14
+                          end: 15
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                7736: 5527
+                                7737: 5538
+                                7738: 5540
+                                7739: 5543
+                      - key: 7744
+                        txgs:
+                          start: 14
+                          end: 15
+                        ptr:
+                          Addr: 1007744
+                      - key: 7752
+                        txgs:
+                          start: 14
+                          end: 15
+                        ptr:
+                          Addr: 1007752
+                      - key: 7760
+                        txgs:
+                          start: 14
+                          end: 15
+                        ptr:
+                          Addr: 1007760
+            - key: 7840
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Addr: 7693
+            - key: 8000
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Addr: 7692
+  "#));
     tree.clone().range_delete(7168..7680, TxgT::from(42))
         .now_or_never().unwrap().unwrap();
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 4
   max_int_fanout: 10
@@ -3752,76 +3794,78 @@ limits:
   max_leaf_fanout: 10
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 4
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 7148
-            txgs:
-              start: 14
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 7148
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              7153: 6699
-                              7156: 6702
-                              7164: 6710
-                              7735: 5525
-                    - key: 7736
-                      txgs:
-                        start: 14
-                        end: 15
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              7736: 5527
-                              7737: 5538
-                              7738: 5540
-                              7739: 5543
-                    - key: 7744
-                      txgs:
-                        start: 14
-                        end: 15
-                      ptr:
-                        Addr: 1007744
-                    - key: 7752
-                      txgs:
-                        start: 14
-                        end: 15
-                      ptr:
-                        Addr: 1007752
-                    - key: 7760
-                      txgs:
-                        start: 14
-                        end: 15
-                      ptr:
-                        Addr: 1007760
-          - key: 7840
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Addr: 7693
-          - key: 8000
-            txgs:
-              start: 14
-              end: 15
-            ptr:
-              Addr: 7692"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 4
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 7148
+              txgs:
+                start: 14
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 7148
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                7153: 6699
+                                7156: 6702
+                                7164: 6710
+                                7735: 5525
+                      - key: 7736
+                        txgs:
+                          start: 14
+                          end: 15
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                7736: 5527
+                                7737: 5538
+                                7738: 5540
+                                7739: 5543
+                      - key: 7744
+                        txgs:
+                          start: 14
+                          end: 15
+                        ptr:
+                          Addr: 1007744
+                      - key: 7752
+                        txgs:
+                          start: 14
+                          end: 15
+                        ptr:
+                          Addr: 1007752
+                      - key: 7760
+                        txgs:
+                          start: 14
+                          end: 15
+                        ptr:
+                          Addr: 1007760
+            - key: 7840
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Addr: 7693
+            - key: 8000
+              txgs:
+                start: 14
+                end: 15
+              ptr:
+                Addr: 7692"#);
 }
 
 /// Delete a range that causes the root node to be merged down
@@ -3831,7 +3875,6 @@ fn range_delete_merge_root() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -3839,45 +3882,46 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-                    3: 3.0
-          - key: 4
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+                      3: 3.0
+            - key: 4
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+  "#));
     let r = tree.clone().range_delete(0..4, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -3885,19 +3929,21 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          4: 4.0
-          5: 5.0
-          6: 6.0
-          7: 7.0
-          8: 8.0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            4: 4.0
+            5: 5.0
+            6: 6.0
+            7: 7.0
+            8: 8.0"#);
 }
 
 /// Regression test for bug 40b01eb: Can't fix a node during range_delete_pass2
@@ -3910,7 +3956,6 @@ fn range_delete_merge_root_during_ascent() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -3918,144 +3963,145 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 2
-    end: 14
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 2762
-            txgs:
-              start: 12
-              end: 14
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 2778
-                      txgs:
-                        start: 12
-                        end: 13
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2778: 2859
-                              2781: 2868
-                              2782: 2869
-                    - key: 2788
-                      txgs:
-                        start: 13
-                        end: 14
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2965: 4758
-                              3027: 4820
-                              3074: 6186
-                    - key: 3077
-                      txgs:
-                        start: 13
-                        end: 14
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3081: 6193
-                              3085: 6197
-                              3088: 6200
-          - key: 3109
-            txgs:
-              start: 12
-              end: 14
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 3109
-                      txgs:
-                        start: 13
-                        end: 14
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3112: 6224
-                              3113: 6225
-                              3122: 6234
-                    - key: 3149
-                      txgs:
-                        start: 13
-                        end: 14
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3149: 6261
-                              3153: 6265
-                              3154: 6266
-                    - key: 3157
-                      txgs:
-                        start: 13
-                        end: 14
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3157: 6269
-                              3166: 6278
-                              3167: 6279
-          - key: 3365
-            txgs:
-              start: 13
-              end: 14
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 3509
-                      txgs:
-                        start: 13
-                        end: 14
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3509: 6621
-                              3531: 6643
-                              3532: 6644
-                    - key: 3541
-                      txgs:
-                        start: 13
-                        end: 14
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3546: 6658
-                              3547: 6659
-                              3572: 6684
-                    - key: 3573
-                      txgs:
-                        start: 13
-                        end: 14
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3581: 6693
-                              3584: 3091
-                              3585: 3092
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 2
+      end: 14
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 2762
+              txgs:
+                start: 12
+                end: 14
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 2778
+                        txgs:
+                          start: 12
+                          end: 13
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2778: 2859
+                                2781: 2868
+                                2782: 2869
+                      - key: 2788
+                        txgs:
+                          start: 13
+                          end: 14
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2965: 4758
+                                3027: 4820
+                                3074: 6186
+                      - key: 3077
+                        txgs:
+                          start: 13
+                          end: 14
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3081: 6193
+                                3085: 6197
+                                3088: 6200
+            - key: 3109
+              txgs:
+                start: 12
+                end: 14
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 3109
+                        txgs:
+                          start: 13
+                          end: 14
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3112: 6224
+                                3113: 6225
+                                3122: 6234
+                      - key: 3149
+                        txgs:
+                          start: 13
+                          end: 14
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3149: 6261
+                                3153: 6265
+                                3154: 6266
+                      - key: 3157
+                        txgs:
+                          start: 13
+                          end: 14
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3157: 6269
+                                3166: 6278
+                                3167: 6279
+            - key: 3365
+              txgs:
+                start: 13
+                end: 14
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 3509
+                        txgs:
+                          start: 13
+                          end: 14
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3509: 6621
+                                3531: 6643
+                                3532: 6644
+                      - key: 3541
+                        txgs:
+                          start: 13
+                          end: 14
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3546: 6658
+                                3547: 6659
+                                3572: 6684
+                      - key: 3573
+                        txgs:
+                          start: 13
+                          end: 14
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3581: 6693
+                                3584: 3091
+                                3585: 3092
+  "#));
     let r = tree.clone().range_delete(3072..3584, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -4063,37 +4109,39 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 12
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 2778
-            txgs:
-              start: 12
-              end: 13
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    2778: 2859
-                    2781: 2868
-                    2782: 2869
-          - key: 2788
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    2965: 4758
-                    3027: 4820
-                    3584: 3091
-                    3585: 3092"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 12
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 2778
+              txgs:
+                start: 12
+                end: 13
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      2778: 2859
+                      2781: 2868
+                      2782: 2869
+            - key: 2788
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      2965: 4758
+                      3027: 4820
+                      3584: 3091
+                      3585: 3092"#);
 }
 
 /// Delete a range that causes the root node to be merged two steps down
@@ -4103,7 +4151,6 @@ fn range_delete_merge_root_twice() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -4111,85 +4158,86 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              2: 2.0
-                              3: 3.0
-                    - key: 4
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4: 4.0
-                              5: 5.0
-                              6: 6.0
-                              7: 7.0
-                              8: 8.0
-          - key: 10
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 10
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              10: 10.0
-                              11: 11.0
-                              12: 12.0
-                    - key: 13
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              13: 13.0
-                              14: 14.0
-                              15: 15.0
-                              16: 16.0
-                              17: 17.0
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                2: 2.0
+                                3: 3.0
+                      - key: 4
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4: 4.0
+                                5: 5.0
+                                6: 6.0
+                                7: 7.0
+                                8: 8.0
+            - key: 10
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 10
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                10: 10.0
+                                11: 11.0
+                                12: 12.0
+                      - key: 13
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                13: 13.0
+                                14: 14.0
+                                15: 15.0
+                                16: 16.0
+                                17: 17.0
+  "#));
     let r = tree.clone().range_delete(0..13, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -4197,19 +4245,21 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          13: 13.0
-          14: 14.0
-          15: 15.0
-          16: 16.0
-          17: 17.0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            13: 13.0
+            14: 14.0
+            15: 15.0
+            16: 16.0
+            17: 17.0"#);
 }
 
 // After the descent phase of range_delete_pass2_r, there is an underflowing
@@ -4221,7 +4271,6 @@ fn range_delete_parent_and_child_underflow_after_descent() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 4
 limits:
   min_int_fanout: 4
   max_int_fanout: 17
@@ -4229,212 +4278,213 @@ limits:
   max_leaf_fanout: 17
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 11
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 11
-            ptr:
-              Addr: 1000000
-          - key: 2218
-            txgs:
-              start: 5
-              end: 11
-            ptr:
-              Addr: 1002218
-          - key: 3563
-            txgs:
-              start: 8
-              end: 11
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 3563
-                      txgs:
-                        start: 9
-                        end: 11
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 3563
-                                txgs:
-                                  start: 9
-                                  end: 10
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        3563: 2604
-                                        3564: 2605
-                                        3565: 2606
-                                        3566: 2607
-                              - key: 3611
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        3613: 3005
-                                        3621: 3013
-                                        3624: 3016
-                                        3625: 3017
-                              - key: 3627
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        3627: 3019
-                                        3640: 3032
-                                        3641: 3033
-                                        3642: 3034
-                              - key: 3643
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        3643: 3035
-                                        3664: 3056
-                                        3665: 3057
-                                        3666: 3058
-                    - key: 4051
-                      txgs:
-                        start: 8
-                        end: 11
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 4075
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        4075: 3467
-                                        4076: 3468
-                                        4077: 3469
-                                        4078: 3470
-                              - key: 4083
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        4083: 3475
-                                        4084: 3476
-                                        4085: 3477
-                                        4086: 3478
-                              - key: 4091
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        4091: 3483
-                                        4092: 3484
-                                        4093: 3485
-                                        4094: 3486
-                                        4095: 3487
-                              - key: 4604
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        4609: 3745
-                                        4610: 3746
-                                        4614: 3750
-                                        4615: 3751
-          - key: 4620
-            txgs:
-              start: 9
-              end: 11
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4620
-                      txgs:
-                        start: 9
-                        end: 11
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 4620
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Addr: 1004620
-                              - key: 4628
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Addr: 1004628
-                              - key: 4636
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Addr: 1004636
-                              - key: 4644
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Addr: 1004644
-                    - key: 4684
-                      txgs:
-                        start: 9
-                        end: 11
-                      ptr:
-                        Addr: 1004684
-                    - key: 4748
-                      txgs:
-                        start: 9
-                        end: 11
-                      ptr:
-                        Addr: 1004748
-                    - key: 5119
-                      txgs:
-                        start: 9
-                        end: 11
-                      ptr:
-                        Addr: 1005119
-"#));
+  height: 4
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 11
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 11
+              ptr:
+                Addr: 1000000
+            - key: 2218
+              txgs:
+                start: 5
+                end: 11
+              ptr:
+                Addr: 1002218
+            - key: 3563
+              txgs:
+                start: 8
+                end: 11
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 3563
+                        txgs:
+                          start: 9
+                          end: 11
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 3563
+                                  txgs:
+                                    start: 9
+                                    end: 10
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          3563: 2604
+                                          3564: 2605
+                                          3565: 2606
+                                          3566: 2607
+                                - key: 3611
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          3613: 3005
+                                          3621: 3013
+                                          3624: 3016
+                                          3625: 3017
+                                - key: 3627
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          3627: 3019
+                                          3640: 3032
+                                          3641: 3033
+                                          3642: 3034
+                                - key: 3643
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          3643: 3035
+                                          3664: 3056
+                                          3665: 3057
+                                          3666: 3058
+                      - key: 4051
+                        txgs:
+                          start: 8
+                          end: 11
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 4075
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          4075: 3467
+                                          4076: 3468
+                                          4077: 3469
+                                          4078: 3470
+                                - key: 4083
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          4083: 3475
+                                          4084: 3476
+                                          4085: 3477
+                                          4086: 3478
+                                - key: 4091
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          4091: 3483
+                                          4092: 3484
+                                          4093: 3485
+                                          4094: 3486
+                                          4095: 3487
+                                - key: 4604
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          4609: 3745
+                                          4610: 3746
+                                          4614: 3750
+                                          4615: 3751
+            - key: 4620
+              txgs:
+                start: 9
+                end: 11
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4620
+                        txgs:
+                          start: 9
+                          end: 11
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 4620
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Addr: 1004620
+                                - key: 4628
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Addr: 1004628
+                                - key: 4636
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Addr: 1004636
+                                - key: 4644
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Addr: 1004644
+                      - key: 4684
+                        txgs:
+                          start: 9
+                          end: 11
+                        ptr:
+                          Addr: 1004684
+                      - key: 4748
+                        txgs:
+                          start: 9
+                          end: 11
+                        ptr:
+                          Addr: 1004748
+                      - key: 5119
+                        txgs:
+                          start: 9
+                          end: 11
+                        ptr:
+                          Addr: 1005119
+  "#));
     let r = tree.clone().range_delete(3584..4096, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 4
 limits:
   min_int_fanout: 4
   max_int_fanout: 17
@@ -4442,108 +4492,110 @@ limits:
   max_leaf_fanout: 17
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 11
-            ptr:
-              Addr: 1000000
-          - key: 2218
-            txgs:
-              start: 5
-              end: 11
-            ptr:
-              Addr: 1002218
-          - key: 3563
-            txgs:
-              start: 8
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 3563
-                      txgs:
-                        start: 10
-                        end: 43
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 3563
-                                txgs:
-                                  start: 42
-                                  end: 43
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        3563: 2604
-                                        3564: 2605
-                                        3565: 2606
-                                        3566: 2607
-                              - key: 4604
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        4609: 3745
-                                        4610: 3746
-                                        4614: 3750
-                                        4615: 3751
-                              - key: 4620
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Addr: 1004620
-                              - key: 4628
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Addr: 1004628
-                              - key: 4636
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Addr: 1004636
-                              - key: 4644
-                                txgs:
-                                  start: 10
-                                  end: 11
-                                ptr:
-                                  Addr: 1004644
-                    - key: 4684
-                      txgs:
-                        start: 9
-                        end: 11
-                      ptr:
-                        Addr: 1004684
-                    - key: 4748
-                      txgs:
-                        start: 9
-                        end: 11
-                      ptr:
-                        Addr: 1004748
-                    - key: 5119
-                      txgs:
-                        start: 9
-                        end: 11
-                      ptr:
-                        Addr: 1005119"#);
+  height: 4
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 11
+              ptr:
+                Addr: 1000000
+            - key: 2218
+              txgs:
+                start: 5
+                end: 11
+              ptr:
+                Addr: 1002218
+            - key: 3563
+              txgs:
+                start: 8
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 3563
+                        txgs:
+                          start: 10
+                          end: 43
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 3563
+                                  txgs:
+                                    start: 42
+                                    end: 43
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          3563: 2604
+                                          3564: 2605
+                                          3565: 2606
+                                          3566: 2607
+                                - key: 4604
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          4609: 3745
+                                          4610: 3746
+                                          4614: 3750
+                                          4615: 3751
+                                - key: 4620
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Addr: 1004620
+                                - key: 4628
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Addr: 1004628
+                                - key: 4636
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Addr: 1004636
+                                - key: 4644
+                                  txgs:
+                                    start: 10
+                                    end: 11
+                                  ptr:
+                                    Addr: 1004644
+                      - key: 4684
+                        txgs:
+                          start: 9
+                          end: 11
+                        ptr:
+                          Addr: 1004684
+                      - key: 4748
+                        txgs:
+                          start: 9
+                          end: 11
+                        ptr:
+                          Addr: 1004748
+                      - key: 5119
+                        txgs:
+                          start: 9
+                          end: 11
+                        ptr:
+                          Addr: 1005119"#);
 }
 
 // After pass1, there are two sibling nodes that can't be fixed so that each of
@@ -4555,7 +4607,6 @@ fn range_delete_cant_fix_for_minfanout_plus_two() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -4563,97 +4614,98 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003623
-          - key: 3889
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003889
-          - key: 4145
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4160
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004160
-                    - key: 4194
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4193: 4193.0
-                              4195: 4195.0
-          - key: 4599
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4600
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4601: 4601.0
-                              4608: 4608.0
-                    - key: 4609
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4610: 4610.0
-                              4612: 4612.0
-                    - key: 4617
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004617
-                    - key: 4627
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004627
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003623
+            - key: 3889
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003889
+            - key: 4145
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4160
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004160
+                      - key: 4194
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4193: 4193.0
+                                4195: 4195.0
+            - key: 4599
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4600
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4601: 4601.0
+                                4608: 4608.0
+                      - key: 4609
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4610: 4610.0
+                                4612: 4612.0
+                      - key: 4617
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004617
+                      - key: 4627
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004627
+  "#));
     let r = tree.clone().range_delete(4480..4600, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -4661,90 +4713,92 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003623
-          - key: 3889
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003889
-          - key: 4145
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4160
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004160
-                    - key: 4194
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4193: 4193.0
-                              4195: 4195.0
-          - key: 4599
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4600
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4601: 4601.0
-                              4608: 4608.0
-                    - key: 4609
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4610: 4610.0
-                              4612: 4612.0
-                    - key: 4617
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004617
-                    - key: 4627
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004627"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003623
+            - key: 3889
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003889
+            - key: 4145
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4160
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004160
+                      - key: 4194
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4193: 4193.0
+                                4195: 4195.0
+            - key: 4599
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4600
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4601: 4601.0
+                                4608: 4608.0
+                      - key: 4609
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4610: 4610.0
+                                4612: 4612.0
+                      - key: 4617
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004617
+                      - key: 4627
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004627"#);
 }
 
 #[test]
@@ -4753,7 +4807,6 @@ fn range_delete_cant_steal_to_fix_lca() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -4761,105 +4814,106 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 1
-    end: 2
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 1
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 1000001
-                    - key: 10
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              10: 10.0
-                              11: 11.0
-                              12: 12.0
-                    - key: 20
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                              22: 22.0
-                    - key: 30
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              30: 30.0
-                              31: 31.0
-                              32: 32.0
-          - key: 40
-            txgs:
-              start: 1
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 40
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              40: 40.0
-                              41: 41.0
-                              42: 42.0
-                    - key: 50
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 1000050
-                    - key: 60
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 1000060
-                    - key: 70
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 1000070
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 1
+      end: 2
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 1
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 1000001
+                      - key: 10
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                10: 10.0
+                                11: 11.0
+                                12: 12.0
+                      - key: 20
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                                22: 22.0
+                      - key: 30
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                30: 30.0
+                                31: 31.0
+                                32: 32.0
+            - key: 40
+              txgs:
+                start: 1
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 40
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                40: 40.0
+                                41: 41.0
+                                42: 42.0
+                      - key: 50
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 1000050
+                      - key: 60
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 1000060
+                      - key: 70
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 1000070
+  "#));
     let r = tree.clone().range_delete(21..32, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -4867,78 +4921,80 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 1
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 1
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 1000001
-                    - key: 10
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              10: 10.0
-                              11: 11.0
-                              12: 12.0
-                    - key: 20
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              32: 32.0
-                              40: 40.0
-                              41: 41.0
-                              42: 42.0
-          - key: 50
-            txgs:
-              start: 1
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 50
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 1000050
-                    - key: 60
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 1000060
-                    - key: 70
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 1000070"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 1
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 1
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 1000001
+                      - key: 10
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                10: 10.0
+                                11: 11.0
+                                12: 12.0
+                      - key: 20
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                32: 32.0
+                                40: 40.0
+                                41: 41.0
+                                42: 42.0
+            - key: 50
+              txgs:
+                start: 1
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 50
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 1000050
+                      - key: 60
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 1000060
+                      - key: 70
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 1000070"#);
 }
 
 // Delete a range that's contained within a single LeafNode
@@ -4948,7 +5004,6 @@ fn range_delete_single_node() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -4956,55 +5011,56 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-          - key: 4
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0
-          - key: 10
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-                    12: 12.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+            - key: 4
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+            - key: 10
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+  "#));
     let r = tree.clone().range_delete(5..7, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5012,46 +5068,48 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-          - key: 4
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    7: 7.0
-                    8: 8.0
-          - key: 10
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-                    12: 12.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+            - key: 4
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      7: 7.0
+                      8: 8.0
+            - key: 10
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0"#);
 }
 
 /// At 375e9ad5c6f01b09b87d12f2d01a68b3c5dfd58b, this test will cause a node to
@@ -5063,7 +5121,6 @@ fn range_delete_underflow_and_steal_left() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5071,110 +5128,111 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003623
-          - key: 3889
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003889
-          - key: 4145
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4193
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4193: 4193.0
-                              4195: 4195.0
-                    - key: 4457
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4565: 4565.0
-                              4567: 4567.0
-          - key: 4599
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4600
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4601: 4601.0
-                              4605: 4605.0
-                              4606: 4606.0
-                              4607: 4607.0
-                              4608: 4608.0
-                    - key: 4609
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4610: 4610.0
-                              4612: 4612.0
-                    - key: 4617
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004617
-                    - key: 4627
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004627
-                    - key: 4637
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004637
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003623
+            - key: 3889
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003889
+            - key: 4145
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4193
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4193: 4193.0
+                                4195: 4195.0
+                      - key: 4457
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4565: 4565.0
+                                4567: 4567.0
+            - key: 4599
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4600
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4601: 4601.0
+                                4605: 4605.0
+                                4606: 4606.0
+                                4607: 4607.0
+                                4608: 4608.0
+                      - key: 4609
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4610: 4610.0
+                                4612: 4612.0
+                      - key: 4617
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004617
+                      - key: 4627
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004627
+                      - key: 4637
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004637
+  "#));
     let r = tree.clone().range_delete(4480..4605, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5182,92 +5240,94 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003623
-          - key: 3889
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003889
-          - key: 4145
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4193
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4193: 4193.0
-                              4195: 4195.0
-                    - key: 4600
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4605: 4605.0
-                              4606: 4606.0
-                              4607: 4607.0
-                              4608: 4608.0
-                    - key: 4609
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4610: 4610.0
-                              4612: 4612.0
-                    - key: 4617
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004617
-          - key: 4627
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4627
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004627
-                    - key: 4637
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004637"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003623
+            - key: 3889
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003889
+            - key: 4145
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4193
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4193: 4193.0
+                                4195: 4195.0
+                      - key: 4600
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4605: 4605.0
+                                4606: 4606.0
+                                4607: 4607.0
+                                4608: 4608.0
+                      - key: 4609
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4610: 4610.0
+                                4612: 4612.0
+                      - key: 4617
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004617
+            - key: 4627
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4627
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004627
+                      - key: 4637
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004637"#);
 }
 
 // Delete a range that includes a whole Node at the end of the Tree
@@ -5277,7 +5337,6 @@ fn range_delete_to_end() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5285,53 +5344,54 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-          - key: 4
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-          - key: 10
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+            - key: 4
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+            - key: 10
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+  "#));
     let r = tree.clone().range_delete(7..20, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5339,35 +5399,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-          - key: 4
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+            - key: 4
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0"#);
 }
 
 // Delete a range that passes the right side of an int node, with another
@@ -5378,7 +5440,6 @@ fn range_delete_to_end_of_int_node() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5386,121 +5447,123 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              2: 2.0
-                    - key: 4
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4: 4.0
-                              5: 5.0
-                              6: 6.0
-                    - key: 7
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              7: 7.0
-                              8: 8.0
-                    - key: 10
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              10: 10.0
-                              11: 11.0
-          - key: 15
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 20
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                              22: 22.0
-                    - key: 24
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              24: 24.0
-                              26: 26.0
-          - key: 30
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 30
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              30: 30.0
-                              31: 31.0
-                    - key: 40
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              40: 40.0
-                              41: 41.0
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                2: 2.0
+                      - key: 4
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4: 4.0
+                                5: 5.0
+                                6: 6.0
+                      - key: 7
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                7: 7.0
+                                8: 8.0
+                      - key: 10
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                10: 10.0
+                                11: 11.0
+            - key: 15
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 20
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                                22: 22.0
+                      - key: 24
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                24: 24.0
+                                26: 26.0
+            - key: 30
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 30
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                30: 30.0
+                                31: 31.0
+                      - key: 40
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                40: 40.0
+                                41: 41.0
+  "#));
     let r = tree.clone().range_delete(10..16, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
@@ -5509,7 +5572,6 @@ root:
     // pass is done, the 2nd pass can't tell that that node wasn't modified.
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5517,110 +5579,112 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              2: 2.0
-                    - key: 4
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4: 4.0
-                              5: 5.0
-                              6: 6.0
-                    - key: 7
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              7: 7.0
-                              8: 8.0
-          - key: 15
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 20
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                              22: 22.0
-                    - key: 24
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              24: 24.0
-                              26: 26.0
-          - key: 30
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 30
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              30: 30.0
-                              31: 31.0
-                    - key: 40
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              40: 40.0
-                              41: 41.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                2: 2.0
+                      - key: 4
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4: 4.0
+                                5: 5.0
+                                6: 6.0
+                      - key: 7
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                7: 7.0
+                                8: 8.0
+            - key: 15
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 20
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                                22: 22.0
+                      - key: 24
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                24: 24.0
+                                26: 26.0
+            - key: 30
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 30
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                30: 30.0
+                                31: 31.0
+                      - key: 40
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                40: 40.0
+                                41: 41.0"#);
 }
 
 // Delete a range that includes only whole nodes
@@ -5630,7 +5694,6 @@ fn range_delete_whole_nodes() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5638,58 +5701,60 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-                    3: 3.0
-          - key: 4
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-          - key: 10
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-          - key: 20
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    20: 20.0
-                    21: 21.0
-                    22: 22.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+                      3: 3.0
+            - key: 4
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+            - key: 10
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+            - key: 20
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+  "#));
     let r = tree.clone().range_delete(4..20, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
@@ -5698,7 +5763,6 @@ root:
     // done, the 2nd pass can't tell that that node wasn't modified.
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5706,36 +5770,38 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    1: 1.0
-                    2: 2.0
-                    3: 3.0
-          - key: 20
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    20: 20.0
-                    21: 21.0
-                    22: 22.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      1: 1.0
+                      2: 2.0
+                      3: 3.0
+            - key: 20
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0"#);
 }
 
 // Delete a range of just a single whole node whose parent key isn't normalized
@@ -5745,7 +5811,6 @@ fn range_delete_whole_node_denormalized() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5753,83 +5818,84 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003623
-          - key: 3889
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003889
-          - key: 4145
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4193
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004193
-                    - key: 4457
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004457
-          - key: 4599
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4600
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004600
-                    - key: 4609
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              4610: 4610.0
-                              4612: 4612.0
-                    - key: 4617
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004617
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003623
+            - key: 3889
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003889
+            - key: 4145
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4193
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004193
+                      - key: 4457
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004457
+            - key: 4599
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4600
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004600
+                      - key: 4609
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                4610: 4610.0
+                                4612: 4612.0
+                      - key: 4617
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004617
+  "#));
     let r = tree.clone().range_delete(4610..4613, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5837,58 +5903,60 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003623
-          - key: 3889
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 1003889
-          - key: 4145
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 4193
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004193
-                    - key: 4457
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004457
-                    - key: 4600
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004600
-                    - key: 4617
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1004617"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003623
+            - key: 3889
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 1003889
+            - key: 4145
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 4193
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004193
+                      - key: 4457
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004457
+                      - key: 4600
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004600
+                      - key: 4617
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1004617"#);
 }
 
 // range_delete_pass2 needs to steal 2 nodes in order to guarantee invariants.
@@ -5901,7 +5969,6 @@ fn range_delete_pass2_steal_creates_an_lca() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 5
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -5909,391 +5976,392 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 1
-    end: 6
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 2599
-            txgs:
-              start: 2
-              end: 6
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 3634
-                      txgs:
-                        start: 3
-                        end: 6
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 3634
-                                txgs:
-                                  start: 3
-                                  end: 6
-                                ptr:
-                                  Addr: 103634
-                              - key: 3682
-                                txgs:
-                                  start: 3
-                                  end: 6
-                                ptr:
-                                  Mem:
-                                    Int:
-                                      children:
-                                        - key: 3682
-                                          txgs:
-                                            start: 3
-                                            end: 4
-                                          ptr:
-                                            Addr: 4494
-                                        - key: 3686
-                                          txgs:
-                                            start: 3
-                                            end: 4
-                                          ptr:
-                                            Addr: 4495
-                                        - key: 3690
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 7382
-                                        - key: 3698
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 7384
-                              - key: 3706
-                                txgs:
-                                  start: 4
-                                  end: 6
-                                ptr:
-                                  Mem:
-                                    Int:
-                                      children:
-                                        - key: 3706
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  3706: 3060
-                                                  3704: 3061
-                                                  3711: 3065
-                                        - key: 4774
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  4774: 3069
-                                                  4775: 3070
-                                                  4776: 3071
-                                        - key: 4778
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  4778: 3073
-                                                  4780: 3075
-                                                  4781: 3076
-                                                  4785: 3080
-                                                  4786: 3081
-                                                  4789: 3084
-                              - key: 4790
-                                txgs:
-                                  start: 5
-                                  end: 6
-                                ptr:
-                                  Mem:
-                                    Int:
-                                      children:
-                                        - key: 4790
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  4791: 3086
-                                                  4792: 3087
-                                                  4793: 3088
-                                        - key: 4794
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  4794: 3089
-                                                  4795: 3090
-                                                  4796: 3091
-                                                  4801: 3096
-                                        - key: 4802
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  4802: 3097
-                                                  4804: 3099
-                                                  4805: 3100
-                                        - key: 4806
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  4806: 3101
-                                                  4808: 3103
-                                                  4812: 3107
-                                                  4815: 3110
-                                        - key: 4818
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  4818: 3113
-                                                  4820: 3115
-                                                  4832: 3127
-                                                  4834: 3129
-                                                  4835: 3130
-                                                  4836: 3131
-                                        - key: 4838
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  4838: 3133
-                                                  4839: 3134
-                                                  4845: 3140
-                                                  4846: 3141
-                                                  4847: 3142
-                    - key: 4850
-                      txgs:
-                        start: 4
-                        end: 6
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 4850
-                                txgs:
-                                  start: 4
-                                  end: 6
-                                ptr:
-                                  Mem:
-                                    Int:
-                                      children:
-                                        - key: 4850
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 104850
-                                        - key: 4865
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 104865
-                                        - key: 4878
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 104878
-                              - key: 5035
-                                txgs:
-                                  start: 5
-                                  end: 6
-                                ptr:
-                                  Mem:
-                                    Int:
-                                      children:
-                                        - key: 5035
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 105035
-                                        - key: 5058
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 105058
-                                        - key: 5062
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 105062
-                              - key: 5070
-                                txgs:
-                                  start: 5
-                                  end: 6
-                                ptr:
-                                  Mem:
-                                    Int:
-                                      children:
-                                        - key: 5070
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 105070
-                                        - key: 5090
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 105090
-                                        - key: 5100
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 105100
-                    - key: 5106
-                      txgs:
-                        start: 4
-                        end: 6
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 5106
-                                txgs:
-                                  start: 4
-                                  end: 6
-                                ptr:
-                                  Mem:
-                                    Int:
-                                      children:
-                                        - key: 5106
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  5107: 3402
-                                                  5112: 3407
-                                                  5113: 3408
-                                        - key: 5114
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  5115: 3410
-                                                  5119: 3414
-                                                  5120: 3415
-                                        - key: 5122
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Mem:
-                                              Leaf:
-                                                items:
-                                                  5122: 3417
-                                                  5123: 3418
-                                                  5137: 3432
-                              - key: 5138
-                                txgs:
-                                  start: 4
-                                  end: 6
-                                ptr:
-                                  Mem:
-                                    Int:
-                                      children:
-                                        - key: 5138
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 1005138
-                                        - key: 5146
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 1005146
-                                        - key: 5162
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 1005162
-                                        - key: 5166
-                                          txgs:
-                                            start: 5
-                                            end: 6
-                                          ptr:
-                                            Addr: 1005166
-                              - key: 5182
-                                txgs:
-                                  start: 4
-                                  end: 6
-                                ptr:
-                                  Addr: 105182
-                              - key: 5202
-                                txgs:
-                                  start: 5
-                                  end: 6
-                                ptr:
-                                  Addr: 105202
-                              - key: 5298
-                                txgs:
-                                  start: 4
-                                  end: 6
-                                ptr:
-                                  Addr: 105298
-                              - key: 5330
-                                txgs:
-                                  start: 4
-                                  end: 6
-                                ptr:
-                                  Addr: 105330
-"#));
+  height: 5
+  elem:
+    key: 0
+    txgs:
+      start: 1
+      end: 6
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 2599
+              txgs:
+                start: 2
+                end: 6
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 3634
+                        txgs:
+                          start: 3
+                          end: 6
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 3634
+                                  txgs:
+                                    start: 3
+                                    end: 6
+                                  ptr:
+                                    Addr: 103634
+                                - key: 3682
+                                  txgs:
+                                    start: 3
+                                    end: 6
+                                  ptr:
+                                    Mem:
+                                      Int:
+                                        children:
+                                          - key: 3682
+                                            txgs:
+                                              start: 3
+                                              end: 4
+                                            ptr:
+                                              Addr: 4494
+                                          - key: 3686
+                                            txgs:
+                                              start: 3
+                                              end: 4
+                                            ptr:
+                                              Addr: 4495
+                                          - key: 3690
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 7382
+                                          - key: 3698
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 7384
+                                - key: 3706
+                                  txgs:
+                                    start: 4
+                                    end: 6
+                                  ptr:
+                                    Mem:
+                                      Int:
+                                        children:
+                                          - key: 3706
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    3706: 3060
+                                                    3704: 3061
+                                                    3711: 3065
+                                          - key: 4774
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    4774: 3069
+                                                    4775: 3070
+                                                    4776: 3071
+                                          - key: 4778
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    4778: 3073
+                                                    4780: 3075
+                                                    4781: 3076
+                                                    4785: 3080
+                                                    4786: 3081
+                                                    4789: 3084
+                                - key: 4790
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr:
+                                    Mem:
+                                      Int:
+                                        children:
+                                          - key: 4790
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    4791: 3086
+                                                    4792: 3087
+                                                    4793: 3088
+                                          - key: 4794
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    4794: 3089
+                                                    4795: 3090
+                                                    4796: 3091
+                                                    4801: 3096
+                                          - key: 4802
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    4802: 3097
+                                                    4804: 3099
+                                                    4805: 3100
+                                          - key: 4806
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    4806: 3101
+                                                    4808: 3103
+                                                    4812: 3107
+                                                    4815: 3110
+                                          - key: 4818
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    4818: 3113
+                                                    4820: 3115
+                                                    4832: 3127
+                                                    4834: 3129
+                                                    4835: 3130
+                                                    4836: 3131
+                                          - key: 4838
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    4838: 3133
+                                                    4839: 3134
+                                                    4845: 3140
+                                                    4846: 3141
+                                                    4847: 3142
+                      - key: 4850
+                        txgs:
+                          start: 4
+                          end: 6
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 4850
+                                  txgs:
+                                    start: 4
+                                    end: 6
+                                  ptr:
+                                    Mem:
+                                      Int:
+                                        children:
+                                          - key: 4850
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 104850
+                                          - key: 4865
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 104865
+                                          - key: 4878
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 104878
+                                - key: 5035
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr:
+                                    Mem:
+                                      Int:
+                                        children:
+                                          - key: 5035
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 105035
+                                          - key: 5058
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 105058
+                                          - key: 5062
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 105062
+                                - key: 5070
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr:
+                                    Mem:
+                                      Int:
+                                        children:
+                                          - key: 5070
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 105070
+                                          - key: 5090
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 105090
+                                          - key: 5100
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 105100
+                      - key: 5106
+                        txgs:
+                          start: 4
+                          end: 6
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 5106
+                                  txgs:
+                                    start: 4
+                                    end: 6
+                                  ptr:
+                                    Mem:
+                                      Int:
+                                        children:
+                                          - key: 5106
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    5107: 3402
+                                                    5112: 3407
+                                                    5113: 3408
+                                          - key: 5114
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    5115: 3410
+                                                    5119: 3414
+                                                    5120: 3415
+                                          - key: 5122
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Mem:
+                                                Leaf:
+                                                  items:
+                                                    5122: 3417
+                                                    5123: 3418
+                                                    5137: 3432
+                                - key: 5138
+                                  txgs:
+                                    start: 4
+                                    end: 6
+                                  ptr:
+                                    Mem:
+                                      Int:
+                                        children:
+                                          - key: 5138
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 1005138
+                                          - key: 5146
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 1005146
+                                          - key: 5162
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 1005162
+                                          - key: 5166
+                                            txgs:
+                                              start: 5
+                                              end: 6
+                                            ptr:
+                                              Addr: 1005166
+                                - key: 5182
+                                  txgs:
+                                    start: 4
+                                    end: 6
+                                  ptr:
+                                    Addr: 105182
+                                - key: 5202
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr:
+                                    Addr: 105202
+                                - key: 5298
+                                  txgs:
+                                    start: 4
+                                    end: 6
+                                  ptr:
+                                    Addr: 105298
+                                - key: 5330
+                                  txgs:
+                                    start: 4
+                                    end: 6
+                                  ptr:
+                                    Addr: 105330
+  "#));
     let r = tree.clone().range_delete(4608..5120, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 4
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -6301,147 +6369,149 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 2
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 3634
-            txgs:
-              start: 3
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 3634
-                      txgs:
-                        start: 3
-                        end: 6
-                      ptr:
-                        Addr: 103634
-                    - key: 3682
-                      txgs:
-                        start: 3
-                        end: 6
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 3682
-                                txgs:
-                                  start: 3
-                                  end: 4
-                                ptr:
-                                  Addr: 4494
-                              - key: 3686
-                                txgs:
-                                  start: 3
-                                  end: 4
-                                ptr:
-                                  Addr: 4495
-                              - key: 3690
-                                txgs:
-                                  start: 5
-                                  end: 6
-                                ptr:
-                                  Addr: 7382
-                              - key: 3698
-                                txgs:
-                                  start: 5
-                                  end: 6
-                                ptr:
-                                  Addr: 7384
-                    - key: 3706
-                      txgs:
-                        start: 5
-                        end: 43
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 3706
-                                txgs:
-                                  start: 42
-                                  end: 43
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        3704: 3061
-                                        3706: 3060
-                                        3711: 3065
-                              - key: 5114
-                                txgs:
-                                  start: 42
-                                  end: 43
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        5120: 3415
-                                        5122: 3417
-                                        5123: 3418
-                                        5137: 3432
-                              - key: 5138
-                                txgs:
-                                  start: 5
-                                  end: 6
-                                ptr:
-                                  Addr: 1005138
-                              - key: 5146
-                                txgs:
-                                  start: 5
-                                  end: 6
-                                ptr:
-                                  Addr: 1005146
-                              - key: 5162
-                                txgs:
-                                  start: 5
-                                  end: 6
-                                ptr:
-                                  Addr: 1005162
-                              - key: 5166
-                                txgs:
-                                  start: 5
-                                  end: 6
-                                ptr:
-                                  Addr: 1005166
-          - key: 5182
-            txgs:
-              start: 4
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 5182
-                      txgs:
-                        start: 4
-                        end: 6
-                      ptr:
-                        Addr: 105182
-                    - key: 5202
-                      txgs:
-                        start: 5
-                        end: 6
-                      ptr:
-                        Addr: 105202
-                    - key: 5298
-                      txgs:
-                        start: 4
-                        end: 6
-                      ptr:
-                        Addr: 105298
-                    - key: 5330
-                      txgs:
-                        start: 4
-                        end: 6
-                      ptr:
-                        Addr: 105330"#);
+  height: 4
+  elem:
+    key: 0
+    txgs:
+      start: 2
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 3634
+              txgs:
+                start: 3
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 3634
+                        txgs:
+                          start: 3
+                          end: 6
+                        ptr:
+                          Addr: 103634
+                      - key: 3682
+                        txgs:
+                          start: 3
+                          end: 6
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 3682
+                                  txgs:
+                                    start: 3
+                                    end: 4
+                                  ptr:
+                                    Addr: 4494
+                                - key: 3686
+                                  txgs:
+                                    start: 3
+                                    end: 4
+                                  ptr:
+                                    Addr: 4495
+                                - key: 3690
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr:
+                                    Addr: 7382
+                                - key: 3698
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr:
+                                    Addr: 7384
+                      - key: 3706
+                        txgs:
+                          start: 5
+                          end: 43
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 3706
+                                  txgs:
+                                    start: 42
+                                    end: 43
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          3704: 3061
+                                          3706: 3060
+                                          3711: 3065
+                                - key: 5114
+                                  txgs:
+                                    start: 42
+                                    end: 43
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          5120: 3415
+                                          5122: 3417
+                                          5123: 3418
+                                          5137: 3432
+                                - key: 5138
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr:
+                                    Addr: 1005138
+                                - key: 5146
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr:
+                                    Addr: 1005146
+                                - key: 5162
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr:
+                                    Addr: 1005162
+                                - key: 5166
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr:
+                                    Addr: 1005166
+            - key: 5182
+              txgs:
+                start: 4
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 5182
+                        txgs:
+                          start: 4
+                          end: 6
+                        ptr:
+                          Addr: 105182
+                      - key: 5202
+                        txgs:
+                          start: 5
+                          end: 6
+                        ptr:
+                          Addr: 105202
+                      - key: 5298
+                        txgs:
+                          start: 4
+                          end: 6
+                        ptr:
+                          Addr: 105298
+                      - key: 5330
+                        txgs:
+                          start: 4
+                          end: 6
+                        ptr:
+                          Addr: 105330"#);
 }
 
 // Range delete pass2 steals a leaf node to the left
@@ -6451,7 +6521,6 @@ fn range_delete_pass2_steal_left() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -6459,89 +6528,90 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 2
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 11
-                    - key: 3
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-                              5: 5.0
-          - key: 20
-            txgs:
-              start: 0
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 20
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                              22: 22.0
-                    - key: 26
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 126
-                    - key: 29
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 32
-                    - key: 30
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 33
-                    - key: 40
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 34
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 2
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 11
+                      - key: 3
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+                                5: 5.0
+            - key: 20
+              txgs:
+                start: 0
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 20
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                                22: 22.0
+                      - key: 26
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 126
+                      - key: 29
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 32
+                      - key: 30
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 33
+                      - key: 40
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 34
+  "#));
     let r = tree.clone().range_delete(3..21, TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -6549,70 +6619,72 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 3
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 3
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 11
-                    - key: 20
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0
-                    - key: 26
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 126
-                    - key: 29
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 32
-          - key: 30
-            txgs:
-              start: 0
-              end: 3
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 30
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 33
-                    - key: 40
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 34"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 3
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 3
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 11
+                      - key: 20
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0
+                      - key: 26
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 126
+                      - key: 29
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 32
+            - key: 30
+              txgs:
+                start: 0
+                end: 3
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 30
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 33
+                      - key: 40
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 34"#);
 }
 
 // range_delete_pass2 tries to steal a node to the right
@@ -6622,7 +6694,6 @@ fn range_delete_pass2_steal_right() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 4
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -6630,185 +6701,186 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 23
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 5409
-            txgs:
-              start: 14
-              end: 23
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 5729
-                      txgs:
-                        start: 14
-                        end: 23
-                      ptr:
-                        Addr: 1005729
-                    - key: 6809
-                      txgs:
-                        start: 16
-                        end: 23
-                      ptr:
-                        Addr: 1006809
-                    - key: 9437
-                      txgs:
-                        start: 17
-                        end: 23
-                      ptr:
-                        Addr: 1009437
-          - key: 10049
-            txgs:
-              start: 18
-              end: 23
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 10113
-                      txgs:
-                        start: 22
-                        end: 23
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 10113
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        11264: 9282
-                                        11269: 9287
-                                        11270: 9288
-                                        11271: 9289
-                              - key: 11279
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        11281: 9299
-                                        11283: 9301
-                                        11284: 9302
-                                        11285: 9303
-                              - key: 11287
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        11288: 9306
-                                        11292: 9310
-                                        11293: 9311
-                                        11294: 9312
-                              - key: 11295
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        11295: 9313
-                                        11298: 9316
-                                        11300: 9318
-                                        11301: 9319
-                    - key: 11495
-                      txgs:
-                        start: 21
-                        end: 23
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 11511
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        11511: 9529
-                                        11514: 9532
-                              - key: 11519
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        11616: 9634
-                                        11994: 6844
-                              - key: 11995
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        11995: 6871
-                                        12002: 7037
-                              - key: 12003
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        12003: 7053
-                                        12010: 7164
-                    - key: 12037
-                      txgs:
-                        start: 22
-                        end: 23
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 12037
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Addr: 1012037
-                              - key: 12095
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Addr: 1012095
-                    - key: 12155
-                      txgs:
-                        start: 22
-                        end: 23
-                      ptr:
-                        Addr: 1012155
-"#));
+  height: 4
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 23
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 5409
+              txgs:
+                start: 14
+                end: 23
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 5729
+                        txgs:
+                          start: 14
+                          end: 23
+                        ptr:
+                          Addr: 1005729
+                      - key: 6809
+                        txgs:
+                          start: 16
+                          end: 23
+                        ptr:
+                          Addr: 1006809
+                      - key: 9437
+                        txgs:
+                          start: 17
+                          end: 23
+                        ptr:
+                          Addr: 1009437
+            - key: 10049
+              txgs:
+                start: 18
+                end: 23
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 10113
+                        txgs:
+                          start: 22
+                          end: 23
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 10113
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          11264: 9282
+                                          11269: 9287
+                                          11270: 9288
+                                          11271: 9289
+                                - key: 11279
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          11281: 9299
+                                          11283: 9301
+                                          11284: 9302
+                                          11285: 9303
+                                - key: 11287
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          11288: 9306
+                                          11292: 9310
+                                          11293: 9311
+                                          11294: 9312
+                                - key: 11295
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          11295: 9313
+                                          11298: 9316
+                                          11300: 9318
+                                          11301: 9319
+                      - key: 11495
+                        txgs:
+                          start: 21
+                          end: 23
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 11511
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          11511: 9529
+                                          11514: 9532
+                                - key: 11519
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          11616: 9634
+                                          11994: 6844
+                                - key: 11995
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          11995: 6871
+                                          12002: 7037
+                                - key: 12003
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          12003: 7053
+                                          12010: 7164
+                      - key: 12037
+                        txgs:
+                          start: 22
+                          end: 23
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 12037
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Addr: 1012037
+                                - key: 12095
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Addr: 1012095
+                      - key: 12155
+                        txgs:
+                          start: 22
+                          end: 23
+                        ptr:
+                          Addr: 1012155
+  "#));
     let r = tree.clone().range_delete(11264..11776, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 4
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -6816,95 +6888,97 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 5409
-            txgs:
-              start: 14
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 5729
-                      txgs:
-                        start: 14
-                        end: 23
-                      ptr:
-                        Addr: 1005729
-                    - key: 6809
-                      txgs:
-                        start: 16
-                        end: 23
-                      ptr:
-                        Addr: 1006809
-          - key: 9437
-            txgs:
-              start: 17
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9437
-                      txgs:
-                        start: 17
-                        end: 23
-                      ptr:
-                        Addr: 1009437
-                    - key: 11495
-                      txgs:
-                        start: 22
-                        end: 43
-                      ptr:
-                        Mem:
-                          Int:
-                            children:
-                              - key: 11519
-                                txgs:
-                                  start: 42
-                                  end: 43
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        11994: 6844
-                                        11995: 6871
-                                        12002: 7037
-                              - key: 12003
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Mem:
-                                    Leaf:
-                                      items:
-                                        12003: 7053
-                                        12010: 7164
-                              - key: 12037
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Addr: 1012037
-                              - key: 12095
-                                txgs:
-                                  start: 22
-                                  end: 23
-                                ptr:
-                                  Addr: 1012095
-                    - key: 12155
-                      txgs:
-                        start: 22
-                        end: 23
-                      ptr:
-                        Addr: 1012155"#);
+  height: 4
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 5409
+              txgs:
+                start: 14
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 5729
+                        txgs:
+                          start: 14
+                          end: 23
+                        ptr:
+                          Addr: 1005729
+                      - key: 6809
+                        txgs:
+                          start: 16
+                          end: 23
+                        ptr:
+                          Addr: 1006809
+            - key: 9437
+              txgs:
+                start: 17
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9437
+                        txgs:
+                          start: 17
+                          end: 23
+                        ptr:
+                          Addr: 1009437
+                      - key: 11495
+                        txgs:
+                          start: 22
+                          end: 43
+                        ptr:
+                          Mem:
+                            Int:
+                              children:
+                                - key: 11519
+                                  txgs:
+                                    start: 42
+                                    end: 43
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          11994: 6844
+                                          11995: 6871
+                                          12002: 7037
+                                - key: 12003
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Mem:
+                                      Leaf:
+                                        items:
+                                          12003: 7053
+                                          12010: 7164
+                                - key: 12037
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Addr: 1012037
+                                - key: 12095
+                                  txgs:
+                                    start: 22
+                                    end: 23
+                                  ptr:
+                                    Addr: 1012095
+                      - key: 12155
+                        txgs:
+                          start: 22
+                          end: 23
+                        ptr:
+                          Addr: 1012155"#);
 }
 
 // range_delete of a small range at the end of the tree
@@ -6934,7 +7008,6 @@ fn range_delete_range_from() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -6942,74 +7015,75 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 2
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 10010
-                    - key: 3
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-                              5: 5.0
-          - key: 20
-            txgs:
-              start: 0
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 20
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                    - key: 26
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              26: 26.0
-                              27: 27.0
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 2
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 10010
+                      - key: 3
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+                                5: 5.0
+            - key: 20
+              txgs:
+                start: 0
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 20
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                      - key: 26
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                26: 26.0
+                                27: 27.0
+  "#));
     let r = tree.clone().range_delete(5.., TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7017,30 +7091,32 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 3
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 1
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Addr: 10010
-          - key: 3
-            txgs:
-              start: 2
-              end: 3
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 3
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 1
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Addr: 10010
+            - key: 3
+              txgs:
+                start: 2
+                end: 3
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0"#);
 }
 
 // range_delete with a RangeFull (..) argument
@@ -7050,7 +7126,6 @@ fn range_delete_range_full() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7058,78 +7133,79 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 2
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              2: 2.0
-                    - key: 3
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-          - key: 20
-            txgs:
-              start: 0
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 20
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                              22: 22.0
-                    - key: 26
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              26: 26.0
-                              27: 27.0
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 2
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                2: 2.0
+                      - key: 3
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+            - key: 20
+              txgs:
+                start: 0
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 20
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                                22: 22.0
+                      - key: 26
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                26: 26.0
+                                27: 27.0
+  "#));
     let r = tree.clone().range_delete(.., TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7137,14 +7213,16 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 3
-  ptr:
-    Mem:
-      Leaf:
-        items: {}"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 3
+    ptr:
+      Mem:
+        Leaf:
+          items: {}"#);
 }
 
 // range_delete with a RangeTo (..x) argument
@@ -7154,7 +7232,6 @@ fn range_delete_range_to() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7162,74 +7239,75 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 2
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              2: 2.0
-                    - key: 3
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-          - key: 20
-            txgs:
-              start: 0
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 20
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                              22: 22.0
-                    - key: 26
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 10026
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 2
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                2: 2.0
+                      - key: 3
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+            - key: 20
+              txgs:
+                start: 0
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 20
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                                22: 22.0
+                      - key: 26
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 10026
+  "#));
     let r = tree.clone().range_delete(..21, TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7237,30 +7315,32 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 3
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 20
-            txgs:
-              start: 2
-              end: 3
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    21: 21.0
-                    22: 22.0
-          - key: 26
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Addr: 10026"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 3
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 20
+              txgs:
+                start: 2
+                end: 3
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      21: 21.0
+                      22: 22.0
+            - key: 26
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Addr: 10026"#);
 }
 
 // range_delete with a range that includes a whole IntNode at the end of the
@@ -7287,7 +7367,6 @@ fn range_delete_to_end_deep() {
     // single Leaf.
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7295,35 +7374,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 2
-    end: 3
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 2
-              end: 3
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-                    2: 2.0
-          - key: 3
-            txgs:
-              start: 2
-              end: 3
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 2
+      end: 3
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 2
+                end: 3
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+            - key: 3
+              txgs:
+                start: 2
+                end: 3
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0"#);
 
 }
 
@@ -7333,7 +7414,6 @@ fn range_delete_underflow_in_parent_and_child() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7341,79 +7421,80 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 2
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 1
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              1: 1.0
-                              2: 2.0
-                    - key: 3
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-                              5: 5.0
-          - key: 20
-            txgs:
-              start: 0
-              end: 2
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 20
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                              22: 22.0
-                    - key: 26
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              26: 26.0
-                              27: 27.0
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 2
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 1
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                1: 1.0
+                                2: 2.0
+                      - key: 3
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+                                5: 5.0
+            - key: 20
+              txgs:
+                start: 0
+                end: 2
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 20
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                                22: 22.0
+                      - key: 26
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                26: 26.0
+                                27: 27.0
+  "#));
     let r = tree.clone().range_delete(2..30, TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7421,15 +7502,17 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 2
-    end: 3
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          1: 1.0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 2
+      end: 3
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            1: 1.0"#);
 }
 
 #[test]
@@ -7437,7 +7520,6 @@ fn range_empty_range() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7445,35 +7527,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+  "#));
     let r = tree.range(1..1)
         .try_collect()
         .now_or_never().unwrap();
@@ -7499,7 +7583,6 @@ fn range_full() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7507,35 +7590,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+  "#));
     let r = tree.range(..)
         .try_collect()
         .now_or_never().unwrap();
@@ -7547,7 +7632,6 @@ fn range_exclusive_start() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7555,35 +7639,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+  "#));
     // A query that starts on a leaf
     let r = tree.range((Bound::Excluded(0), Bound::Excluded(4)))
         .try_collect()
@@ -7602,7 +7688,6 @@ fn range_leaf() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7610,20 +7695,22 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
-          1: 1.0
-          2: 2.0
-          3: 3.0
-          4: 4.0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
+            1: 1.0
+            2: 2.0
+            3: 3.0
+            4: 4.0
+  "#));
     let r = tree.range(1..3)
         .try_collect()
         .now_or_never().unwrap();
@@ -7635,7 +7722,6 @@ fn range_leaf_inclusive_end() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7643,20 +7729,22 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
-          1: 1.0
-          2: 2.0
-          3: 3.0
-          4: 4.0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
+            1: 1.0
+            2: 2.0
+            3: 3.0
+            4: 4.0
+  "#));
     let r = tree.range(3..=4)
         .try_collect()
         .now_or_never().unwrap();
@@ -7668,7 +7756,6 @@ fn range_nonexistent_between_two_leaves() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7676,35 +7763,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5: 5.0
-                    6: 6.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5: 5.0
+                      6: 6.0
+  "#));
     let r = tree.range(2..4)
         .try_collect()
         .now_or_never().unwrap();
@@ -7716,7 +7805,6 @@ fn range_two_ints() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7724,51 +7812,53 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 0
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-          - key: 9
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 0
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 0
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+            - key: 9
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 0
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+  "#));
     let r = tree.range(1..10)
         .try_collect()
         .now_or_never().unwrap();
@@ -7780,7 +7870,6 @@ fn range_ends_between_two_leaves() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7788,35 +7877,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 4
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    4: 4.0
-                    5: 5.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 4
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      4: 4.0
+                      5: 5.0
+  "#));
     let r = tree.range(0..3)
         .try_collect()
         .now_or_never().unwrap();
@@ -7828,7 +7919,6 @@ fn range_ends_before_node_but_after_parent_pointer() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7836,35 +7926,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 4
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    6: 6.0
-                    7: 7.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 4
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      6: 6.0
+                      7: 7.0
+  "#));
     let r = tree.range(0..5)
         .try_collect()
         .now_or_never().unwrap();
@@ -7876,7 +7968,6 @@ fn range_starts_between_two_leaves() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7884,45 +7975,47 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-          - key: 5
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5: 5.0
-                    6: 6.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+            - key: 5
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5: 5.0
+                      6: 6.0
+  "#));
     let r = tree.range(2..6)
         .try_collect()
         .now_or_never().unwrap();
@@ -7934,7 +8027,6 @@ fn range_two_leaves() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7942,35 +8034,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 0
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 0
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+  "#));
     let r = tree.range(1..4)
         .try_collect()
         .now_or_never().unwrap();
@@ -7983,7 +8077,6 @@ fn remove_last_key() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7991,22 +8084,23 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
+  "#));
     let r = tree.clone().remove(0, TxgT::from(42))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(0.0)));
     assert_eq!(format!("{}", tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8014,14 +8108,16 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 43
-  ptr:
-    Mem:
-      Leaf:
-        items: {}"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 43
+    ptr:
+      Mem:
+        Leaf:
+          items: {}"#);
 }
 
 #[test]
@@ -8030,7 +8126,6 @@ fn remove_from_leaf() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8038,24 +8133,25 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
-          1: 1.0
-          2: 2.0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
+            1: 1.0
+            2: 2.0
+  "#));
     let r = tree.clone().remove(1, TxgT::from(42))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(1.0)));
     assert_eq!(format!("{}", tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8063,16 +8159,18 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
-          2: 2.0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
+            2: 2.0"#);
 }
 
 #[test]
@@ -8081,7 +8179,6 @@ fn remove_and_merge_down() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8089,32 +8186,33 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-                    2: 2.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+  "#));
     let r2 = tree.clone().remove(1, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8122,16 +8220,18 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
-          2: 2.0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
+            2: 2.0"#);
 }
 
 #[test]
@@ -8140,7 +8240,6 @@ fn remove_and_merge_int_left() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8148,125 +8247,126 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 3
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-                    - key: 6
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              6: 6.0
-                              7: 7.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-          - key: 18
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 18
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              18: 18.0
-                              19: 19.0
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0
-                              23: 23.0"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 3
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+                      - key: 6
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                6: 6.0
+                                7: 7.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+            - key: 18
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 18
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                18: 18.0
+                                19: 19.0
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0
+                                23: 23.0"#));
     let r2 = tree.clone().remove(23, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8274,110 +8374,112 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 3
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-                    - key: 6
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              6: 6.0
-                              7: 7.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                    - key: 18
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              18: 18.0
-                              19: 19.0
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 3
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+                      - key: 6
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                6: 6.0
+                                7: 7.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                      - key: 18
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                18: 18.0
+                                19: 19.0
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0"#);
 }
 
 #[test]
@@ -8386,7 +8488,6 @@ fn remove_and_merge_int_right() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8394,115 +8495,116 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 2
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2: 2.0
-                              3: 3.0
-                              4: 4.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-          - key: 18
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 18
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              18: 18.0
-                              19: 19.0
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 2
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2: 2.0
+                                3: 3.0
+                                4: 4.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+            - key: 18
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 18
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                18: 18.0
+                                19: 19.0
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0"#));
     let r2 = tree.clone().remove(4, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8510,100 +8612,102 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 2
-                      txgs:
-                        start: 41
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2: 2.0
-                              3: 3.0
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-          - key: 18
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 18
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              18: 18.0
-                              19: 19.0
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 2
+                        txgs:
+                          start: 41
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2: 2.0
+                                3: 3.0
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+            - key: 18
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 18
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                18: 18.0
+                                19: 19.0
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0"#);
 }
 
 #[test]
@@ -8612,7 +8716,6 @@ fn remove_and_merge_leaf_left() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8620,51 +8723,52 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-          - key: 5
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5: 5.0
-                    7: 7.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+            - key: 5
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5: 5.0
+                      7: 7.0
+  "#));
     let r2 = tree.clone().remove(7, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8672,35 +8776,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-                    5: 5.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0"#);
 }
 
 #[test]
@@ -8709,7 +8815,6 @@ fn remove_and_merge_leaf_right() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8717,52 +8822,53 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-          - key: 5
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+            - key: 5
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+  "#));
     let r2 = tree.clone().remove(4, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8770,36 +8876,38 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0"#);
 }
 
 #[test]
@@ -8808,7 +8916,6 @@ fn remove_and_steal_int_left() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8816,135 +8923,136 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 2
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2: 2.0
-                              3: 3.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                    - key: 17
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              17: 17.0
-                              18: 18.0
-                    - key: 19
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              19: 19.0
-                              20: 20.0
-          - key: 21
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0
-                    - key: 24
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              24: 24.0
-                              25: 25.0
-                              26: 26.0"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 2
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2: 2.0
+                                3: 3.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                      - key: 17
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                17: 17.0
+                                18: 18.0
+                      - key: 19
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                19: 19.0
+                                20: 20.0
+            - key: 21
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0
+                      - key: 24
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                24: 24.0
+                                25: 25.0
+                                26: 26.0"#));
     let r2 = tree.clone().remove(26, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8952,128 +9060,130 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 2
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2: 2.0
-                              3: 3.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                    - key: 17
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              17: 17.0
-                              18: 18.0
-          - key: 19
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 19
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              19: 19.0
-                              20: 20.0
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0
-                    - key: 24
-                      txgs:
-                        start: 41
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              24: 24.0
-                              25: 25.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 2
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2: 2.0
+                                3: 3.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                      - key: 17
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                17: 17.0
+                                18: 18.0
+            - key: 19
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 19
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                19: 19.0
+                                20: 20.0
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0
+                      - key: 24
+                        txgs:
+                          start: 41
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                24: 24.0
+                                25: 25.0"#);
 }
 
 #[test]
@@ -9082,7 +9192,6 @@ fn remove_and_steal_int_right() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9090,135 +9199,136 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 2
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2: 2.0
-                              3: 3.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                              14: 14.0
-          - key: 15
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                    - key: 17
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              17: 17.0
-                              18: 18.0
-                    - key: 19
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              19: 19.0
-                              20: 20.0
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0
-                    - key: 24
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              24: 24.0
-                              26: 26.0"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 2
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2: 2.0
+                                3: 3.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                                14: 14.0
+            - key: 15
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                      - key: 17
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                17: 17.0
+                                18: 18.0
+                      - key: 19
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                19: 19.0
+                                20: 20.0
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0
+                      - key: 24
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                24: 24.0
+                                26: 26.0"#));
     let r2 = tree.clone().remove(14, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9226,128 +9336,130 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 2
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2: 2.0
-                              3: 3.0
-          - key: 9
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-          - key: 17
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 17
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              17: 17.0
-                              18: 18.0
-                    - key: 19
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              19: 19.0
-                              20: 20.0
-                    - key: 21
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              21: 21.0
-                              22: 22.0
-                    - key: 24
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              24: 24.0
-                              26: 26.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 2
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2: 2.0
+                                3: 3.0
+            - key: 9
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+            - key: 17
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 17
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                17: 17.0
+                                18: 18.0
+                      - key: 19
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                19: 19.0
+                                20: 20.0
+                      - key: 21
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                21: 21.0
+                                22: 22.0
+                      - key: 24
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                24: 24.0
+                                26: 26.0"#);
 }
 
 #[test]
@@ -9356,7 +9468,6 @@ fn remove_and_steal_leaf_left() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9364,54 +9475,55 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 2
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    2: 2.0
-                    3: 3.0
-                    4: 4.0
-                    5: 5.0
-                    6: 6.0
-          - key: 8
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    8: 8.0
-                    9: 9.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 2
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      2: 2.0
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+            - key: 8
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      8: 8.0
+                      9: 9.0
+  "#));
     let r2 = tree.clone().remove(8, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9419,46 +9531,48 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 2
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    2: 2.0
-                    3: 3.0
-                    4: 4.0
-                    5: 5.0
-          - key: 6
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    6: 6.0
-                    9: 9.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 2
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      2: 2.0
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+            - key: 6
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      6: 6.0
+                      9: 9.0"#);
 }
 
 #[test]
@@ -9467,7 +9581,6 @@ fn remove_and_steal_leaf_right() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9475,54 +9588,55 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    4: 4.0
-          - key: 5
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5: 5.0
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0
-                    9: 9.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      4: 4.0
+            - key: 5
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+                      9: 9.0
+  "#));
     let r2 = tree.clone().remove(4, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9530,46 +9644,48 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    1: 1.0
-          - key: 3
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    3: 3.0
-                    5: 5.0
-          - key: 6
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    6: 6.0
-                    7: 7.0
-                    8: 8.0
-                    9: 9.0"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      1: 1.0
+            - key: 3
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      3: 3.0
+                      5: 5.0
+            - key: 6
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+                      9: 9.0"#);
 }
 
 #[test]

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -16,7 +16,7 @@ fn insert() {
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
     let tree = Arc::new(
-        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false)
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false, None)
     );
     let r = tree.clone().insert(0, 0.0, TxgT::from(42))
         .now_or_never().unwrap();
@@ -1284,7 +1284,7 @@ fn get() {
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
     let tree = Arc::new(
-        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false)
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false, None)
     );
     let r = tree.clone().insert(0, 0.0, TxgT::from(42))
         .and_then(|_| tree.get(0))
@@ -1344,7 +1344,7 @@ fn get_nonexistent() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::new(dml, limits, false);
+    let tree: Tree<u32, MockDML, u32, f32> = Tree::new(dml, limits, false, None);
     let r = tree.get(0).now_or_never().unwrap();
     assert_eq!(r, Ok(None))
 }
@@ -1353,7 +1353,7 @@ fn get_nonexistent() {
 fn last_key_empty() {
     let dml = Arc::new(MockDML::new());
     let limits = Limits::new(2, 5, 2, 5);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::new(dml, limits, false);
+    let tree: Tree<u32, MockDML, u32, f32> = Tree::new(dml, limits, false, None);
     let r = tree.last_key().now_or_never().unwrap();
     assert_eq!(r, Ok(None))
 }
@@ -6988,7 +6988,7 @@ fn range_delete_at_end() {
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
     let tree = Arc::new(
-        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false)
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false, None)
     );
     (0..23).map(|k| {
         tree.clone().insert(k, k as f32, TxgT::from(2))
@@ -7351,7 +7351,7 @@ fn range_delete_to_end_deep() {
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
     let tree = Arc::new(
-        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false)
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false, None)
     );
     (0..23).map(|k| {
         tree.clone().insert(k, k as f32, TxgT::from(2))
@@ -9694,7 +9694,7 @@ fn remove_nonexistent() {
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
     let tree = Arc::new(
-        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false)
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false, None)
     );
     let r = tree.remove(3, TxgT::from(42))
         .now_or_never().unwrap();

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -15,8 +15,10 @@ fn insert() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::new(dml, limits, false);
-    let r = tree.insert(0, 0.0, TxgT::from(42))
+    let tree = Arc::new(
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false)
+    );
+    let r = tree.clone().insert(0, 0.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(None));
     assert_eq!(format!("{}", tree),
@@ -46,7 +48,7 @@ root:
 fn insert_lower_than_parents_key() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -88,8 +90,8 @@ root:
                     72: 72.0
                     73: 73.0
                     74: 74.0
-"#);
-    assert!(tree.insert(36, 36.0, TxgT::from(42))
+"#));
+    assert!(tree.clone().insert(36, 36.0, TxgT::from(42))
             .now_or_never().unwrap()
             .is_ok());
     assert_eq!(format!("{}", tree),
@@ -141,7 +143,7 @@ root:
 fn insert_dup() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 1
 limits:
@@ -160,8 +162,8 @@ root:
       Leaf:
         items:
           0: 0.0
-"#);
-    let r = tree.insert(0, 100.0, TxgT::from(42))
+"#));
+    let r = tree.clone().insert(0, 100.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(0.0)));
     assert_eq!(format!("{}", tree),
@@ -191,7 +193,7 @@ root:
 fn insert_dup_no_split() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 1
 limits:
@@ -214,8 +216,8 @@ root:
           2: 2.0
           3: 3.0
           4: 4.0
-"#);
-    let r = tree.insert(0, 100.0, TxgT::from(42))
+"#));
+    let r = tree.clone().insert(0, 100.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(0.0)));
     assert_eq!(format!("{}", tree),
@@ -248,7 +250,7 @@ root:
 fn insert_split_int() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -369,8 +371,8 @@ root:
                             items:
                               21: 21.0
                               22: 22.0
-                              23: 23.0"#);
-    let r2 = tree.insert(24, 24.0, TxgT::from(42))
+                              23: 23.0"#));
+    let r2 = tree.clone().insert(24, 24.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -511,7 +513,7 @@ root:
 fn insert_split_int_sequential() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, true, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, true, r#"
 ---
 height: 3
 limits:
@@ -644,8 +646,8 @@ root:
                           Leaf:
                             items:
                               30: 30.0
-                              31: 31.0"#);
-    let r2 = tree.insert(33, 33.0, TxgT::from(42))
+                              31: 31.0"#));
+    let r2 = tree.clone().insert(33, 33.0, TxgT::from(42))
     .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -798,7 +800,7 @@ root:
 fn insert_split_leaf() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -840,8 +842,8 @@ root:
                     5: 5.0
                     6: 6.0
                     7: 7.0
-"#);
-    let r2 = tree.insert(8, 8.0, TxgT::from(42))
+"#));
+    let r2 = tree.clone().insert(8, 8.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", tree),
@@ -902,7 +904,7 @@ root:
 fn insert_split_leaf_sequential() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, true, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, true, r#"
 ---
 height: 2
 limits:
@@ -948,8 +950,8 @@ root:
                     9: 9.0
                     10: 10.0
                     11: 11.0
-"#);
-    let r2 = tree.insert(12, 12.0, TxgT::from(42))
+"#));
+    let r2 = tree.clone().insert(12, 12.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", tree),
@@ -1014,7 +1016,7 @@ root:
 fn insert_split_root_int() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -1087,8 +1089,8 @@ root:
                     12: 12.0
                     13: 13.0
                     14: 14.0
-"#);
-    let r2 = tree.insert(15, 15.0, TxgT::from(42))
+"#));
+    let r2 = tree.clone().insert(15, 15.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -1188,7 +1190,7 @@ root:
 fn insert_split_root_leaf() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 1
 limits:
@@ -1211,8 +1213,8 @@ root:
           2: 2.0
           3: 3.0
           4: 4.0
-"#);
-    let r2 = tree.insert(5, 5.0, TxgT::from(42))
+"#));
+    let r2 = tree.clone().insert(5, 5.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -1262,8 +1264,10 @@ fn get() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::new(dml, limits, false);
-    let r = tree.insert(0, 0.0, TxgT::from(42))
+    let tree = Arc::new(
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false)
+    );
+    let r = tree.clone().insert(0, 0.0, TxgT::from(42))
         .and_then(|_| tree.get(0))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(0.0)));
@@ -2829,7 +2833,7 @@ root:
 fn range_delete_merge_descending_and_ascending() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -6909,9 +6913,11 @@ fn range_delete_at_end() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::new(dml, limits, false);
+    let tree = Arc::new(
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false)
+    );
     (0..23).map(|k| {
-        tree.insert(k, k as f32, TxgT::from(2))
+        tree.clone().insert(k, k as f32, TxgT::from(2))
     }).collect::<FuturesUnordered<_>>()
     .try_collect::<Vec<_>>()
     .now_or_never().unwrap()
@@ -6926,7 +6932,7 @@ fn range_delete_at_end() {
 fn range_delete_range_from() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -6997,7 +7003,7 @@ root:
                             items:
                               26: 26.0
                               27: 27.0
-"#);
+"#));
     let r = tree.range_delete(5.., TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
@@ -7264,9 +7270,11 @@ fn range_delete_to_end_deep() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
     let limits = Limits::new(2, 5, 2, 5);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::new(dml, limits, false);
+    let tree = Arc::new(
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false)
+    );
     (0..23).map(|k| {
-        tree.insert(k, k as f32, TxgT::from(2))
+        tree.clone().insert(k, k as f32, TxgT::from(2))
     }).collect::<FuturesUnordered<_>>()
     .try_collect::<Vec<_>>()
     .now_or_never().unwrap()

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -2489,7 +2489,7 @@ root:
 fn range_delete_merge_and_underflow() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -2562,11 +2562,11 @@ root:
                     13: 13.0
                     14: 14.0
                     15: 15.0
-"#);
+"#));
     let r = tree.range_delete(2..6, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
-    assert!(tree.check().now_or_never().unwrap().unwrap());
+    assert!(tree.clone().check().now_or_never().unwrap().unwrap());
     assert_eq!(format!("{}", &tree),
 r#"---
 height: 2
@@ -2829,7 +2829,7 @@ root:
 fn range_delete_merge_descending_and_ascending() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -2959,8 +2959,8 @@ root:
                             items:
                               1759: 861
                               1762: 864
-"#);
-    assert!(tree.check().now_or_never().unwrap().unwrap());
+"#));
+    assert!(tree.clone().check().now_or_never().unwrap().unwrap());
     let r = tree.range_delete(1024..1536, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -1276,7 +1276,7 @@ fn get() {
 #[test]
 fn get_deep() {
     let dml = Arc::new(MockDML::new());
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -1314,7 +1314,7 @@ root:
                   items:
                     3: 3.0
                     4: 4.0
-"#);
+"#));
     let r = tree.get(3).now_or_never().unwrap();
     assert_eq!(r, Ok(Some(3.0)))
 }
@@ -1398,7 +1398,7 @@ root:
 fn range_delete() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -1511,8 +1511,8 @@ root:
                             items:
                               37: 37.0
                               40: 40.0
-"#);
-    let r = tree.range_delete(11..=31, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(11..=31, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -1574,7 +1574,7 @@ root:
 fn range_delete_danger() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -1685,8 +1685,8 @@ root:
                             items:
                               37: 37.0
                               40: 40.0
-"#);
-    let r = tree.range_delete(5..6, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(5..6, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -1806,7 +1806,7 @@ root:
 fn range_delete_exc_exc() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -1870,8 +1870,8 @@ root:
                     20: 20.0
                     21: 21.0
                     22: 22.0
-"#);
-    let r = tree.range_delete(
+"#));
+    let r = tree.clone().range_delete(
         (Bound::Excluded(4), Bound::Excluded(10)),
         TxgT::from(42))
         .now_or_never().unwrap();
@@ -1935,7 +1935,7 @@ root:
 fn range_delete_exc_inc() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -1999,8 +1999,8 @@ root:
                     20: 20.0
                     21: 21.0
                     22: 22.0
-"#);
-    let r = tree.range_delete(
+"#));
+    let r = tree.clone().range_delete(
         (Bound::Excluded(4), Bound::Included(10)),
         TxgT::from(42))
         .now_or_never().unwrap();
@@ -2070,7 +2070,7 @@ fn range_delete_fix_three_times() {
         .returning(move |_, _| Box::pin(future::ok(())));
 
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
 height: 4
 limits:
@@ -2356,8 +2356,8 @@ root:
                         end: 8
                       ptr:
                         Addr: 10025
-"#);
-  let r = tree.range_delete(1024..1536, TxgT::from(42))
+"#));
+  let r = tree.clone().range_delete(1024..1536, TxgT::from(42))
     .now_or_never().unwrap();
   assert!(r.is_ok());
   assert_eq!(format!("{}", &tree),
@@ -2567,7 +2567,7 @@ root:
                     14: 14.0
                     15: 15.0
 "#));
-    let r = tree.range_delete(2..6, TxgT::from(42))
+    let r = tree.clone().range_delete(2..6, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert!(tree.clone().check().now_or_never().unwrap().unwrap());
@@ -2632,7 +2632,7 @@ root:
 fn range_delete_merge_and_parent_underflow() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -2740,8 +2740,8 @@ root:
               end: 1
             ptr:
               Addr: 10040
-"#);
-    let r = tree.range_delete(2..6, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(2..6, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -2965,7 +2965,7 @@ root:
                               1762: 864
 "#));
     assert!(tree.clone().check().now_or_never().unwrap().unwrap());
-    let r = tree.range_delete(1024..1536, TxgT::from(42))
+    let r = tree.clone().range_delete(1024..1536, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert!(tree.check().now_or_never().unwrap().unwrap());
@@ -2977,7 +2977,7 @@ root:
 fn range_delete_merge_left_child_twice() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -3060,8 +3060,8 @@ root:
                     42: 42.0
                     43: 43.0
                     44: 44.0
-"#);
-    let r = tree.range_delete(12..23, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(12..23, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -3134,7 +3134,7 @@ root:
 fn range_delete_merge_to_lca_twice() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
 height: 4
 limits:
@@ -3331,8 +3331,8 @@ root:
               end: 10
             ptr:
               Addr: 112144
-"#);
-    let r = tree.range_delete(11264..11776, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(11264..11776, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -3492,7 +3492,7 @@ root:
 fn range_delete_merge_right_child_descending() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -3558,8 +3558,8 @@ root:
                     5637: 7559
                     5638: 7560
                     5642: 7564
-"#);
-    let r = tree.range_delete(5120..5632, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(5120..5632, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -3615,7 +3615,7 @@ root:
 fn range_delete_merge_right_child_first() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -3739,8 +3739,8 @@ root:
               end: 15
             ptr:
               Addr: 7692
-"#);
-    tree.range_delete(7168..7680, TxgT::from(42))
+"#));
+    tree.clone().range_delete(7168..7680, TxgT::from(42))
         .now_or_never().unwrap().unwrap();
     assert_eq!(format!("{}", &tree),
 r#"---
@@ -3829,7 +3829,7 @@ root:
 fn range_delete_merge_root() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -3871,8 +3871,8 @@ root:
                     6: 6.0
                     7: 7.0
                     8: 8.0
-"#);
-    let r = tree.range_delete(0..4, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(0..4, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -3908,7 +3908,7 @@ root:
 fn range_delete_merge_root_during_ascent() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -4049,8 +4049,8 @@ root:
                               3581: 6693
                               3584: 3091
                               3585: 3092
-"#);
-    let r = tree.range_delete(3072..3584, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(3072..3584, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -4101,7 +4101,7 @@ root:
 fn range_delete_merge_root_twice() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -4183,8 +4183,8 @@ root:
                               15: 15.0
                               16: 16.0
                               17: 17.0
-"#);
-    let r = tree.range_delete(0..13, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(0..13, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -4219,7 +4219,7 @@ root:
 fn range_delete_parent_and_child_underflow_after_descent() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
 height: 4
 limits:
@@ -4428,8 +4428,8 @@ root:
                         end: 11
                       ptr:
                         Addr: 1005119
-"#);
-    let r = tree.range_delete(3584..4096, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(3584..4096, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -4553,7 +4553,7 @@ root:
 fn range_delete_cant_fix_for_minfanout_plus_two() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -4647,8 +4647,8 @@ root:
                         end: 42
                       ptr:
                         Addr: 1004627
-"#);
-    let r = tree.range_delete(4480..4600, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(4480..4600, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -4751,7 +4751,7 @@ root:
 fn range_delete_cant_steal_to_fix_lca() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -4853,8 +4853,8 @@ root:
                         end: 2
                       ptr:
                         Addr: 1000070
-"#);
-    let r = tree.range_delete(21..32, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(21..32, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -4946,7 +4946,7 @@ root:
 fn range_delete_single_node() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -4998,8 +4998,8 @@ root:
                     10: 10.0
                     11: 11.0
                     12: 12.0
-"#);
-    let r = tree.range_delete(5..7, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(5..7, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -5061,7 +5061,7 @@ root:
 fn range_delete_underflow_and_steal_left() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -5168,8 +5168,8 @@ root:
                         end: 42
                       ptr:
                         Addr: 1004637
-"#);
-    let r = tree.range_delete(4480..4605, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(4480..4605, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -5275,7 +5275,7 @@ root:
 fn range_delete_to_end() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -5325,8 +5325,8 @@ root:
                   items:
                     10: 10.0
                     11: 11.0
-"#);
-    let r = tree.range_delete(7..20, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(7..20, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -5376,7 +5376,7 @@ root:
 fn range_delete_to_end_of_int_node() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -5500,8 +5500,8 @@ root:
                             items:
                               40: 40.0
                               41: 41.0
-"#);
-    let r = tree.range_delete(10..16, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(10..16, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     // Ideally the leaf node with key 7 wouldn't have its end txg changed.
@@ -5628,7 +5628,7 @@ root:
 fn range_delete_whole_nodes() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -5689,8 +5689,8 @@ root:
                     20: 20.0
                     21: 21.0
                     22: 22.0
-"#);
-    let r = tree.range_delete(4..20, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(4..20, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     // Ideally the first leaf node wouldn't have its end txg changed.  However,
@@ -5743,7 +5743,7 @@ root:
 fn range_delete_whole_node_denormalized() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -5823,8 +5823,8 @@ root:
                         end: 42
                       ptr:
                         Addr: 1004617
-"#);
-    let r = tree.range_delete(4610..4613, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(4610..4613, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -5899,7 +5899,7 @@ fn range_delete_pass2_steal_creates_an_lca() {
         .returning(move |_, _| Box::pin(future::ok(())));
 
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
 height: 5
 limits:
@@ -6287,8 +6287,8 @@ root:
                                   end: 6
                                 ptr:
                                   Addr: 105330
-"#);
-    let r = tree.range_delete(4608..5120, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(4608..5120, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -6449,7 +6449,7 @@ root:
 fn range_delete_pass2_steal_left() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -6535,8 +6535,8 @@ root:
                         end: 1
                       ptr:
                         Addr: 34
-"#);
-    let r = tree.range_delete(3..21, TxgT::from(2))
+"#));
+    let r = tree.clone().range_delete(3..21, TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -6620,7 +6620,7 @@ root:
 fn range_delete_pass2_steal_right() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
 height: 4
 limits:
@@ -6802,8 +6802,8 @@ root:
                         end: 23
                       ptr:
                         Addr: 1012155
-"#);
-    let r = tree.range_delete(11264..11776, TxgT::from(42))
+"#));
+    let r = tree.clone().range_delete(11264..11776, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -7004,7 +7004,7 @@ root:
                               26: 26.0
                               27: 27.0
 "#));
-    let r = tree.range_delete(5.., TxgT::from(2))
+    let r = tree.clone().range_delete(5.., TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -7048,7 +7048,7 @@ root:
 fn range_delete_range_full() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -7123,8 +7123,8 @@ root:
                             items:
                               26: 26.0
                               27: 27.0
-"#);
-    let r = tree.range_delete(.., TxgT::from(2))
+"#));
+    let r = tree.clone().range_delete(.., TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -7152,7 +7152,7 @@ root:
 fn range_delete_range_to() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -7223,8 +7223,8 @@ root:
                         end: 1
                       ptr:
                         Addr: 10026
-"#);
-    let r = tree.range_delete(..21, TxgT::from(2))
+"#));
+    let r = tree.clone().range_delete(..21, TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -7279,7 +7279,7 @@ fn range_delete_to_end_deep() {
     .try_collect::<Vec<_>>()
     .now_or_never().unwrap()
     .unwrap();
-    let r = tree.range_delete(5..24, TxgT::from(2))
+    let r = tree.clone().range_delete(5..24, TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     // NB: in this case, it would be acceptable for the final Tree to consist of
@@ -7331,7 +7331,7 @@ root:
 fn range_delete_underflow_in_parent_and_child() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -7407,8 +7407,8 @@ root:
                             items:
                               26: 26.0
                               27: 27.0
-"#);
-    let r = tree.range_delete(2..30, TxgT::from(2))
+"#));
+    let r = tree.clone().range_delete(2..30, TxgT::from(2))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),

--- a/bfffs-core/src/tree/tree/tests/io.rs
+++ b/bfffs-core/src/tree/tree/tests/io.rs
@@ -676,7 +676,7 @@ fn range_delete() {
     expect_pop(&mut mock, addrl7, leafnode7);
 
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -712,8 +712,9 @@ root:
               end: 24
             ptr:
               Addr: 2
-"#);
-    tree.range_delete(5..25, TxgT::from(42)).now_or_never().unwrap().unwrap();
+"#));
+    tree.clone().range_delete(5..25, TxgT::from(42))
+        .now_or_never().unwrap().unwrap();
     assert_eq!(format!("{}", &tree),
 r#"---
 height: 3
@@ -810,7 +811,7 @@ fn range_delete_left_in_cut_full() {
     expect_delete(&mut mock, addrl1);
 
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -920,8 +921,9 @@ root:
                         end: 3
                       ptr:
                         Addr: 175
-"#);
-    tree.range_delete(4..32, TxgT::from(42)).now_or_never().unwrap().unwrap();
+"#));
+    tree.clone().range_delete(4..32, TxgT::from(42))
+        .now_or_never().unwrap().unwrap();
     assert_eq!(format!("{}", &tree),
 r#"---
 height: 3

--- a/bfffs-core/src/tree/tree/tests/io.rs
+++ b/bfffs-core/src/tree/tree/tests/io.rs
@@ -1170,7 +1170,7 @@ fn remove_and_merge_down() {
         .return_once(move |_, _| future::ok(Box::new(leafnode)).boxed());
 
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -1194,8 +1194,8 @@ root:
               end: 42
             ptr:
               Addr: 0
-"#);
-    let r2 = tree.remove(1, TxgT::from(42)).now_or_never().unwrap();
+"#));
+    let r2 = tree.clone().remove(1, TxgT::from(42)).now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---

--- a/bfffs-core/src/tree/tree/tests/io.rs
+++ b/bfffs-core/src/tree/tree/tests/io.rs
@@ -601,6 +601,7 @@ fn open() {
     let tod = TreeOnDisk(
         InnerOnDisk {
             height: 1,
+            _reserved: Default::default(),
             limits,
             root: root_drp,
             txgs: TxgT(0)..TxgT(42),
@@ -1318,6 +1319,7 @@ fn serialize_inner() {
     let expected = TreeOnDisk(
         InnerOnDisk {
             height: 1,
+            _reserved: Default::default(),
             limits: Limits::new(2, 5, 2, 5),
             root: root_drp,
             txgs: TxgT(0)..TxgT(42),

--- a/bfffs-core/src/tree/tree/tests/io.rs
+++ b/bfffs-core/src/tree/tree/tests/io.rs
@@ -610,8 +610,8 @@ fn open() {
     let mock = DDML::default();
     let ddml = Arc::new(mock);
     let tree = Tree::<DRP, DDML, u32, u32>::open(ddml, false, tod);
-    assert_eq!(tree.i.limits, limits);
-    let root_guard = tree.i.root.try_read().unwrap();
+    assert_eq!(tree.limits, limits);
+    let root_guard = tree.root.try_read().unwrap();
     assert_eq!(root_guard.height, 1);
     assert_eq!(root_guard.elem.key, 0);
     assert_eq!(root_guard.elem.txgs, TxgT::from(0)..TxgT::from(42));
@@ -1125,7 +1125,7 @@ root:
       Addr: 102
   "#);
 
-    let root_guard = tree.i.root.try_read().unwrap();
+    let root_guard = tree.root.try_read().unwrap();
     let r = root_guard.elem.rlock(&dml).map_ok(|node| {
         let int_data = (*node).as_int();
         assert_eq!(int_data.nchildren(), 2);
@@ -1719,7 +1719,7 @@ root:
     assert!(r.is_ok());
     assert!(r.is_ok());
     let tref = Arc::get_mut(&mut tree).unwrap();
-    let root = tref.i.root.get_mut().unwrap();
+    let root = tref.root.get_mut().unwrap();
     assert_eq!(*root.elem.ptr.as_addr(), addr);
     assert_eq!(root.elem.txgs.start, TxgT::from(5));
     assert_eq!(root.elem.txgs.end, TxgT::from(43));
@@ -1766,7 +1766,7 @@ root:
     let r = tree.clone().flush(TxgT::from(42)).now_or_never().unwrap();
     assert!(r.is_ok());
     let tref = Arc::get_mut(&mut tree).unwrap();
-    let root = tref.i.root.get_mut().unwrap();
+    let root = tref.root.get_mut().unwrap();
     assert_eq!(*root.elem.ptr.as_addr(), addr);
     assert_eq!(root.elem.txgs.start, TxgT::from(42));
     assert_eq!(root.elem.txgs.end, TxgT::from(43));

--- a/bfffs-core/src/tree/tree/tests/io.rs
+++ b/bfffs-core/src/tree/tree/tests/io.rs
@@ -80,7 +80,6 @@ fn addresses() {
     let dml = Arc::new(mock);
     let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -88,52 +87,54 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 8
-              end: 9
-            ptr:
-              Addr: 3
-          - key: 10
-            txgs:
-              start: 20
-              end: 32
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 10
-                      txgs:
-                        start: 9
-                        end: 10
-                      ptr:
-                        Addr: 2
-                    - key: 15
-                      txgs:
-                        start: 9
-                        end: 10
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                              17: 17.0
-          # This  Node is not returned due to its TXG range
-          - key: 20
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Addr: 4
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 8
+                end: 9
+              ptr:
+                Addr: 3
+            - key: 10
+              txgs:
+                start: 20
+                end: 32
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 10
+                        txgs:
+                          start: 9
+                          end: 10
+                        ptr:
+                          Addr: 2
+                      - key: 15
+                        txgs:
+                          start: 9
+                          end: 10
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                                17: 17.0
+            # This  Node is not returned due to its TXG range
+            - key: 20
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Addr: 4
 "#);
     let mut rt = basic_runtime();
     let addrs = rt.block_on(async {
@@ -152,7 +153,6 @@ fn addresses_leaf() {
     let dml = Arc::new(mock);
     let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -160,12 +160,14 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Addr: 0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Addr: 0"#);
     let mut rt = basic_runtime();
     let addrs = rt.block_on(async {
         tree.addresses(..)
@@ -234,7 +236,6 @@ fn dump() {
     let dml = Arc::new(mock);
     let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -242,55 +243,56 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 8
-              end: 9
-            ptr:
-              Addr: 3
-          - key: 10
-            txgs:
-              start: 20
-              end: 32
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 10
-                      txgs:
-                        start: 9
-                        end: 10
-                      ptr:
-                        Addr: 2
-                    - key: 15
-                      txgs:
-                        start: 9
-                        end: 10
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                              17: 17.0
-          - key: 20
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Addr: 4
-"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 8
+                end: 9
+              ptr:
+                Addr: 3
+            - key: 10
+              txgs:
+                start: 20
+                end: 32
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 10
+                        txgs:
+                          start: 9
+                          end: 10
+                        ptr:
+                          Addr: 2
+                      - key: 15
+                        txgs:
+                          start: 9
+                          end: 10
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                                17: 17.0
+            - key: 20
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Addr: 4
+  "#);
 let expected =
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -298,51 +300,53 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 8
-              end: 9
-            ptr:
-              Addr: 3
-          - key: 10
-            txgs:
-              start: 20
-              end: 32
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 10
-                      txgs:
-                        start: 9
-                        end: 10
-                      ptr:
-                        Addr: 2
-                    - key: 15
-                      txgs:
-                        start: 9
-                        end: 10
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                              17: 17.0
-          - key: 20
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Addr: 4
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 8
+                end: 9
+              ptr:
+                Addr: 3
+            - key: 10
+              txgs:
+                start: 20
+                end: 32
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 10
+                        txgs:
+                          start: 9
+                          end: 10
+                        ptr:
+                          Addr: 2
+                      - key: 15
+                        txgs:
+                          start: 9
+                          end: 10
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                                17: 17.0
+            - key: 20
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Addr: 4
 ---
 0:
   Leaf:
@@ -424,7 +428,6 @@ fn insert_below_root() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -432,33 +435,34 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 0
-          - key: 256
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 256
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 0
+            - key: 256
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 256
+  "#));
 
     let r = tree.clone().insert(0, 0, TxgT::from(42)).now_or_never().unwrap();
     assert_eq!(r, Ok(None));
     assert_eq!(format!("{}", tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -466,29 +470,31 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0
-          - key: 256
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 256"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0
+            - key: 256
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 256"#);
 }
 
 /// Insert an item into a Tree that's not dirty
@@ -506,7 +512,6 @@ fn insert_root() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -514,19 +519,20 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Addr: 0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Addr: 0
+  "#));
 
     let r = tree.clone().insert(0, 0, TxgT::from(42)).now_or_never().unwrap();
     assert_eq!(r, Ok(None));
     assert_eq!(format!("{}", tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -534,15 +540,17 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 42
-    end: 43
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 42
+      end: 43
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0"#);
 }
 
 #[test]
@@ -559,7 +567,6 @@ fn is_dirty() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -567,13 +574,15 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Addr: 0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Addr: 0
+  "#));
 
     assert!(!tree.is_dirty());
     tree.clone().insert(0, 0, TxgT::from(42)).now_or_never().unwrap().unwrap();
@@ -600,12 +609,12 @@ fn open() {
     let mock = DDML::default();
     let ddml = Arc::new(mock);
     let tree = Tree::<DRP, DDML, u32, u32>::open(ddml, false, tod);
-    assert_eq!(tree.i.height.load(Ordering::Relaxed), 1);
     assert_eq!(tree.i.limits, limits);
-    let root_elem_guard = tree.i.root.try_read().unwrap();
-    assert_eq!(root_elem_guard.key, 0);
-    assert_eq!(root_elem_guard.txgs, TxgT::from(0)..TxgT::from(42));
-    let drp = root_elem_guard.ptr.as_addr();
+    let root_guard = tree.i.root.try_read().unwrap();
+    assert_eq!(root_guard.height, 1);
+    assert_eq!(root_guard.elem.key, 0);
+    assert_eq!(root_guard.elem.txgs, TxgT::from(0)..TxgT::from(42));
+    let drp = root_guard.elem.ptr.as_addr();
     assert_eq!(*drp, root_drp);
 }
 
@@ -678,7 +687,6 @@ fn range_delete() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -686,38 +694,39 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 8
-              end: 9
-            ptr:
-              Addr: 0
-          - key: 10
-            txgs:
-              start: 20
-              end: 32
-            ptr:
-              Addr: 1
-          - key: 20
-            txgs:
-              start: 8
-              end: 24
-            ptr:
-              Addr: 2
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 8
+                end: 9
+              ptr:
+                Addr: 0
+            - key: 10
+              txgs:
+                start: 20
+                end: 32
+              ptr:
+                Addr: 1
+            - key: 20
+              txgs:
+                start: 8
+                end: 24
+              ptr:
+                Addr: 2
+  "#));
     tree.clone().range_delete(5..25, TxgT::from(42))
         .now_or_never().unwrap().unwrap();
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -725,70 +734,72 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 10
-                    - key: 1
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 11
-          - key: 3
-            txgs:
-              start: 0
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 3
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              3: 3.0
-                              4: 4.0
-                    - key: 26
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 31
-                    - key: 29
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 32
-                    - key: 30
-                      txgs:
-                        start: 0
-                        end: 1
-                      ptr:
-                        Addr: 33"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 10
+                      - key: 1
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 11
+            - key: 3
+              txgs:
+                start: 0
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 3
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                3: 3.0
+                                4: 4.0
+                      - key: 26
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 31
+                      - key: 29
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 32
+                      - key: 30
+                        txgs:
+                          start: 0
+                          end: 1
+                        ptr:
+                          Addr: 33"#);
 }
 
 /// Regression test for bug 2d045899e991a7cf977303abb565c09cf8c34b2f
@@ -813,7 +824,6 @@ fn range_delete_left_in_cut_full() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -821,112 +831,113 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 3
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 3
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 81
-                    - key: 22
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Addr: 94
-                    - key: 25
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              25: 21
-                              31: 27
-                              32: 16
-                    - key: 33
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              33: 17
-                              34: 18
-                              35: 19
-                    - key: 37
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              37: 17
-                              38: 18
-                              39: 19
-          - key: 46
-            txgs:
-              start: 1
-              end: 3
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 46
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              46: 20
-                              47: 21
-                              48: 27
-                              77: 33
-                              78: 34
-                    - key: 69
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 84
-                    - key: 72
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Addr: 172
-                    - key: 75
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Addr: 175
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 3
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 3
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 81
+                      - key: 22
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Addr: 94
+                      - key: 25
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                25: 21
+                                31: 27
+                                32: 16
+                      - key: 33
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                33: 17
+                                34: 18
+                                35: 19
+                      - key: 37
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                37: 17
+                                38: 18
+                                39: 19
+            - key: 46
+              txgs:
+                start: 1
+                end: 3
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 46
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                46: 20
+                                47: 21
+                                48: 27
+                                77: 33
+                                78: 34
+                      - key: 69
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 84
+                      - key: 72
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Addr: 172
+                      - key: 75
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Addr: 175
+  "#));
     tree.clone().range_delete(4..32, TxgT::from(42))
         .now_or_never().unwrap().unwrap();
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -934,84 +945,86 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 2
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 25
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              32: 16.0
-                              33: 17.0
-                              34: 18.0
-                              35: 19.0
-                    - key: 37
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              37: 17.0
-                              38: 18.0
-                              39: 19.0
-                    - key: 46
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              46: 20.0
-                              47: 21.0
-                              48: 27.0
-                              77: 33.0
-                              78: 34.0
-          - key: 69
-            txgs:
-              start: 1
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 69
-                      txgs:
-                        start: 1
-                        end: 2
-                      ptr:
-                        Addr: 84
-                    - key: 72
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Addr: 172
-                    - key: 75
-                      txgs:
-                        start: 2
-                        end: 3
-                      ptr:
-                        Addr: 175"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 2
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 25
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                32: 16.0
+                                33: 17.0
+                                34: 18.0
+                                35: 19.0
+                      - key: 37
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                37: 17.0
+                                38: 18.0
+                                39: 19.0
+                      - key: 46
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                46: 20.0
+                                47: 21.0
+                                48: 27.0
+                                77: 33.0
+                                78: 34.0
+            - key: 69
+              txgs:
+                start: 1
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 69
+                        txgs:
+                          start: 1
+                          end: 2
+                        ptr:
+                          Addr: 84
+                      - key: 72
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Addr: 172
+                      - key: 75
+                        txgs:
+                          start: 2
+                          end: 3
+                        ptr:
+                          Addr: 175"#);
 }
 
 #[test]
@@ -1047,7 +1060,6 @@ fn range_leaf() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1055,13 +1067,15 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Addr: 0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Addr: 0
+  "#));
     let mut rt = basic_runtime();
     let r = rt.block_on(async {
         tree.range(1..3)
@@ -1093,7 +1107,6 @@ fn read_int() {
     let tree: Tree<u32, MockDML, u32, u32> =
         Tree::from_str(dml.clone(), false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1101,16 +1114,18 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Addr: 102
-"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Addr: 102
+  "#);
 
     let root_guard = tree.i.root.try_read().unwrap();
-    let r = root_guard.rlock(&dml).map_ok(|node| {
+    let r = root_guard.elem.rlock(&dml).map_ok(|node| {
         let int_data = (*node).as_int();
         assert_eq!(int_data.nchildren(), 2);
         // Validate IntElems as well as possible using their public API
@@ -1136,7 +1151,6 @@ fn read_leaf() {
     let dml = Arc::new(mock);
     let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1144,13 +1158,15 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Addr: 0
-"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Addr: 0
+  "#);
 
     let r = tree.get(1).now_or_never().unwrap();
     assert_eq!(Ok(Some(200)), r);
@@ -1174,7 +1190,6 @@ fn remove_and_merge_down() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1182,26 +1197,27 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 0
+  "#));
     let r2 = tree.clone().remove(1, TxgT::from(42)).now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1209,17 +1225,19 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          3: 3.0
-          4: 4.0
-          5: 5.0"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            3: 3.0
+            4: 4.0
+            5: 5.0"#);
 }
 
 // This test mimics what the IDML does with the alloc_t
@@ -1230,7 +1248,6 @@ fn serialize_alloc_t() {
     let typical_tree: Tree<DRP, DDML, PBA, RID> =
         Tree::from_str(idml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1238,22 +1255,24 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key:
-    cluster: 0
-    lba: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Addr:
-      pba:
-        cluster: 2
-        lba: 0x0102030405060708
-      compressed: true
-      lsize: 78
-      csize: 36
-      checksum: 0x0807060504030201
-"#);
+  height: 1
+  elem:
+    key:
+      cluster: 0
+      lba: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Addr:
+        pba:
+          cluster: 2
+          lba: 0x0102030405060708
+        compressed: true
+        lsize: 78
+        csize: 36
+        checksum: 0x0807060504030201
+  "#);
     let typical_tod = typical_tree.serialize().unwrap();
     assert_eq!(TreeOnDisk::<DRP>::TYPICAL_SIZE,
                bincode::serialized_size(&typical_tod).unwrap() as usize);
@@ -1267,7 +1286,6 @@ fn serialize_forest() {
     let typical_tree: Tree<RID, IDML, FSKey, FSValue<RID>> =
         Tree::from_str(idml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1275,14 +1293,16 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Addr:
-      1
-"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Addr:
+        1
+  "#);
 
     let typical_tod = typical_tree.serialize().unwrap();
     assert_eq!(TreeOnDisk::<RID>::TYPICAL_SIZE,
@@ -1307,7 +1327,6 @@ fn serialize_inner() {
     let ddml = Arc::new(mock);
     let tree: Tree<DRP, DDML, u32, u32> = Tree::from_str(ddml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1315,20 +1334,22 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Addr:
-      pba:
-        cluster: 2
-        lba: 0x0102030405060708
-      compressed: true
-      lsize: 78
-      csize: 36
-      checksum: 0x0807060504030201
-"#);
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Addr:
+        pba:
+          cluster: 2
+          lba: 0x0102030405060708
+        compressed: true
+        lsize: 78
+        csize: 36
+        checksum: 0x0807060504030201
+  "#);
 
     assert_eq!(expected, tree.serialize().unwrap())
 }
@@ -1339,7 +1360,6 @@ fn write_clean() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1347,13 +1367,15 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Addr: 0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Addr: 0
+  "#));
 
     let r = tree.flush(TxgT::from(42)).now_or_never().unwrap();
     assert!(r.is_ok());
@@ -1397,7 +1419,6 @@ fn write_height2() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1405,38 +1426,39 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 30
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 100
-                    1: 200
-          - key: 256
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Addr: 256
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 30
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 100
+                      1: 200
+            - key: 256
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Addr: 256
+  "#));
 
     let r = tree.clone().flush(TxgT::from(42)).now_or_never().unwrap();
     assert!(r.is_ok());
 
     assert_eq!(format!("{}", tree),
 r#"---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1444,12 +1466,14 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 43
-  ptr:
-    Addr: 101"#);
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 43
+    ptr:
+      Addr: 101"#);
 }
 
 /// Sync a Tree with dirty nodes at all levels, with a height of 3.
@@ -1533,7 +1557,6 @@ fn write_height3() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1541,87 +1564,88 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 5
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 10
-                      txgs:
-                        start: 9
-                        end: 10
-                      ptr:
-                        Addr: 2
-                    - key: 15
-                      txgs:
-                        start: 9
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              15: 15.0
-                              16: 16.0
-                    - key: 20
-                      txgs:
-                        start: 5
-                        end: 7
-                      ptr:
-                        Addr: 3
-          - key: 30
-            txgs:
-              start: 20
-              end: 32
-            ptr:
-              Addr: 4
-          - key: 40
-            txgs:
-              start: 7
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 40
-                      txgs:
-                        start: 9
-                        end: 10
-                      ptr:
-                        Addr: 5
-                    - key: 50
-                      txgs:
-                        start: 11
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              50: 50.0
-                              51: 51.0
-                    - key: 60
-                      txgs:
-                        start: 7
-                        end: 8
-                      ptr:
-                        Addr: 6
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 5
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 10
+                        txgs:
+                          start: 9
+                          end: 10
+                        ptr:
+                          Addr: 2
+                      - key: 15
+                        txgs:
+                          start: 9
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                15: 15.0
+                                16: 16.0
+                      - key: 20
+                        txgs:
+                          start: 5
+                          end: 7
+                        ptr:
+                          Addr: 3
+            - key: 30
+              txgs:
+                start: 20
+                end: 32
+              ptr:
+                Addr: 4
+            - key: 40
+              txgs:
+                start: 7
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 40
+                        txgs:
+                          start: 9
+                          end: 10
+                        ptr:
+                          Addr: 5
+                      - key: 50
+                        txgs:
+                          start: 11
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                50: 50.0
+                                51: 51.0
+                      - key: 60
+                        txgs:
+                          start: 7
+                          end: 8
+                        ptr:
+                          Addr: 6
+  "#));
 
     let r = tree.clone().flush(TxgT::from(42)).now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1629,12 +1653,14 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 5
-    end: 43
-  ptr:
-    Addr: 11"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 5
+      end: 43
+    ptr:
+      Addr: 11"#);
 }
 
 #[test]
@@ -1656,7 +1682,6 @@ fn write_int() {
     let mut tree = Arc::new(
         Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1664,27 +1689,29 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 5
-    end: 25
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 5
-              end: 15
-            ptr:
-              Addr: 0
-          - key: 256
-            txgs:
-              start: 18
-              end: 25
-            ptr:
-              Addr: 256
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 5
+      end: 25
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 5
+                end: 15
+              ptr:
+                Addr: 0
+            - key: 256
+              txgs:
+                start: 18
+                end: 25
+              ptr:
+                Addr: 256
+  "#));
 
     let r = tree.clone().flush(TxgT::from(42)).now_or_never().unwrap();
     assert!(r.is_ok());
@@ -1692,9 +1719,9 @@ root:
     let tref = Arc::get_mut(&mut tree).unwrap();
     let root = Arc::get_mut(&mut tref.i).unwrap()
         .root.get_mut().unwrap();
-    assert_eq!(*root.ptr.as_addr(), addr);
-    assert_eq!(root.txgs.start, TxgT::from(5));
-    assert_eq!(root.txgs.end, TxgT::from(43));
+    assert_eq!(*root.elem.ptr.as_addr(), addr);
+    assert_eq!(root.elem.txgs.start, TxgT::from(5));
+    assert_eq!(root.elem.txgs.end, TxgT::from(43));
 }
 
 #[test]
@@ -1714,7 +1741,6 @@ fn write_leaf() {
     let mut tree = Arc::new(
         Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1722,26 +1748,28 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 1
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 100
-          1: 200
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 1
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 100
+            1: 200
+  "#));
 
     let r = tree.clone().flush(TxgT::from(42)).now_or_never().unwrap();
     assert!(r.is_ok());
     let tref = Arc::get_mut(&mut tree).unwrap();
     let root = Arc::get_mut(&mut tref.i).unwrap()
         .root.get_mut().unwrap();
-    assert_eq!(*root.ptr.as_addr(), addr);
-    assert_eq!(root.txgs.start, TxgT::from(42));
-    assert_eq!(root.txgs.end, TxgT::from(43));
+    assert_eq!(*root.elem.ptr.as_addr(), addr);
+    assert_eq!(root.elem.txgs.start, TxgT::from(42));
+    assert_eq!(root.elem.txgs.end, TxgT::from(43));
 }
 
 /// While flushing a Tree, another task dirties a previously-flushed node.
@@ -1820,7 +1848,6 @@ fn write_race() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1828,87 +1855,89 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 30
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 5
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Addr: 0
-          - key: 10
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 10
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              10: 10.0
-                              11: 11.0
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1
-          - key: 20
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 20
-                      txgs:
-                        start: 41
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              20: 20.0
-                              21: 21.0
-                    - key: 25
-                      txgs:
-                        start: 40
-                        end: 41
-                      ptr:
-                        Addr: 2
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 30
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 5
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Addr: 0
+            - key: 10
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 10
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                10: 10.0
+                                11: 11.0
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1
+            - key: 20
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 20
+                        txgs:
+                          start: 41
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                20: 20.0
+                                21: 21.0
+                      - key: 25
+                        txgs:
+                          start: 40
+                          end: 41
+                        ptr:
+                          Addr: 2
+  "#));
     *otree.write().unwrap() = Some(tree);
     let guard = otree.read().unwrap();
     let tref = guard.as_ref().unwrap();
@@ -1918,7 +1947,6 @@ root:
 
     assert_eq!(format!("{}", tref),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1926,79 +1954,81 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 30
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                              2: 2.0
-                    - key: 5
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Addr: 0
-          - key: 10
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 10
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Addr: 70
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 1
-          - key: 20
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 20
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Addr: 71
-                    - key: 25
-                      txgs:
-                        start: 40
-                        end: 41
-                      ptr:
-                        Addr: 2"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 30
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                                2: 2.0
+                      - key: 5
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Addr: 0
+            - key: 10
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 10
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Addr: 70
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 1
+            - key: 20
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 20
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Addr: 71
+                      - key: 25
+                        txgs:
+                          start: 40
+                          end: 41
+                        ptr:
+                          Addr: 2"#);
 }
 
 // LCOV_EXCL_STOP

--- a/bfffs-core/src/tree/tree/tests/io.rs
+++ b/bfffs-core/src/tree/tree/tests/io.rs
@@ -1043,7 +1043,7 @@ fn range_leaf() {
             fut.boxed()
         });
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 1
 limits:
@@ -1059,7 +1059,7 @@ root:
     end: 42
   ptr:
     Addr: 0
-"#);
+"#));
     let mut rt = basic_runtime();
     let r = rt.block_on(async {
         tree.range(1..3)

--- a/bfffs-core/src/tree/tree/tests/io.rs
+++ b/bfffs-core/src/tree/tree/tests/io.rs
@@ -1719,8 +1719,7 @@ root:
     assert!(r.is_ok());
     assert!(r.is_ok());
     let tref = Arc::get_mut(&mut tree).unwrap();
-    let root = Arc::get_mut(&mut tref.i).unwrap()
-        .root.get_mut().unwrap();
+    let root = tref.i.root.get_mut().unwrap();
     assert_eq!(*root.elem.ptr.as_addr(), addr);
     assert_eq!(root.elem.txgs.start, TxgT::from(5));
     assert_eq!(root.elem.txgs.end, TxgT::from(43));
@@ -1767,8 +1766,7 @@ root:
     let r = tree.clone().flush(TxgT::from(42)).now_or_never().unwrap();
     assert!(r.is_ok());
     let tref = Arc::get_mut(&mut tree).unwrap();
-    let root = Arc::get_mut(&mut tref.i).unwrap()
-        .root.get_mut().unwrap();
+    let root = tref.i.root.get_mut().unwrap();
     assert_eq!(*root.elem.ptr.as_addr(), addr);
     assert_eq!(root.elem.txgs.start, TxgT::from(42));
     assert_eq!(root.elem.txgs.end, TxgT::from(43));

--- a/bfffs-core/src/tree/tree/tests/txg.rs
+++ b/bfffs-core/src/tree/tree/tests/txg.rs
@@ -11,7 +11,7 @@ use super::*;
 fn check_bad_root_txgs() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -49,7 +49,7 @@ root:
                   items:
                     256: 256.0
                     257: 257.0
-"#);
+"#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -60,7 +60,7 @@ root:
 fn check_bad_int_txgs() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -134,7 +134,7 @@ root:
                             items:
                               12: 12.0
                               13: 13.0
-"#);
+"#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -145,7 +145,7 @@ root:
 fn check_bad_key() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -183,7 +183,7 @@ root:
                   items:
                     13: 13.0
                     14: 14.0
-"#);
+"#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -194,7 +194,7 @@ root:
 fn check_ok() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -271,7 +271,7 @@ root:
                             items:
                               12: 12.0
                               13: 13.0
-"#);
+"#));
 
     assert!(tree.check()
             .now_or_never().unwrap()
@@ -282,7 +282,9 @@ root:
 fn check_empty() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::create(dml, false, 1.0, 1.0);
+    let tree = Arc::new(
+        Tree::<u32, MockDML, u32, f32>::create(dml, false, 1.0, 1.0)
+    );
 
     assert!(tree.check()
             .now_or_never().unwrap()
@@ -293,7 +295,7 @@ fn check_empty() {
 fn check_leaf_underflow() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -330,7 +332,7 @@ root:
                   items:
                     13: 13.0
                     14: 14.0
-"#);
+"#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -342,7 +344,7 @@ root:
 fn check_root_int_underflow() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -384,7 +386,7 @@ root:
                     21: 21.0
                     22: 22.0
                     23: 23.0
-"#);
+"#));
 
     assert!(tree.check()
             .now_or_never().unwrap()
@@ -396,7 +398,7 @@ root:
 fn check_root_leaf_ok() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 1
 limits:
@@ -415,7 +417,7 @@ root:
       Leaf:
         items:
           0: 0.0
-"#);
+"#));
 
     assert!(tree.check()
             .now_or_never().unwrap()
@@ -426,7 +428,7 @@ root:
 fn check_root_leaf_overflow() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 1
 limits:
@@ -450,7 +452,7 @@ root:
           3: 3.0
           4: 4.0
           5: 5.0
-"#);
+"#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -462,7 +464,7 @@ root:
 fn check_unsorted() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -501,7 +503,7 @@ root:
                     5: 5.0
                     6: 6.0
                     11: 11.0
-"#);
+"#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()

--- a/bfffs-core/src/tree/tree/tests/txg.rs
+++ b/bfffs-core/src/tree/tree/tests/txg.rs
@@ -681,7 +681,7 @@ fn split() {
         .with(eq(addrl), eq(TxgT::from(42)))
         .return_once(move |_, _| Box::pin(future::ok(Box::new(node))));
     let dml = Arc::new(mock);
-    let tree = Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 2
 limits:
@@ -729,8 +729,8 @@ root:
               end: 34
             ptr:
               Addr: 1280
-"#);
-    let r2 = tree.insert(15, 15.0, TxgT::from(42))
+"#));
+    let r2 = tree.clone().insert(15, 15.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),

--- a/bfffs-core/src/tree/tree/tests/txg.rs
+++ b/bfffs-core/src/tree/tree/tests/txg.rs
@@ -13,7 +13,6 @@ fn check_bad_root_txgs() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -21,35 +20,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 42
-              end: 43
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 1.0
-                    1: 2.0
-          - key: 256
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    256: 256.0
-                    257: 257.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 42
+                end: 43
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 1.0
+                      1: 2.0
+            - key: 256
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      256: 256.0
+                      257: 257.0
+  "#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -62,7 +63,6 @@ fn check_bad_int_txgs() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -70,71 +70,73 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 20
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 30
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 30
-                        end: 31
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 1.0
-                              1: 2.0
-                    - key: 2
-                      txgs:
-                        start: 31
-                        end: 32
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2: 3.0
-                              3: 4.0
-          - key: 9
-            txgs:
-              start: 21
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              9: 9.0
-                              10: 10.0
-                    - key: 12
-                      txgs:
-                        start: 20
-                        end: 21
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 20
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 30
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 30
+                          end: 31
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 1.0
+                                1: 2.0
+                      - key: 2
+                        txgs:
+                          start: 31
+                          end: 32
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2: 3.0
+                                3: 4.0
+            - key: 9
+              txgs:
+                start: 21
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                9: 9.0
+                                10: 10.0
+                      - key: 12
+                        txgs:
+                          start: 20
+                          end: 21
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+  "#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -147,7 +149,6 @@ fn check_bad_key() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -155,35 +156,37 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 11
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-          - key: 13
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    13: 13.0
-                    14: 14.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 11
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+            - key: 13
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      13: 13.0
+                      14: 14.0
+  "#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -196,7 +199,6 @@ fn check_ok() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -204,74 +206,76 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 20
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 30
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 30
-                        end: 31
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              0: 0.0
-                              1: 1.0
-                    - key: 2
-                      txgs:
-                        start: 31
-                        end: 32
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2: 2.0
-                              3: 3.0
-                              4: 4.0
-                              5: 5.0
-                              6: 6.0
-          - key: 9
-            txgs:
-              start: 20
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              10: 10.0
-                              11: 11.0
-                    - key: 12
-                      txgs:
-                        start: 20
-                        end: 21
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 20
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 30
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 30
+                          end: 31
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                0: 0.0
+                                1: 1.0
+                      - key: 2
+                        txgs:
+                          start: 31
+                          end: 32
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2: 2.0
+                                3: 3.0
+                                4: 4.0
+                                5: 5.0
+                                6: 6.0
+            - key: 9
+              txgs:
+                start: 20
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                10: 10.0
+                                11: 11.0
+                      - key: 12
+                        txgs:
+                          start: 20
+                          end: 21
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+  "#));
 
     assert!(tree.check()
             .now_or_never().unwrap()
@@ -297,7 +301,6 @@ fn check_leaf_underflow() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -305,34 +308,36 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 9
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-          - key: 13
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    13: 13.0
-                    14: 14.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 9
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+            - key: 13
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      13: 13.0
+                      14: 14.0
+  "#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -346,7 +351,6 @@ fn check_root_int_underflow() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -354,39 +358,41 @@ limits:
   max_leaf_fanout: 7
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 41
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 9
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    10: 10.0
-                    11: 11.0
-                    12: 12.0
-                    13: 13.0
-          - key: 19
-            txgs:
-              start: 41
-              end: 42
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    20: 20.0
-                    21: 21.0
-                    22: 22.0
-                    23: 23.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 41
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 9
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+                      13: 13.0
+            - key: 19
+              txgs:
+                start: 41
+                end: 42
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+                      23: 23.0
+  "#));
 
     assert!(tree.check()
             .now_or_never().unwrap()
@@ -400,7 +406,6 @@ fn check_root_leaf_ok() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -408,16 +413,18 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 1
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 1
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
+  "#));
 
     assert!(tree.check()
             .now_or_never().unwrap()
@@ -430,7 +437,6 @@ fn check_root_leaf_overflow() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 1
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -438,21 +444,23 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 1
-  ptr:
-    Mem:
-      Leaf:
-        items:
-          0: 0.0
-          1: 1.0
-          2: 2.0
-          3: 3.0
-          4: 4.0
-          5: 5.0
-"#));
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 1
+    ptr:
+      Mem:
+        Leaf:
+          items:
+            0: 0.0
+            1: 1.0
+            2: 2.0
+            3: 3.0
+            4: 4.0
+            5: 5.0
+  "#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -466,7 +474,6 @@ fn check_unsorted() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -474,36 +481,38 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 0
-    end: 1
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    0: 0.0
-                    10: 10.0
-          - key: 5
-            txgs:
-              start: 0
-              end: 1
-            ptr:
-              Mem:
-                Leaf:
-                  items:
-                    5: 5.0
-                    6: 6.0
-                    11: 11.0
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 1
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      0: 0.0
+                      10: 10.0
+            - key: 5
+              txgs:
+                start: 0
+                end: 1
+              ptr:
+                Mem:
+                  Leaf:
+                    items:
+                      5: 5.0
+                      6: 6.0
+                      11: 11.0
+  "#));
 
     assert!(!tree.check()
             .now_or_never().unwrap()
@@ -527,7 +536,6 @@ fn merge() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -535,72 +543,73 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 20
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 30
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 30
-                        end: 31
-                      ptr:
-                        Addr: 1
-                    - key: 2
-                      txgs:
-                        start: 31
-                        end: 32
-                      ptr:
-                        Addr: 2
-          - key: 9
-            txgs:
-              start: 20
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 3
-                    - key: 12
-                      txgs:
-                        start: 20
-                        end: 21
-                      ptr:
-                        Addr: 4
-                    - key: 15
-                      txgs:
-                        start: 24
-                        end: 25
-                      ptr:
-                        Addr: 5
-          - key: 18
-            txgs:
-              start: 15
-              end: 16
-            ptr:
-              Addr: 6"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 20
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 30
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 30
+                          end: 31
+                        ptr:
+                          Addr: 1
+                      - key: 2
+                        txgs:
+                          start: 31
+                          end: 32
+                        ptr:
+                          Addr: 2
+            - key: 9
+              txgs:
+                start: 20
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 3
+                      - key: 12
+                        txgs:
+                          start: 20
+                          end: 21
+                        ptr:
+                          Addr: 4
+                      - key: 15
+                        txgs:
+                          start: 24
+                          end: 25
+                        ptr:
+                          Addr: 5
+            - key: 18
+              txgs:
+                start: 15
+                end: 16
+              ptr:
+                Addr: 6"#));
     let r2 = tree.clone().remove(4, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -608,62 +617,64 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 20
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 20
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 30
-                        end: 31
-                      ptr:
-                        Addr: 1
-                    - key: 2
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              2: 2.0
-                              3: 3.0
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 3
-                    - key: 12
-                      txgs:
-                        start: 20
-                        end: 21
-                      ptr:
-                        Addr: 4
-                    - key: 15
-                      txgs:
-                        start: 24
-                        end: 25
-                      ptr:
-                        Addr: 5
-          - key: 18
-            txgs:
-              start: 15
-              end: 16
-            ptr:
-              Addr: 6"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 20
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 20
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 30
+                          end: 31
+                        ptr:
+                          Addr: 1
+                      - key: 2
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                2: 2.0
+                                3: 3.0
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 3
+                      - key: 12
+                        txgs:
+                          start: 20
+                          end: 21
+                        ptr:
+                          Addr: 4
+                      - key: 15
+                        txgs:
+                          start: 24
+                          end: 25
+                        ptr:
+                          Addr: 5
+            - key: 18
+              txgs:
+                start: 15
+                end: 16
+              ptr:
+                Addr: 6"#);
 }
 
 /// Insert a key that splits the root IntNode
@@ -683,7 +694,6 @@ fn split() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 2
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -691,51 +701,52 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 3
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 4
-              end: 10
-            ptr:
-              Addr: 256
-          - key: 3
-            txgs:
-              start: 5
-              end: 11
-            ptr:
-              Addr: 512
-          - key: 6
-            txgs:
-              start: 3
-              end: 12
-            ptr:
-              Addr: 768
-          - key: 9
-            txgs:
-              start: 6
-              end: 22
-            ptr:
-              Addr: 1024
-          - key: 12
-            txgs:
-              start: 7
-              end: 34
-            ptr:
-              Addr: 1280
-"#));
+  height: 2
+  elem:
+    key: 0
+    txgs:
+      start: 3
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 4
+                end: 10
+              ptr:
+                Addr: 256
+            - key: 3
+              txgs:
+                start: 5
+                end: 11
+              ptr:
+                Addr: 512
+            - key: 6
+              txgs:
+                start: 3
+                end: 12
+              ptr:
+                Addr: 768
+            - key: 9
+              txgs:
+                start: 6
+                end: 22
+              ptr:
+                Addr: 1024
+            - key: 12
+              txgs:
+                start: 7
+                end: 34
+              ptr:
+                Addr: 1280
+  "#));
     let r2 = tree.clone().insert(15, 15.0, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -743,66 +754,68 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 3
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 3
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 0
-                      txgs:
-                        start: 4
-                        end: 10
-                      ptr:
-                        Addr: 256
-                    - key: 3
-                      txgs:
-                        start: 5
-                        end: 11
-                      ptr:
-                        Addr: 512
-                    - key: 6
-                      txgs:
-                        start: 3
-                        end: 12
-                      ptr:
-                        Addr: 768
-          - key: 9
-            txgs:
-              start: 6
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 6
-                        end: 22
-                      ptr:
-                        Addr: 1024
-                    - key: 12
-                      txgs:
-                        start: 42
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              12: 12.0
-                              13: 13.0
-                              14: 14.0
-                              15: 15.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 3
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 3
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 0
+                        txgs:
+                          start: 4
+                          end: 10
+                        ptr:
+                          Addr: 256
+                      - key: 3
+                        txgs:
+                          start: 5
+                          end: 11
+                        ptr:
+                          Addr: 512
+                      - key: 6
+                        txgs:
+                          start: 3
+                          end: 12
+                        ptr:
+                          Addr: 768
+            - key: 9
+              txgs:
+                start: 6
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 6
+                          end: 22
+                        ptr:
+                          Addr: 1024
+                      - key: 12
+                        txgs:
+                          start: 42
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                12: 12.0
+                                13: 13.0
+                                14: 14.0
+                                15: 15.0"#);
 }
 
 /// Recompute TXG ranges after stealing keys
@@ -812,7 +825,6 @@ fn steal() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -820,89 +832,90 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 10
-    end: 42
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 10
-              end: 11
-            ptr:
-              Addr: 0
-          - key: 9
-            txgs:
-              start: 21
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 9
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 12
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 15
-                    - key: 17
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 17
-                    - key: 19
-                      txgs:
-                        start: 21
-                        end: 22
-                      ptr:
-                        Addr: 19
-          - key: 21
-            txgs:
-              start: 39
-              end: 42
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 21
-                      txgs:
-                        start: 39
-                        end: 40
-                      ptr:
-                        Addr: 21
-                    - key: 24
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              24: 24.0
-                              25: 25.0
-                              26: 26.0"#));
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 10
+      end: 42
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 10
+                end: 11
+              ptr:
+                Addr: 0
+            - key: 9
+              txgs:
+                start: 21
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 9
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 12
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 15
+                      - key: 17
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 17
+                      - key: 19
+                        txgs:
+                          start: 21
+                          end: 22
+                        ptr:
+                          Addr: 19
+            - key: 21
+              txgs:
+                start: 39
+                end: 42
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 21
+                        txgs:
+                          start: 39
+                          end: 40
+                        ptr:
+                          Addr: 21
+                      - key: 24
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                24: 24.0
+                                25: 25.0
+                                26: 26.0"#));
     let r2 = tree.clone().remove(26, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
 r#"---
-height: 3
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -910,82 +923,84 @@ limits:
   max_leaf_fanout: 5
   _max_size: 4194304
 root:
-  key: 0
-  txgs:
-    start: 10
-    end: 43
-  ptr:
-    Mem:
-      Int:
-        children:
-          - key: 0
-            txgs:
-              start: 10
-              end: 11
-            ptr:
-              Addr: 0
-          - key: 9
-            txgs:
-              start: 41
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 9
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 9
-                    - key: 12
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 12
-                    - key: 15
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 15
-                    - key: 17
-                      txgs:
-                        start: 41
-                        end: 42
-                      ptr:
-                        Addr: 17
-          - key: 19
-            txgs:
-              start: 21
-              end: 43
-            ptr:
-              Mem:
-                Int:
-                  children:
-                    - key: 19
-                      txgs:
-                        start: 21
-                        end: 22
-                      ptr:
-                        Addr: 19
-                    - key: 21
-                      txgs:
-                        start: 39
-                        end: 40
-                      ptr:
-                        Addr: 21
-                    - key: 24
-                      txgs:
-                        start: 41
-                        end: 43
-                      ptr:
-                        Mem:
-                          Leaf:
-                            items:
-                              24: 24.0
-                              25: 25.0"#);
+  height: 3
+  elem:
+    key: 0
+    txgs:
+      start: 10
+      end: 43
+    ptr:
+      Mem:
+        Int:
+          children:
+            - key: 0
+              txgs:
+                start: 10
+                end: 11
+              ptr:
+                Addr: 0
+            - key: 9
+              txgs:
+                start: 41
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 9
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 9
+                      - key: 12
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 12
+                      - key: 15
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 15
+                      - key: 17
+                        txgs:
+                          start: 41
+                          end: 42
+                        ptr:
+                          Addr: 17
+            - key: 19
+              txgs:
+                start: 21
+                end: 43
+              ptr:
+                Mem:
+                  Int:
+                    children:
+                      - key: 19
+                        txgs:
+                          start: 21
+                          end: 22
+                        ptr:
+                          Addr: 19
+                      - key: 21
+                        txgs:
+                          start: 39
+                          end: 40
+                        ptr:
+                          Addr: 21
+                      - key: 24
+                        txgs:
+                          start: 41
+                          end: 43
+                        ptr:
+                          Mem:
+                            Leaf:
+                              items:
+                                24: 24.0
+                                25: 25.0"#);
 }
 
 // LCOV_EXCL_STOP

--- a/bfffs-core/src/tree/tree/tests/txg.rs
+++ b/bfffs-core/src/tree/tree/tests/txg.rs
@@ -525,7 +525,7 @@ fn merge() {
         .with(eq(addrl1), eq(TxgT::from(42)))
         .return_once(move |_, _| Box::pin(future::ok(Box::new(ln1))));
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -594,8 +594,8 @@ root:
               start: 15
               end: 16
             ptr:
-              Addr: 6"#);
-    let r2 = tree.remove(4, TxgT::from(42))
+              Addr: 6"#));
+    let r2 = tree.clone().remove(4, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
@@ -810,7 +810,7 @@ root:
 fn steal() {
     let mock = MockDML::new();
     let dml = Arc::new(mock);
-    let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
+    let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
 ---
 height: 3
 limits:
@@ -896,8 +896,8 @@ root:
                             items:
                               24: 24.0
                               25: 25.0
-                              26: 26.0"#);
-    let r2 = tree.remove(26, TxgT::from(42))
+                              26: 26.0"#));
+    let r2 = tree.clone().remove(26, TxgT::from(42))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),

--- a/bfffs-core/src/tree/tree_mock.rs
+++ b/bfffs-core/src/tree/tree_mock.rs
@@ -54,8 +54,7 @@ mock! {
             -> MockTree<A, D, K, V>;
         pub fn dump(&self, f: &mut (dyn io::Write + 'static))
             -> Result<(), Error>;
-        pub fn flush(&self, txg: TxgT)
-            -> Pin<Box<dyn Future<Output=Result<(), Error>> + Send>>;
+        pub async fn flush(self: Arc<Self>, txg: TxgT) -> Result<(), Error>;
         pub fn get(&self, k: K)
             -> Pin<Box<dyn Future<Output=Result<Option<V>, Error>> + Send>>;
         pub async fn insert(self: Arc<Self>, k: K, v: V, txg: TxgT)

--- a/bfffs-core/src/tree/tree_mock.rs
+++ b/bfffs-core/src/tree/tree_mock.rs
@@ -57,8 +57,8 @@ mock! {
             -> Pin<Box<dyn Future<Output=Result<(), Error>> + Send>>;
         pub fn get(&self, k: K)
             -> Pin<Box<dyn Future<Output=Result<Option<V>, Error>> + Send>>;
-        pub fn insert(&self, k: K, v: V, txg: TxgT)
-            -> Pin<Box<dyn Future<Output=Result<Option<V>, Error>> + Send>>;
+        pub async fn insert(self: Arc<Self>, k: K, v: V, txg: TxgT)
+            -> Result<Option<V>, Error>;
         pub fn is_dirty(&self) -> bool;
         pub fn last_key(&self)
             -> Pin<Box<dyn Future<Output=Result<Option<K>, Error>> + Send>>;

--- a/bfffs-core/src/tree/tree_mock.rs
+++ b/bfffs-core/src/tree/tree_mock.rs
@@ -68,8 +68,8 @@ mock! {
             where K: Borrow<T>,
                   R: RangeBounds<T> + 'static,
                   T: Debug + Ord + Clone + Send + 'static;
-        pub fn range_delete<R, T>(&self, range: R, txg: TxgT)
-            -> Pin<Box<dyn Future<Output=Result<(), Error>> + Send>>
+        pub async fn range_delete<R, T>(self: Arc<Self>, range: R, txg: TxgT)
+            -> Result<(), Error>
             where K: Borrow<T>,
                   R: RangeBounds<T> + 'static,
                   T: Ord + Clone + Send + 'static;

--- a/bfffs-core/src/tree/tree_mock.rs
+++ b/bfffs-core/src/tree/tree_mock.rs
@@ -73,8 +73,8 @@ mock! {
             where K: Borrow<T>,
                   R: RangeBounds<T> + 'static,
                   T: Ord + Clone + Send + 'static;
-        pub fn remove(&self, k: K, txg: TxgT)
-            -> Pin<Box<dyn Future<Output=Result<Option<V>, Error>> + Send>>;
+        pub async fn remove(self: Arc<Self>, k: K, txg: TxgT)
+            -> Result<Option<V>, Error>;
         pub fn serialize(&self) -> Result<TreeOnDisk<A>, Error>;
     }
 }

--- a/bfffs-core/src/tree/tree_mock.rs
+++ b/bfffs-core/src/tree/tree_mock.rs
@@ -46,8 +46,7 @@ mock! {
               K: Key,
               V: Value
     {
-        pub fn check(&self)
-            -> Pin<Box<dyn Future<Output=Result<bool, Error>> + Send>>;
+        pub async fn check(self: Arc<Self>) -> Result<bool, Error>;
         pub fn clean_zone(&self, pbas: Range<PBA>, txgs: Range<TxgT>, txg: TxgT)
             -> Pin<Box<dyn Future<Output=Result<(), Error>> + Send>>;
         pub fn create(dml: Arc<D>, seq: bool, lzratio: f32, izratio: f32)

--- a/bfffs-core/src/tree/tree_mock.rs
+++ b/bfffs-core/src/tree/tree_mock.rs
@@ -47,8 +47,9 @@ mock! {
               V: Value
     {
         pub async fn check(self: Arc<Self>) -> Result<bool, Error>;
-        pub fn clean_zone(&self, pbas: Range<PBA>, txgs: Range<TxgT>, txg: TxgT)
-            -> Pin<Box<dyn Future<Output=Result<(), Error>> + Send>>;
+        pub async fn clean_zone(self: Arc<Self>, pbas: Range<PBA>,
+                                txgs: Range<TxgT>, txg: TxgT)
+            -> Result<(), Error>;
         pub fn create(dml: Arc<D>, seq: bool, lzratio: f32, izratio: f32)
             -> MockTree<A, D, K, V>;
         pub fn dump(&self, f: &mut (dyn io::Write + 'static))

--- a/bfffs-core/tests/functional/fs.rs
+++ b/bfffs-core/tests/functional/fs.rs
@@ -276,7 +276,6 @@ test_suite! {
         mocks.val.0.dump(&mut buf).unwrap();
         let fs_tree = String::from_utf8(buf).unwrap();
         let expected = r#"---
-height: 1
 limits:
   min_int_fanout: 91
   max_int_fanout: 364
@@ -284,12 +283,14 @@ limits:
   max_leaf_fanout: 2302
   _max_size: 4194304
 root:
-  key: 0-0-00000000000000
-  txgs:
-    start: 0
-    end: 1
-  ptr:
-    Addr: 0
+  height: 1
+  elem:
+    key: 0-0-00000000000000
+    txgs:
+      start: 0
+      end: 1
+    ptr:
+      Addr: 0
 ---
 0:
   Leaf:


### PR DESCRIPTION
* Flatten `tree::Inner` into `tree::Tree`
* Make most of `Tree`'s public methods `async fn`, with `self: Arc<Self>` arguments.  This requires some `clone` calls in `Tree`'s callers, but it reduces the overall amount of clone activity.
* inline some of `Tree`'s private methods
* Only use 8 bits to represent Tree height
* Protect `Tree:height` with the tree root's lock
* Flatten `IDML`.