### PR TITLE
Specify the cache size and writeback size on the cmd line

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,13 +9,11 @@ task:
   matrix:
     - name: cargo test (nightly)
       env:
-        # Pin nightly to 2020-08-28 to workaround Rust ICE
-        # https://github.com/rust-lang/rust/issues/67684
-        VERSION: nightly-2020-08-28-x86_64-unknown-freebsd
+        VERSION: nightly
         CARGO_ARGS: --all-features
     - name: cargo test (stable)
       env:
-        VERSION: 1.45.0
+        VERSION: 1.52.0
   setup_script:
     - pkg install -y c-blosc isa-l fusefs-libs pkgconf
     - fetch https://sh.rustup.rs -o rustup.sh

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ target/debug/bfffs pool create foo /tmp/bfffs.img
 sudo target/debug/bfffsd -o allow_other,default_permissions foo /mnt /tmp/bfffs.img
 ```
 
+Where `OPTIONS` can be:
+
+* `allow_other,default_permissions` - Allow users other than the one running
+  bfffsd to access the mounted file system.
+* `cache_size` - Set the maximum mount of cached clean data in bytes.  Higher
+  values will generally give better performance.  Beware, though, that unlike
+  an in-kernel file system bfffsd will never shrink the cache in response to
+  memory pressure.  The kernel will simply kill bfffsd or some other process
+  instead.
+* `writeback_size` - Set the maximum amount of cached dirty data in bytes.
+  This is completely independent of `cache_size`.  Generally it should be at
+  least several seconds' worth of your disks' maximum throughput.
+
 # License
 BFFFS is primarily distributed under the terms of both the MIT license
 and the Apache License (Version 2.0).

--- a/bfffs-core/src/writeback/writeback.rs
+++ b/bfffs-core/src/writeback/writeback.rs
@@ -223,10 +223,8 @@ impl WriteBack {
     }
 
     /// Construct a nearly unlimited WriteBack cache.
-    ///
-    /// TODO: remove this method once the actual constructor is hooked up.
     pub fn limitless() -> Self {
-        Self::with_capacity(isize::max_value() >> 1)
+        Self::with_capacity((isize::max_value() >> 1) as usize)
     }
 
     pub fn repay(&self, mut credit: Credit) {
@@ -246,10 +244,11 @@ impl WriteBack {
         mem::forget(credit);
     }
 
-    pub fn with_capacity(capacity: isize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Self {
+        let icapacity: isize = capacity.try_into().unwrap();
         WriteBack {
-            capacity: capacity << 1,
-            supply: AtomicIsize::new(capacity << 1),
+            capacity: icapacity << 1,
+            supply: AtomicIsize::new(icapacity << 1),
             sleepers: Default::default()
         }
     }

--- a/bfffs-core/tests/functional/database.rs
+++ b/bfffs-core/tests/functional/database.rs
@@ -31,7 +31,7 @@ fn open_db(rt: &mut Runtime, path: PathBuf) -> Database {
             let cache = Cache::with_capacity(4_194_304);
             let arc_cache = Arc::new(Mutex::new(cache));
             let ddml = Arc::new(DDML::open(pool, arc_cache.clone()));
-            let (idml, reader) = IDML::open(ddml, arc_cache, reader);
+            let (idml, reader) = IDML::open(ddml, arc_cache, 1<<30, reader);
             Database::open(Arc::new(idml), handle, reader)
         }).await
     }).unwrap()

--- a/bfffs-core/tests/functional/idml.rs
+++ b/bfffs-core/tests/functional/idml.rs
@@ -160,7 +160,7 @@ test_suite! {
                 let cache = cache::Cache::with_capacity(4_194_304);
                 let arc_cache = Arc::new(Mutex::new(cache));
                 let ddml = Arc::new(ddml::DDML::open(pool, arc_cache.clone()));
-                idml::IDML::open(ddml, arc_cache, reader)
+                idml::IDML::open(ddml, arc_cache, 1<<30, reader)
             }).await
         }).unwrap();
     }

--- a/bfffs-fio/bfffs.fio
+++ b/bfffs-fio/bfffs.fio
@@ -14,6 +14,8 @@ end_fsync=1
 # Don't precreate files and zero-fill them.
 create_on_open=1
 # Your pool info goes here:
+cache_size=1g
+writeback_size=256m
 pool=foo
 vdevs=/dev/da0
 


### PR DESCRIPTION
Add new options to both bfffsd and bfffs-fio to specify these options.
The defaults are 1GiB and 256 MiB respectively.

Fixes #40