### PR TITLE
Fix a race in the fs::dump test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ dependencies = [
  "futures",
  "libc",
  "mockall",
- "predicates",
  "time",
  "tokio",
  "tracing-subscriber",
@@ -545,9 +544,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "linked-hash-map"

--- a/bfffs-core/tests/functional/fs.rs
+++ b/bfffs-core/tests/functional/fs.rs
@@ -269,6 +269,10 @@ test_suite! {
     // Tree::dump, so the bulk of testing is in the tree tests.
     test dump(mocks(vec![])) {
         let root = mocks.val.0.root();
+        // Sync before clearing timestamps to improve determinism; the timed
+        // flusher may or may not have already flushed the tree.
+        mocks.val.0.sync();
+        // Clear timestamps to make the dump output deterministic
         clear_timestamps(&mocks.val.0, &root);
         mocks.val.0.sync();
 
@@ -287,13 +291,13 @@ root:
   elem:
     key: 0-0-00000000000000
     txgs:
-      start: 0
-      end: 1
+      start: 1
+      end: 2
     ptr:
-      Addr: 0
+      Addr: 2
 ...
 ---
-0:
+2:
   Leaf:
     credit: 0
     items:

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -33,4 +33,3 @@ features = [ "ansi", "env-filter", "fmt", "tracing-log" ]
 [dev-dependencies]
 divbuf = { git = "https://github.com/asomers/divbuf.git", rev = "0a72fb5"}
 mockall = "0.10.1"
-predicates = "1.0"


### PR DESCRIPTION
When running with slow storage for TMPDIR, the background flusher
sometimes flushed the tree before the test cleared its timestamps,
resulting in the tree being written to a different address.  Fix this
race by always flushing it prior to clearing the timestamps.
