### PR TITLE
"Fix" a clippy redundant_allocation warning

### DIFF
--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -606,7 +606,7 @@ impl Limits {
 /// Guard that holds the Node lock object for reading
 pub enum TreeReadGuard<A: Addr, K: Key, V: Value> {
     Mem(RwLockReadGuard<NodeData<A, K, V>>),
-    Addr(RwLockReadGuard<NodeData<A, K, V>>, Box<Arc<Node<A, K, V>>>)
+    Addr(RwLockReadGuard<NodeData<A, K, V>>, Arc<Node<A, K, V>>)
 }
 
 impl<A: Addr, K: Key, V: Value> TreeReadGuard<A, K, V> {
@@ -620,8 +620,8 @@ impl<A: Addr, K: Key, V: Value> Deref for TreeReadGuard<A, K, V> {
 
     fn deref(&self) -> &Self::Target {
         match self {
-            TreeReadGuard::Mem(guard) => &**guard,
-            TreeReadGuard::Addr(guard, _) => &**guard,
+            TreeReadGuard::Mem(guard) => &*guard,
+            TreeReadGuard::Addr(guard, _) => &*guard,
         }
     }
 }
@@ -875,7 +875,7 @@ impl<A: Addr, K: Key, V: Value> IntElem<A, K, V> {
                 .and_then(|node| {
                     node.0.read()
                         .map(move |guard|
-                             Ok(TreeReadGuard::Addr(guard, node))
+                             Ok(TreeReadGuard::Addr(guard, *node))
                         )
                 }).in_current_span()
                 .boxed()


### PR DESCRIPTION
The latest clippy warns about types like Box<Arc<T>>, because the Arc<T>
is already on the heap, so Clippy thinks that the Box has no purpose.
But in this case it does; it serves to turn the Arc<T> into a trait
object, for a trait that is implemented on the Arc<T> itself rather
than on T.  So the double allocation really is necessary.

Despite this, I "fixed" the warning basically by moving the Box's deref
from TreeReadGuard::deref to IntElem::rlock.  I think the total number
of Box deref operations will be unchanged, at least for common
operations like Tree::get.

See also https://github.com/rust-lang/rust-clippy/issues/7472