### PR TITLE
Clippy cleanup

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,7 +56,5 @@ clippy_task:
   lint_script:
     - . $HOME/.cargo/env
     - $HOME/.cargo/bin/rustup component add --toolchain $VERSION clippy
-    # Suppress clippy::nonstandard_macro_braces due to a clippy bug.
-    # https://github.com/rust-lang/rust-clippy/issues/7434
-    - cargo +$VERSION clippy --all-features --all-targets -- -D warnings -A clippy::nonstandard_macro_braces
+    - cargo +$VERSION clippy --all-features --all-targets -- -D warnings
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/bfffs-core/src/database/database.rs
+++ b/bfffs-core/src/database/database.rs
@@ -520,7 +520,7 @@ impl Database {
               R: 'static,
     {
         self.ro_filesystem(tree_id)
-            .and_then(|ds| f(ds))
+            .and_then(f)
     }
 
     /// Perform a read-only operation on a Filesystem

--- a/bfffs-core/src/lib.rs
+++ b/bfffs-core/src/lib.rs
@@ -18,6 +18,10 @@
 // of e.g. "Idml" as opposed to "IDML".
 #![allow(clippy::upper_case_acronyms)]
 
+// In some circumstances, I consider if-then-panic to be more readable than
+// assert
+#![allow(clippy::if_then_panic)]
+
 // error: reached the type-length limit while instantiating std::pin::Pin...
 #![type_length_limit="3790758"]
 // error: trait bounds overflowed in Database::sync_transaction_priv

--- a/bfffs-core/tests/cacheable_space.rs
+++ b/bfffs-core/tests/cacheable_space.rs
@@ -1,6 +1,8 @@
 //! Measures the actual memory consumption of Cacheable implementors
 //!
 //! Can't use the standard test harness because we need to run single-threaded.
+#![allow(clippy::if_then_panic)]
+
 use bfffs_core::{
     cache::Cacheable,
     ddml::DRP,


### PR DESCRIPTION
Revert the workaround for Clippy bug 7434, suppress a new Clippy lint,
and eliminate a redundant closure.