### PR TITLE
Replace ECKSUM with EINTEGRITY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,9 +570,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "linked-hash-map"

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -27,7 +27,7 @@ futures-locks = { git = "http://github.com/asomers/futures-locks.git", rev = "eb
 itertools = "0.7"
 isa-l = { path = "../isa-l" }
 lazy_static = "1.0"
-libc = "0.2.44"
+libc = "0.2.105"
 metrohash = "1.0"
 mockall_double = "0.2.0"
 nix = "0.22.0"

--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -645,7 +645,7 @@ impl SpacemapOnDisk {
             if hasher.finish() == sod.checksum {
                 Ok(sod)
             } else {
-                Err(Error::ECKSUM)
+                Err(Error::EINTEGRITY)
             }
         })
     }
@@ -1332,7 +1332,7 @@ mod cluster {
             });
 
         let r = FreeSpaceMap::open(Arc::new(vr)).now_or_never().unwrap();
-        assert_eq!(Error::ECKSUM, r.err().unwrap());
+        assert_eq!(Error::EINTEGRITY, r.err().unwrap());
     }
 
     #[test]

--- a/bfffs-core/src/ddml/ddml.rs
+++ b/bfffs-core/src/ddml/ddml.rs
@@ -134,7 +134,7 @@ impl DDML {
                         future::ok(dbs)
                     }
                 } else {
-                    future::err(Error::ECKSUM)
+                    future::err(Error::EINTEGRITY)
                 }
             })
         )
@@ -539,7 +539,7 @@ mod ddml {
         let err = ddml.get::<DivBufShared, DivBuf>(&drp)
             .now_or_never().unwrap()
             .unwrap_err();
-        assert_eq!(err, Error::ECKSUM);
+        assert_eq!(err, Error::EINTEGRITY);
     }
 
     #[test]
@@ -668,7 +668,7 @@ mod ddml {
         let err = ddml.pop::<DivBufShared, DivBuf>(&drp, TxgT::from(0))
             .now_or_never().unwrap()
             .unwrap_err();
-        assert_eq!(err, Error::ECKSUM);
+        assert_eq!(err, Error::EINTEGRITY);
     }
 
     #[test]

--- a/bfffs-core/src/label.rs
+++ b/bfffs-core/src/label.rs
@@ -86,7 +86,7 @@ impl LabelReader {
             hasher.write(contents);
         }
         if checksum != hasher.finish() {
-            return Err(Error::ECKSUM);
+            return Err(Error::EINTEGRITY);
         }
 
         let mut cursor = io::Cursor::new(buffer);

--- a/bfffs-core/src/types.rs
+++ b/bfffs-core/src/types.rs
@@ -155,11 +155,10 @@ pub enum Error {
     ECAPMODE        = libc::ECAPMODE as isize,
     ENOTRECOVERABLE = libc::ENOTRECOVERABLE as isize,
     EOWNERDEAD      = libc::EOWNERDEAD as isize,
+    EINTEGRITY      = libc::EINTEGRITY as isize,
 
     //// BFFFS custom error types below
     EUNKNOWN        = 256,
-    // TODO: Change ECKSUM to EINTEGRITY in FreeBSD 12.1
-    ECKSUM          = 257,
 }
 
 impl Error {
@@ -198,9 +197,6 @@ impl From<Error> for i32 {
         match e {
             Error::EUNKNOWN =>
                 panic!("Unknown error codes should never be exposed"),
-            // Checksum errors are a special case of I/O errors until FreeBSD
-            // 12.1, whenthey will become EINTEGRITY errors
-            Error::ECKSUM => Error::EIO.to_i32().unwrap(),
             _ => e.to_i32().unwrap()
         }
     }

--- a/bfffs-core/tests/functional/vdev_file.rs
+++ b/bfffs-core/tests/functional/vdev_file.rs
@@ -307,7 +307,7 @@ mod persistence {
         let e = rt.block_on(async { VdevFile::open(harness.0).await})
             .err()
             .expect("Opening the file should've failed");
-        assert_eq!(e, Error::ECKSUM);
+        assert_eq!(e, Error::EINTEGRITY);
     }
 
     /// Open a device that only has one valid label, the first one


### PR DESCRIPTION
Originally ECKSUM was a custom internal error code.  But FreeBSD 12 made
EINTEGRITY standard.  Since BFFFS no longer runs on FreeBSD 11, use the
standard error code.