### PR TITLE
Don't unnecessarily rebuild isa-l

### DIFF
--- a/isa-l/build.rs
+++ b/isa-l/build.rs
@@ -1,6 +1,9 @@
 // vim: tw=80
 
 fn main() {
+    // Avoid unnecessary re-building.
+    println!("cargo:rerun-if-changed=build.rs");
+
     println!("cargo:rustc-link-search=native=/usr/local/lib");
     println!("cargo:rustc-link-lib=isal");
 }


### PR DESCRIPTION
Cargo usually figures out that it doesn't need to rebuild the isa-l
crate.  However, when RUSTFLAGS="-zinstrument-coverage", it rebuilds it
every time, for some reason.  Explicitly tell it not to.