### PR TITLE
Implement stat.st_blocks

### DIFF
--- a/bfffs-core/src/database/database.rs
+++ b/bfffs-core/src/database/database.rs
@@ -463,6 +463,7 @@ impl Database {
 
                 let inode = Inode {
                     size: 0,
+                    bytes: 0,
                     nlink: 1,   // for "."
                     flags: 0,
                     atime: now,

--- a/bfffs-core/src/fs/tests.rs
+++ b/bfffs-core/src/fs/tests.rs
@@ -93,6 +93,7 @@ async fn create() {
         .returning(move |_| {
             let inode = Inode {
                 size: 0,
+                bytes: 0,
                 nlink: 2,
                 flags: 0,
                 atime: old_ts,
@@ -171,6 +172,7 @@ async fn create_hash_collision() {
         .returning(move |_| {
             let inode = Inode {
                 size: 0,
+                bytes: 0,
                 nlink: 2,
                 flags: 0,
                 atime: old_ts,
@@ -264,7 +266,7 @@ fn debug_getattr() {
     let attr = GetAttr {
         ino: 1,
         size: 4096,
-        blocks: 1,
+        bytes: 4096,
         atime: Timespec::new(1, 2),
         mtime: Timespec::new(3, 4),
         ctime: Timespec::new(5, 6),
@@ -278,7 +280,7 @@ fn debug_getattr() {
         flags: 0,
     };
     let s = format!("{:?}", attr);
-    assert_eq!("GetAttr { ino: 1, size: 4096, blocks: 1, atime: Timespec { sec: 1, nsec: 2 }, mtime: Timespec { sec: 3, nsec: 4 }, ctime: Timespec { sec: 5, nsec: 6 }, birthtime: Timespec { sec: 7, nsec: 8 }, mode: Mode { .0: 33188, perm: 420 }, nlink: 1, uid: 1000, gid: 1000, rdev: 0, blksize: 131072, flags: 0 }", s);
+    assert_eq!("GetAttr { ino: 1, size: 4096, bytes: 4096, atime: Timespec { sec: 1, nsec: 2 }, mtime: Timespec { sec: 3, nsec: 4 }, ctime: Timespec { sec: 5, nsec: 6 }, birthtime: Timespec { sec: 7, nsec: 8 }, mode: Mode { .0: 33188, perm: 420 }, nlink: 1, uid: 1000, gid: 1000, rdev: 0, blksize: 131072, flags: 0 }", s);
 }
 
 // Pet kcov
@@ -287,7 +289,7 @@ fn eq_getattr() {
     let attr = GetAttr {
         ino: 1,
         size: 4096,
-        blocks: 1,
+        bytes: 4096,
         atime: Timespec::new(1, 2),
         mtime: Timespec::new(3, 4),
         ctime: Timespec::new(5, 6),
@@ -548,6 +550,7 @@ async fn rmdir_with_blob_extattr() {
             let now = Timespec::now();
             let inode = Inode {
                 size: 0,
+                bytes: 0,
                 nlink: 2,
                 flags: 0,
                 atime: now,
@@ -631,6 +634,7 @@ async fn rmdir_with_blob_extattr() {
             let now = Timespec::now();
             let inode = Inode {
                 size: 0,
+                bytes: 0,
                 nlink: 3,
                 flags: 0,
                 atime: now,
@@ -653,6 +657,7 @@ async fn rmdir_with_blob_extattr() {
             let now = Timespec::now();
             let inode = Inode {
                 size: 0,
+                bytes: 0,
                 nlink: 2,
                 flags: 0,
                 atime: now,
@@ -861,7 +866,8 @@ async fn unlink() {
         .with(eq(FSKey::new(ino, ObjKey::Inode)))
         .returning(move |_| {
             let inode = Inode {
-                size: 4098,
+                size: 4097,
+                bytes: 4097,
                 nlink: 1,
                 flags: 0,
                 atime: old_ts,
@@ -882,6 +888,7 @@ async fn unlink() {
         .returning(move |_| {
             let inode = Inode {
                 size: 0,
+                bytes: 0,
                 nlink: 2,
                 flags: 0,
                 atime: old_ts,
@@ -1012,7 +1019,8 @@ async fn unlink_with_blob_extattr() {
         .returning(move |_| {
             let now = Timespec::now();
             let inode = Inode {
-                size: 4098,
+                size: 4097,
+                bytes: 4097,
                 nlink: 1,
                 flags: 0,
                 atime: now,
@@ -1033,6 +1041,7 @@ async fn unlink_with_blob_extattr() {
         .returning(move |_| {
             let inode = Inode {
                 size: 0,
+                bytes: 0,
                 nlink: 2,
                 flags: 0,
                 atime: old_ts,
@@ -1183,6 +1192,7 @@ async fn unlink_with_extattr_hash_collision() {
             let now = Timespec::now();
             let inode = Inode {
                 size: 0,
+                bytes: 0,
                 nlink: 1,
                 flags: 0,
                 atime: now,
@@ -1203,6 +1213,7 @@ async fn unlink_with_extattr_hash_collision() {
         .returning(move |_| {
             let inode = Inode {
                 size: 0,
+                bytes: 0,
                 nlink: 2,
                 flags: 0,
                 atime: old_ts,

--- a/bfffs-core/tests/cacheable_space.rs
+++ b/bfffs-core/tests/cacheable_space.rs
@@ -308,6 +308,7 @@ fn fs_leaf_inode(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         let k = FSKey::new(i as u64, ObjKey::Inode);
         let inode = Inode {
             size: 0,
+            bytes: 0,
             nlink: 1,
             flags: 0,
             atime: Timespec{sec: 0, nsec: 0},

--- a/bfffs/src/bin/bfffsd/fs.rs
+++ b/bfffs/src/bin/bfffsd/fs.rs
@@ -146,7 +146,7 @@ impl FuseFs {
                 let reply_attr = FileAttr {
                     ino: attr.ino,
                     size: attr.size,
-                    blocks: attr.blocks,
+                    blocks: attr.bytes << 9,
                     atime: Timestamp::new(attr.atime.sec, attr.atime.nsec),
                     mtime: Timestamp::new(attr.mtime.sec, attr.mtime.nsec),
                     ctime: Timestamp::new(attr.ctime.sec, attr.ctime.nsec),

--- a/bfffs/src/bin/bfffsd/fs/tests.rs
+++ b/bfffs/src/bin/bfffsd/fs/tests.rs
@@ -169,7 +169,7 @@ mod create {
             .return_const(Ok(GetAttr {
                 ino,
                 size: 0,
-                blocks: 0,
+                bytes: 0,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -304,7 +304,7 @@ mod forget {
             .return_const(Ok(GetAttr {
                 ino,
                 size,
-                blocks: 0,
+                bytes: size,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -447,7 +447,7 @@ mod getattr {
             .return_const(Ok(GetAttr {
                 ino,
                 size,
-                blocks: 0,
+                bytes: size,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -791,7 +791,7 @@ mod link {
             .return_const(Ok(GetAttr {
                 ino,
                 size,
-                blocks: 0,
+                bytes: size,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -1061,7 +1061,7 @@ mod lookup {
             .return_const(Ok(GetAttr {
                 ino,
                 size,
-                blocks: 0,
+                bytes: size,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -1128,7 +1128,7 @@ mod lookup {
             .return_const(Ok(GetAttr {
                 ino,
                 size: 2,
-                blocks: 0,
+                bytes: 0,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -1205,7 +1205,7 @@ mod lookup {
             .return_const(Ok(GetAttr {
                 ino,
                 size: 2,
-                blocks: 0,
+                bytes: 0,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -1265,7 +1265,7 @@ mod lookup {
             .return_const(Ok(GetAttr {
                 ino: parent,
                 size: 3,
-                blocks: 0,
+                bytes: 0,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -1397,7 +1397,7 @@ mod lookup {
             .return_const(Ok(GetAttr {
                 ino,
                 size,
-                blocks: 0,
+                bytes: size,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -1467,7 +1467,7 @@ mod lookup {
             .return_const(Ok(GetAttr {
                 ino,
                 size,
-                blocks: 0,
+                bytes: size,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -1588,7 +1588,7 @@ mod lookup {
             .return_const(Ok(GetAttr {
                 ino,
                 size,
-                blocks: 0,
+                bytes: size,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -1823,7 +1823,7 @@ mod mkdir {
             .return_const(Ok(GetAttr {
                 ino,
                 size: 0,
-                blocks: 0,
+                bytes: 0,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -1905,7 +1905,7 @@ mod mknod {
             .return_const(Ok(GetAttr {
                 ino,
                 size: 0,
-                blocks: 0,
+                bytes: 0,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -1982,7 +1982,7 @@ mod mknod {
             .return_const(Ok(GetAttr {
                 ino,
                 size: 0,
-                blocks: 0,
+                bytes: 0,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -2098,7 +2098,7 @@ mod mknod {
             .return_const(Ok(GetAttr {
                 ino,
                 size: 0,
-                blocks: 0,
+                bytes: 0,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -2172,7 +2172,7 @@ mod mknod {
             .return_const(Ok(GetAttr {
                 ino,
                 size: 0,
-                blocks: 0,
+                bytes: 0,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -3220,7 +3220,7 @@ mod setattr {
             .return_const(Ok(GetAttr {
                 ino,
                 size,
-                blocks: 0,
+                bytes: size,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },
@@ -3468,7 +3468,7 @@ mod symlink {
             .return_const(Ok(GetAttr {
                 ino,
                 size: 0,
-                blocks: 0,
+                bytes: 0,
                 atime: Timespec { sec: 0, nsec: 0 },
                 mtime: Timespec { sec: 0, nsec: 0 },
                 ctime: Timespec { sec: 0, nsec: 0 },


### PR DESCRIPTION
In this implementation:
* Compression is not considered
* Extended attributes are ignored, to avoid needing to modify the Inode
  on every extattr modification.
* The Inode itself is not included.
* Directories always have st_blocks == 0.  Since directory entries are
  stored in the BTree rather than in dedicated disk blocks it's hard to
  tally their size, and I'm not sure that it's worth it anyway.