### PR TITLE
Add Fs::deallocate

### DIFF
--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -1429,14 +1429,11 @@ impl<A, D, K, V> Tree<A, D, K, V>
               R: Debug + Clone + RangeBounds<T> + Send + 'static,
               T: Ord + Clone + 'static + Debug
     {
-        // Sanity check the arguments
-        match (range.start_bound(), range.end_bound()) {
-            (Bound::Included(s), Bound::Included(e)) => debug_assert!(s <= e),
-            (Bound::Included(s), Bound::Excluded(e)) => debug_assert!(s < e),
-            (Bound::Excluded(s), Bound::Included(e)) => debug_assert!(s < e),
-            (Bound::Excluded(s), Bound::Excluded(e)) => debug_assert!(s < e),
-            _ => ()
-        };
+        if range.is_empty() {
+            self.dml.repay(credit);
+            return Ok(());
+        }
+
         // Outline:
         // 1) Traverse the tree removing all requested KV-pairs, leaving damaged
         //    nodes, deleting empty nodes, and recording which nodes are

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -2012,6 +2012,21 @@ root:
 "#);
 }
 
+// range_delete of an empty range does nothing bad
+#[test]
+fn range_delete_empty() {
+    let mock = mock_dml();
+    let dml = Arc::new(mock);
+    let limits = Limits::new(2, 5, 2, 5);
+    let tree = Arc::new(
+        Tree::<u32, MockDML, u32, f32>::new(dml, limits, false, None)
+    );
+    let r = tree
+        .range_delete(5..5, TxgT::from(42), Credit::null())
+        .now_or_never().unwrap();
+    assert!(r.is_ok());
+}
+
 // Delete a range that's exclusive on the left and right
 #[test]
 fn range_delete_exc_exc() {

--- a/bfffs/src/bin/bfffsd/fs/mock.rs
+++ b/bfffs/src/bin/bfffsd/fs/mock.rs
@@ -28,6 +28,8 @@ mock! {
     pub Fs {
         pub async fn create(&self, parent: &FileData, name: &OsStr, perm: u16,
             uid: u32, gid: u32) -> Result<FileData, i32>;
+        pub async fn deallocate(&self, fd: &FileData, offset: u64, len: u64)
+            -> Result<(), i32>;
         pub async fn deleteextattr(&self, fd: &FileData, ns: ExtAttrNamespace,
             name: &OsStr) -> Result<(), i32>;
         pub async fn inactive(&self, fd: FileData);


### PR DESCRIPTION
Hole punching: deallocate a range of data from a file.  Requires operating system support, which is not yet in FreeBSD current.