### PR TITLE
vdev_file: refuse to create a vdev on a file that does not exist

### DIFF
--- a/bfffs-core/src/vdev_file.rs
+++ b/bfffs-core/src/vdev_file.rs
@@ -180,12 +180,11 @@ impl VdevFile {
         where P: AsRef<Path> + 'static
     {
         let f = OpenOptions::new()
-            .create(true)
             .read(true)
             .write(true)
             .custom_flags(libc::O_DIRECT)
             .open(path)
-            .map(File::new).unwrap();
+            .map(File::new)?;
         let lpz = match lbas_per_zone {
             None => VdevFile::DEFAULT_LBAS_PER_ZONE,
             Some(x) => x.get()

--- a/bfffs-core/tests/functional/vdev_file.rs
+++ b/bfffs-core/tests/functional/vdev_file.rs
@@ -41,6 +41,18 @@ mod basic {
         format!("{:?}", harness.0);
     }
 
+    #[test]
+    fn create_enoent() {
+        let dir = t!(
+            Builder::new().prefix("test_read_at").tempdir()
+        );
+        let path = dir.path().join("vdev");
+        let e = VdevFile::create(path, None)
+            .err()
+            .unwrap();
+        assert_eq!(e.kind(), std::io::ErrorKind::NotFound);
+    }
+
     /// erase_zone should succeed and do nothing if the underlying file does not
     /// support it.
     #[rstest]


### PR DESCRIPTION
Previously this would create a 0-sized file, and some later code would
fail with ENOSPC.