### PR TITLE
Add fspacectl support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,3 @@
-freebsd_instance:
-  image_family: freebsd-12-2-snap
-
 setup: &SETUP
   env:
     HOME: /tmp # cargo needs it
@@ -16,15 +13,21 @@ setup: &SETUP
 
 task:
   matrix:
+    # Use bleeding edge features: Rust nightly and FreeBSD fspacectl
     - name: cargo test (nightly)
       env:
         # Pin nightly compiler to workaround
         # https://github.com/rust-lang/rust/issues/93209
         VERSION: nightly-2022-01-20
         CARGO_ARGS: --all-features
+      freebsd_instance:
+        image_family: freebsd-14-0-snap
+    # Use stable features
     - name: cargo test (stable)
       env:
         VERSION: 1.54.0
+      freebsd_instance:
+        image: freebsd-12-3-release-amd64
   << : *SETUP
   cargo_cache:
     folder: $HOME/.cargo/registry
@@ -58,6 +61,8 @@ lint_task:
     # https://github.com/rust-lang/rust/issues/93209
     VERSION: nightly-2022-01-20
     CARGO_ARGS: --all-features
+  freebsd_instance:
+    image: freebsd-12-3-release-amd64
   << : *SETUP
   cargo_cache:
     folder: $HOME/.cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi",
 ]
 
@@ -85,7 +85,7 @@ dependencies = [
  "divbuf",
  "fuse3",
  "futures",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockall 0.11.0",
  "nix",
  "predicates 2.1.0",
@@ -123,7 +123,7 @@ dependencies = [
  "isa-l",
  "itertools 0.7.11",
  "lazy_static",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrohash",
  "mockall 0.10.2",
  "mockall_double",
@@ -158,7 +158,7 @@ dependencies = [
  "cc",
  "futures",
  "lazy_static",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.6",
  "tokio",
  "tracing-subscriber",
@@ -192,7 +192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa4be3ff6a15133256bcb58bdc8fefd074aebece453605386646bb96db0dc57"
 dependencies = [
  "blosc-sys",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -364,7 +364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi",
 ]
 
@@ -375,7 +375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -384,7 +384,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17d6dfea8da8b55b0c77800947567f282cad3940dc7edc37bf897a6933afee8d"
 dependencies = [
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -434,7 +434,7 @@ dependencies = [
  "cstr",
  "futures-channel",
  "futures-util",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix",
  "serde",
  "slab",
@@ -572,7 +572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi",
 ]
 
@@ -603,7 +603,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -658,9 +658,14 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+
+[[package]]
+name = "libc"
+version = "0.2.113"
+source = "git+https://github.com/rust-lang/libc?rev=7600416f1ca896b501d58b0f44f1869d566359d6#7600416f1ca896b501d58b0f44f1869d566359d6"
 
 [[package]]
 name = "linked-hash-map"
@@ -728,7 +733,7 @@ version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "miow",
  "ntapi",
@@ -741,7 +746,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "miow",
  "ntapi",
@@ -835,13 +840,11 @@ dependencies = [
 [[package]]
 name = "nix"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+source = "git+https://github.com/nix-rust/nix.git?rev=8ee93662e78b029c0d55a5b67f8944fb1bedcc21#8ee93662e78b029c0d55a5b67f8944fb1bedcc21"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
- "libc",
+ "libc 0.2.113 (git+https://github.com/rust-lang/libc?rev=7600416f1ca896b501d58b0f44f1869d566359d6)",
  "memoffset 0.6.4",
 ]
 
@@ -876,7 +879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -938,7 +941,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 dependencies = [
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6",
  "smallvec",
  "winapi",
@@ -1121,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1",
  "rdrand",
  "winapi",
@@ -1133,7 +1136,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha",
  "rand_core 0.6.3",
  "rand_hc",
@@ -1357,7 +1360,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1406,7 +1409,7 @@ checksum = "4bcf77d15d9b9261f4d32c0b4e3cf09050ee6aabb20cf21cb99dfe69c9a49d83"
 dependencies = [
  "byteorder",
  "errno",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1416,7 +1419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
@@ -1438,7 +1441,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi",
 ]
 
@@ -1488,7 +1491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0a10c9a9fb3a5dce8c2239ed670f1a2569fcf42da035f5face1b19860d52b0"
 dependencies = [
  "itoa",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1498,7 +1501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.7.13",
  "num_cpus",
  "once_cell",
@@ -1511,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "tokio-file"
 version = "0.7.0"
-source = "git+https://github.com/asomers/tokio-file.git#a0af4f72b8e13c541a9bc345b31e2648629a2558"
+source = "git+https://github.com/asomers/tokio-file.git?rev=a0af4f72b8e13c541a9bc345b31e2648629a2558#a0af4f72b8e13c541a9bc345b31e2648629a2558"
 dependencies = [
  "futures",
  "mio 0.7.13",
@@ -1538,7 +1541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6c35a3e32adef32541a7491eaabccdb8e0a7ea10c3ad9814f9ab8f1c9174da"
 dependencies = [
  "filedesc",
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
 ]
 
@@ -1690,7 +1693,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
- "libc",
+ "libc 0.2.113 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ lto = true
 members = ["bfffs-core", "bfffs-fio", "bfffs", "isa-l"]
 
 [patch.crates-io]
+nix = { git = "https://github.com/nix-rust/nix.git", rev = "8ee93662e78b029c0d55a5b67f8944fb1bedcc21" }

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -38,7 +38,7 @@ serde_derive = "1.0"
 serde_yaml = "0.8.16"
 time = { version = "0.3.0", features = [ "formatting" ] }
 tokio = { version = "1.10.0", features = ["rt", "sync", "time"] }
-tokio-file = { git = "https://github.com/asomers/tokio-file.git", revision = "a0af4f72b8e13c541a9bc345b31e2648629a2558" }
+tokio-file = { git = "https://github.com/asomers/tokio-file.git", rev = "a0af4f72b8e13c541a9bc345b31e2648629a2558" }
 tracing = "0.1.5"
 tracing-futures = "0.2.4"
 uuid = { version = "0.8.2", features = ["serde", "v4"]}
@@ -69,6 +69,9 @@ tokio = { version = "1.10.0", features = ["macros", "rt", "rt-multi-thread", "sy
 version = "0.2.15"
 default-features = false
 features = [ "ansi", "env-filter", "fmt", "tracing-log" ]
+
+[build-dependencies]
+nix = "0.23.0"
 
 [[test]]
 name = "cacheable_space"

--- a/bfffs-core/build.rs
+++ b/bfffs-core/build.rs
@@ -1,0 +1,19 @@
+use nix::sys::utsname::uname;
+
+fn main() {
+    // Avoid unnecessary re-building.
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let utsname = uname();
+    if utsname.sysname() == "FreeBSD" {
+        let major = utsname.release()
+            .split('.')
+            .next()
+            .unwrap()
+            .parse::<i32>()
+            .unwrap();
+        if major >= 14 {
+            println!("cargo:rustc-cfg=have_fspacectl");
+        }
+    }
+}


### PR DESCRIPTION
* Use fspacectl to deallocate space on regular files used as backing
  stores.
* With both fspacectl and DIOCGDELETE, use a tokio blocking_task, since
  they block.
* Add a build script to detect fspacectl support.
* Test FreeBSD 14 in CI.
* Update FreeBSD 12 CI image.