### PR TITLE
A few more improvements to the use_graph

### DIFF
--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -2,7 +2,7 @@
 
 //! Nodes for Trees (private module)
 use crate::{
-    dml::*,
+    dml::{Cacheable, CacheRef, DML},
     types::*,
     util::*,
     writeback::Credit
@@ -1469,7 +1469,10 @@ fn yes() {
 #[cfg(test)]
 mod serialization {
 
-use crate::ddml::DRP;
+use crate::{
+    dml::Compression,
+    ddml::DRP
+};
 use pretty_assertions::assert_eq;
 use std::ops::Deref;
 use super::*;


### PR DESCRIPTION
* Rather than hiding utility modules, show them but without edges
* Include DML among said utility modules
* Manually fixup edges wrong because of cargo-modules issue 79