### PR TITLE
Move some stuff from the bfffs command to the bfffs lib

### DIFF
--- a/bfffs-core/src/rpc.rs
+++ b/bfffs-core/src/rpc.rs
@@ -64,4 +64,11 @@ impl Response {
             x => panic!("Unexpected response type {:?}", x)
         }
     }
+
+    pub fn into_fs_mount(self) -> Result<(), Error> {
+        match self {
+            Response::FsMount(r) => r,
+            x => panic!("Unexpected response type {:?}", x)
+        }
+    }
 }

--- a/bfffs/src/bin/bfffs.rs
+++ b/bfffs/src/bin/bfffs.rs
@@ -118,8 +118,6 @@ enum DebugCmd {
 mod fs {
     use std::path::Path;
 
-    use bfffs_core::rpc;
-
     use super::*;
 
     /// Create a new file system
@@ -150,8 +148,7 @@ mod fs {
                     })
                 })
                 .collect::<Vec<_>>();
-            let req = rpc::fs::create(self.name, props);
-            bfffs.call(req).await.unwrap().into_fs_create().map(drop)
+            bfffs.fs_create(self.name, props).await.map(drop)
         }
     }
 
@@ -175,9 +172,7 @@ mod fs {
     impl Mount {
         pub(super) async fn main(self, sock: &Path) -> Result<(), Error> {
             let bfffs = Bfffs::new(sock).await.unwrap();
-            let req = rpc::fs::mount(self.mountpoint, self.name);
-            bfffs.call(req).await.unwrap();
-            Ok(())
+            bfffs.fs_mount(self.name, self.mountpoint).await
         }
     }
 


### PR DESCRIPTION
The bfffs command should have as little logic as possible, apart from
command-line stuff.  So far the logic in the bfffs lib is small enough
that it doesn't warrant separate integration tests, apart from the
CLI's.