### PR TITLE
Fix the "sync mount" problem

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ task:
     # Use stable features
     - name: cargo test (stable)
       env:
-        VERSION: 1.54.0
+        VERSION: 1.56.0
       freebsd_instance:
         image: freebsd-12-3-release-amd64
   << : *SETUP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,8 +424,8 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuse3"
-version = "0.2.1"
-source = "git+https://github.com/asomers/fuse3.git?rev=190061a#190061a66c830de686253c2f96de5e1c46b0e5b4"
+version = "0.3.0"
+source = "git+https://github.com/asomers/fuse3.git?rev=6b05ba4e7df66fc689147f26907997fb1b93bf18#6b05ba4e7df66fc689147f26907997fb1b93bf18"
 dependencies = [
  "async-trait",
  "bincode",

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -18,7 +18,7 @@ bincode = "1.0.1"
 bfffs-core = { path = "../bfffs-core" }
 bytes = "1.0"
 cfg-if = "1.0"
-fuse3 = { git = "https://github.com/asomers/fuse3.git", rev = "190061a", optional = true, features = ["tokio-runtime"] }
+fuse3 = { git = "https://github.com/asomers/fuse3.git", rev = "6b05ba4e7df66fc689147f26907997fb1b93bf18", optional = true, features = ["tokio-runtime"] }
 futures = "0.3.0"
 libc = "0.2.44"
 nix = "0.23.0"

--- a/bfffs/tests/integration/bfffs/fs/mount.rs
+++ b/bfffs/tests/integration/bfffs/fs/mount.rs
@@ -7,10 +7,7 @@ use std::{
 };
 
 use assert_cmd::{cargo::cargo_bin, prelude::*};
-use nix::{
-    mount::{unmount, MntFlags},
-    sys::statfs::statfs,
-};
+use nix::mount::{unmount, MntFlags};
 use rstest::{fixture, rstest};
 use tempfile::{Builder, TempDir};
 
@@ -85,19 +82,13 @@ async fn ok(harness: Harness) {
         .assert()
         .success();
 
-    // Mounting a file system is not synchronous.
-    // https://github.com/Sherlock-Holo/fuse3/issues/27
-    waitfor(Duration::from_secs(5), || {
-        statfs(&mountpoint).unwrap().filesystem_type_name() == "fusefs.bfffs"
-    })
-    .expect("Timeout waiting for bfffs to mount");
     unmount(&mountpoint, MntFlags::empty()).unwrap();
 }
 
 #[rstest]
 #[tokio::test]
 async fn options(harness: Harness) {
-    require_fusefs!("bfffs::fs::mount::noatime");
+    require_fusefs!("bfffs::fs::mount::options");
 
     let mountpoint = harness.tempdir.path().join("mnt");
     fs::create_dir(&mountpoint).unwrap();
@@ -114,13 +105,6 @@ async fn options(harness: Harness) {
         .assert()
         .success();
 
-    // Mounting a file system is not synchronous.
-    // https://github.com/Sherlock-Holo/fuse3/issues/27
-    waitfor(Duration::from_secs(5), || {
-        statfs(&mountpoint).unwrap().filesystem_type_name() == "fusefs.bfffs"
-    })
-    .expect("Timeout waiting for bfffs to mount");
-
     // TODO: figure out how to check if atime is active.
 
     unmount(&mountpoint, MntFlags::empty()).unwrap();
@@ -130,7 +114,7 @@ async fn options(harness: Harness) {
 #[rstest]
 #[tokio::test]
 async fn subfs(harness: Harness) {
-    require_fusefs!("bfffs::fs::mount::ok");
+    require_fusefs!("bfffs::fs::mount::subfs");
 
     let mountpoint = harness.tempdir.path().join("mnt");
     fs::create_dir(&mountpoint).unwrap();
@@ -154,11 +138,5 @@ async fn subfs(harness: Harness) {
         .assert()
         .success();
 
-    // Mounting a file system is not synchronous.
-    // https://github.com/Sherlock-Holo/fuse3/issues/27
-    waitfor(Duration::from_secs(5), || {
-        statfs(&mountpoint).unwrap().filesystem_type_name() == "fusefs.bfffs"
-    })
-    .expect("Timeout waiting for bfffs to mount");
     unmount(&mountpoint, MntFlags::empty()).unwrap();
 }


### PR DESCRIPTION
Previous versions of fuse3 gave no indication of when a mount was
successful.  Now, a patched version does.