### PR TITLE
Degenerify FSValue

### DIFF
--- a/bfffs-core/examples/fanout.rs
+++ b/bfffs-core/examples/fanout.rs
@@ -343,8 +343,7 @@ fn experiment<F>(nelems: u64, save: bool, mut f: F)
     let idml3 = idml.clone();
     let idml4 = idml.clone();
     let tree = Arc::new(
-        Tree::<RID, FakeIDML, FSKey, FSValue<RID>>::create(idml2, false, 9.00,
-                                                           1.61)
+        Tree::<RID, FakeIDML, FSKey, FSValue>::create(idml2, false, 9.00, 1.61)
     );
     let tree2 = tree.clone();
     let txg = TxgT::from(0);

--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -38,7 +38,7 @@ use std::{
 
 #[cfg(test)] mod tests;
 
-pub type ExtAttr = crate::fs_tree::ExtAttr<RID>;
+pub type ExtAttr = crate::fs_tree::ExtAttr;
 pub type ExtAttrNamespace = crate::fs_tree::ExtAttrNamespace;
 pub type Timespec = crate::fs_tree::Timespec;
 
@@ -72,7 +72,7 @@ mod htable {
 
     impl ReadFilesystem<'_> {
         fn get(&self, k: FSKey)
-            -> Pin<Box<dyn Future<Output=Result<Option<FSValue<RID>>>> + Send>>
+            -> Pin<Box<dyn Future<Output=Result<Option<FSValue>>> + Send>>
         {
             match self {
                 ReadFilesystem::ReadOnly(ds) => Box::pin(ds.get(k)),
@@ -682,7 +682,7 @@ impl Fs {
     fn do_read<DS>(dataset: DS, ino: u64, fsize: u64, rs: u64, offset: u64,
                    size: usize)
         -> impl Future<Output=Result<SGList>>
-        where DS: ReadDataset<FSKey, FSValue<RID>>
+        where DS: ReadDataset<FSKey, FSValue>
     {
         // Populate a hole region in an sglist.
         let fill_hole = |sglist: &mut SGList, p: &mut u64, l: usize| {
@@ -1913,7 +1913,7 @@ impl Fs {
         struct ReaddirStream {
             /// Number of entries to skip from the first bucket
             bucket_idx: u8,
-            rq: RangeQuery<FSKey, FSKey, FSValue<RID>>,
+            rq: RangeQuery<FSKey, FSKey, FSValue>,
             /// If the stream is currently positioned in the middle of a bucket,
             /// store that bucket
             bucketing: Option<Bucketing>
@@ -2482,7 +2482,7 @@ impl Fs {
         // this point, we don't know if any of the records we're writing to are
         // already dirty.
         let nrecs = uio.nrecs(offset0, rs);
-        let bb = FSValue::<RID>::extent_space(rs, nrecs);
+        let bb = FSValue::extent_space(rs, nrecs);
 
         self.db.fswrite(self.tree, 1 + nrecs, 0, nrecs, bb,
         move |ds| async move {

--- a/bfffs-core/src/tree/tree/tests/io.rs
+++ b/bfffs-core/src/tree/tree/tests/io.rs
@@ -1766,7 +1766,7 @@ root:
 fn serialize_forest() {
     let mock = IDML::default();
     let idml = Arc::new(mock);
-    let typical_tree: Tree<RID, IDML, FSKey, FSValue<RID>> =
+    let typical_tree: Tree<RID, IDML, FSKey, FSValue> =
         Tree::from_str(idml, false, r#"
 ---
 limits:

--- a/bfffs-core/tests/cacheable_space.rs
+++ b/bfffs-core/tests/cacheable_space.rs
@@ -70,7 +70,7 @@ impl<K: Key, V: Value> CacheableForgetable for Arc<Node<DRP, K, V>> {
     }
 }
 
-impl CacheableForgetable for Arc<Node<RID, FSKey, FSValue<RID>>> {
+impl CacheableForgetable for Arc<Node<RID, FSKey, FSValue>> {
     fn forget(self: Box<Self>) -> Credit {
         let nd = Arc::try_unwrap(*self).unwrap().try_unwrap().unwrap();
         if nd.is_leaf() {
@@ -142,7 +142,7 @@ fn fs_int(_wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         let child = IntElem::new(k, txgs.clone(), TreePtr::Addr(addr));
         children.push(child);
     }
-    let nd = NodeData::<RID, FSKey, FSValue<RID>>::Int(IntData::new(children));
+    let nd = NodeData::<RID, FSKey, FSValue>::Int(IntData::new(children));
     Box::new(Arc::new(Node::new(nd)))
 }
 
@@ -159,7 +159,7 @@ fn fs_leaf_blob_extent(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable>
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, credit);
     }
-    let node_data = NodeData::<RID, FSKey, FSValue<RID>>::Leaf(ld);
+    let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
 }
 
@@ -176,7 +176,7 @@ fn fs_leaf_direntry(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, credit);
     }
-    let node_data = NodeData::<RID, FSKey, FSValue<RID>>::Leaf(ld);
+    let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
 }
 
@@ -198,7 +198,7 @@ fn fs_leaf_direntries(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> 
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, credit);
     }
-    let node_data = NodeData::<RID, FSKey, FSValue<RID>>::Leaf(ld);
+    let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
 }
 
@@ -210,7 +210,7 @@ fn fs_leaf_dyinginode(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> 
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, credit);
     }
-    let node_data = NodeData::<RID, FSKey, FSValue<RID>>::Leaf(ld);
+    let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
 }
 
@@ -232,7 +232,7 @@ fn fs_leaf_extattr_blob(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, credit);
     }
-    let node_data = NodeData::<RID, FSKey, FSValue<RID>>::Leaf(ld);
+    let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
 }
 
@@ -252,7 +252,7 @@ fn fs_leaf_extattr_inline(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetab
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, credit);
     }
-    let node_data = NodeData::<RID, FSKey, FSValue<RID>>::Leaf(ld);
+    let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
 }
 
@@ -284,7 +284,7 @@ fn fs_leaf_extattrs(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, credit);
     }
-    let node_data = NodeData::<RID, FSKey, FSValue<RID>>::Leaf(ld);
+    let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
 }
 
@@ -298,7 +298,7 @@ fn fs_leaf_inline_extent(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetabl
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, credit);
     }
-    let node_data = NodeData::<RID, FSKey, FSValue<RID>>::Leaf(ld);
+    let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
 }
 
@@ -324,7 +324,7 @@ fn fs_leaf_inode(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, credit);
     }
-    let node_data = NodeData::<RID, FSKey, FSValue<RID>>::Leaf(ld);
+    let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
 }
 
@@ -336,7 +336,7 @@ fn fs_leaf_property(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, credit);
     }
-    let node_data = NodeData::<RID, FSKey, FSValue<RID>>::Leaf(ld);
+    let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
 }
 


### PR DESCRIPTION
FSValue was only generic because of some old limitation in the compiler.
But apparently that limitation was lifted by 1.41.0 or earlier.  Time to
make FSValue concrete.