### PR TITLE
Change Value::needs_flush into an associated constant

### DIFF
--- a/bfffs-core/src/fs_tree.rs
+++ b/bfffs-core/src/fs_tree.rs
@@ -984,6 +984,7 @@ impl TypicalSize for FSValue {
 }
 
 impl Value for FSValue {
+    const NEEDS_FLUSH: bool = true;
 
     fn allocated_space(&self) -> usize {
         match self {
@@ -1025,10 +1026,6 @@ impl Value for FSValue {
             },
             _ => future::ok(self).boxed()
         }
-    }
-
-    fn needs_flush() -> bool {
-        true
     }
 }
 


### PR DESCRIPTION
Slightly reduces the binary size.  No benchmarks yet.