### PR TITLE
Revert "Workaround Rust bug 93209 in CI"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,9 +16,7 @@ task:
     # Use bleeding edge features: Rust nightly and FreeBSD fspacectl
     - name: cargo test (nightly)
       env:
-        # Pin nightly compiler to workaround
-        # https://github.com/rust-lang/rust/issues/93209
-        VERSION: nightly-2022-01-20
+        VERSION: nightly
         CARGO_ARGS: --all-features
       freebsd_instance:
         image_family: freebsd-14-0-snap
@@ -57,9 +55,7 @@ task:
 lint_task:
   name: lint
   env:
-    # Pin nightly compiler to workaround
-    # https://github.com/rust-lang/rust/issues/93209
-    VERSION: nightly-2022-01-20
+    VERSION: nightly
     CARGO_ARGS: --all-features
   freebsd_instance:
     image: freebsd-12-3-release-amd64

--- a/bfffs-core/src/vdev_file.rs
+++ b/bfffs-core/src/vdev_file.rs
@@ -414,8 +414,7 @@ impl VdevFile {
             f.read_at(&mut rbuf[..], offset).unwrap().await
         };
         match r {
-            Ok(aio_result) => {
-                drop(aio_result);   // release reference on dbs
+            Ok(_aio_result) => {
                 match LabelReader::new(rbuf) {
                     Ok(lr) => Ok((lr, f)),
                     Err(e) => Err((e, f))


### PR DESCRIPTION
This reverts commit 91558f3ce9885ca10bc82697a1e309a403adfa4c.
The rustc bug has been fixed.