### PR TITLE
Eliminate Dataset::remove_blob

### DIFF
--- a/bfffs-core/src/database/database.rs
+++ b/bfffs-core/src/database/database.rs
@@ -351,6 +351,16 @@ impl Database {
         }
     }
 
+    pub async fn dump_alloct(&self, f: &mut dyn io::Write) -> Result<()>
+    {
+        self.inner.idml.dump_alloct(f).await
+    }
+
+    pub async fn dump_ridt(&self, f: &mut dyn io::Write) -> Result<()>
+    {
+        self.inner.idml.dump_ridt(f).await
+    }
+
     /// Flush the database's dirty data to disk.
     ///
     /// Does not sync a transaction.  Does not rewrite the labels.

--- a/bfffs-core/src/dataset/dataset.rs
+++ b/bfffs-core/src/dataset/dataset.rs
@@ -96,12 +96,6 @@ impl<K: Key, V: Value> Dataset<K, V> {
         self.tree.clone().remove(k, txg, credit)
     }
 
-    fn remove_blob(&self, rid: RID, txg: TxgT)
-        -> impl Future<Output=Result<Box<DivBufShared>>> + Send
-    {
-        self.idml.pop::<DivBufShared, DivBuf>(&rid, txg)
-    }
-
     fn size(&self) -> LbaT {
         self.idml.size()
     }
@@ -207,12 +201,6 @@ impl<K: Key, V: Value> ReadWriteDataset<K, V> {
     {
         let credit = self.credit.atomic_split(self.cr.remove);
         self.dataset.remove(k, self.txg, credit)
-    }
-
-    pub fn remove_blob(&self, rid: RID)
-        -> impl Future<Output=Result<Box<DivBufShared>>> + Send
-    {
-        self.dataset.remove_blob(rid, self.txg)
     }
 }
 

--- a/bfffs-core/src/ddml/mod.rs
+++ b/bfffs-core/src/ddml/mod.rs
@@ -56,7 +56,7 @@ impl DRP {
     }
 
     /// Return the storage space actually allocated for this record
-    fn asize(&self) -> LbaT {
+    pub fn asize(&self) -> LbaT {
         div_roundup(self.csize as usize, BYTES_PER_LBA) as LbaT
     }
 

--- a/bfffs-core/src/fs_tree.rs
+++ b/bfffs-core/src/fs_tree.rs
@@ -974,7 +974,6 @@ impl TypicalSize for FSValue {
 }
 
 impl Value for FSValue {
-    const NEEDS_DCLONE: bool = true;
     const NEEDS_FLUSH: bool = true;
 
     fn allocated_space(&self) -> usize {

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -571,9 +571,10 @@ impl DML for IDML {
                 let alloct_fut = alloct2.remove(entry.drp.pba(), txg,
                     Credit::null());
                 let ridt_fut = ridt2.remove(rid, txg, Credit::null());
-                let (cacheable, old_rid, _old_ridt_entry) =
+                let (cacheable, old_rid, old_ridt_entry) =
                     future::try_join3(bfut, alloct_fut, ridt_fut).await?;
                 assert!(old_rid.is_some());
+                assert!(old_ridt_entry.is_some());
                 Ok(cacheable)
             } else {
                 let cacheval = cache2.lock().unwrap()
@@ -585,7 +586,8 @@ impl DML for IDML {
                     ddml2.get_direct::<T>(&entry.drp).boxed()
                 });
                 let ridt_fut = ridt2.insert(rid, entry, txg, Credit::null());
-                let (cacheable, _) = future::try_join(bfut, ridt_fut).await?;
+                let (cacheable, oldr) = future::try_join(bfut, ridt_fut).await?;
+                assert!(oldr.is_some());
                 Ok(cacheable)
             }
         }.boxed()

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -15,6 +15,7 @@ use futures_locks::{RwLock, RwLockReadFut};
 #[cfg(test)] use mockall::mock;
 use serde_derive::{Deserialize, Serialize};
 use std::{
+    io,
     pin::Pin,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -221,6 +222,16 @@ impl<'a> IDML {
         // TODO: apply configurable writeback size
         let writeback = WriteBack::limitless();
         IDML{cache, ddml, next_rid, transaction, alloct, ridt, writeback}
+    }
+
+    pub async fn dump_alloct(&self, f: &mut dyn io::Write) -> Result<()>
+    {
+        self.alloct.dump(f).await
+    }
+
+    pub async fn dump_ridt(&self, f: &mut dyn io::Write) -> Result<()>
+    {
+        self.ridt.dump(f).await
     }
 
     /// Flush the IDML's data to disk
@@ -616,6 +627,10 @@ mock!{
         pub fn clean_zone(&self, zone: ClosedZone, txg: TxgT)
             -> Pin<Box<dyn Future<Output=Result<()>> + Send>>;
         pub fn create(ddml: Arc<DDML>, cache: Arc<Mutex<Cache>>) -> Self;
+        pub fn dump_alloct(&self, f: &mut dyn io::Write)
+            -> Pin<Box<dyn Future<Output = Result<()>> + Send>>;
+        pub fn dump_ridt(&self, f: &mut dyn io::Write)
+            -> Pin<Box<dyn Future<Output = Result<()>> + Send>>;
         pub fn flush(&self, idx: Option<u32>, txg: TxgT)
             -> Pin<Box<dyn Future<Output=Result<()>> + Send>>;
         pub fn list_closed_zones(&self)

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -102,9 +102,6 @@ impl Key for u32 {}
 pub trait Value: Clone + Debug + DeserializeOwned + PartialEq + Send + Sync +
     Serialize + TypicalSize + 'static
 {
-    /// Does this Value type require dclone/ddrop ?
-    const NEEDS_DCLONE: bool = false;
-
     /// Does this Value type require flushing?
     const NEEDS_FLUSH: bool = false;
 
@@ -122,7 +119,7 @@ pub trait Value: Clone + Debug + DeserializeOwned + PartialEq + Send + Sync +
         -> Pin<Box<dyn Future<Output=Result<()>> + Send>>
         where D: DML + 'static, D::Addr: 'static
     {
-        // should never be called since NEEDS_DCLONE is false.  Ideally, this
+        // should never be called since NEEDS_FLUSH is false.  Ideally, this
         // entire function should go away once generic specialization is stable
         // https://github.com/rust-lang/rust/issues/31844
         unreachable!()
@@ -133,7 +130,7 @@ pub trait Value: Clone + Debug + DeserializeOwned + PartialEq + Send + Sync +
         -> Pin<Box<dyn Future<Output=Result<()>> + Send>>
         where D: DML + 'static, D::Addr: 'static
     {
-        // should never be called since NEEDS_DCLONE is false.  Ideally, this
+        // should never be called since NEEDS_FLUSH is false.  Ideally, this
         // entire function should go away once generic specialization is stable
         // https://github.com/rust-lang/rust/issues/31844
         unreachable!()
@@ -415,7 +412,7 @@ impl<K: Key, V: Value> LeafData<K, V> {
         for k in keys.into_iter() {
             let v = self.items.remove(k.borrow()).unwrap();
             allocated_space += v.allocated_space();
-            if V::NEEDS_DCLONE {
+            if V::NEEDS_FLUSH {
                 fut.push(v.ddrop::<D>(dml, txg));
             }
         }

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -147,6 +147,19 @@ pub trait Value: Clone + Debug + DeserializeOwned + PartialEq + Send + Sync +
         // https://github.com/rust-lang/rust/issues/31844
         unreachable!()
     }
+
+    /// Drop a reference to the on-disk data, and read it into `self`, like the
+    /// opposite of [`flush`].
+    fn dpop<D>(self, _dml: &D, _txg: TxgT)
+        -> Pin<Box<dyn Future<Output=Result<Self>> + Send>>
+        where D: DML + 'static, D::Addr: 'static
+    {
+        // should never be called since needs_flush is false.  Ideally, this
+        // entire function should go away once generic specialization is stable
+        // https://github.com/rust-lang/rust/issues/31844
+        unreachable!()
+    }
+
     // LCOV_EXCL_STOP
 }
 
@@ -331,8 +344,15 @@ impl<K: Key, V: Value> LeafData<K, V> {
 
     /// Insert one key-value pair into the LeafData, returning the old value, if
     /// any.  Also, return any excess credit that was provided.
-    pub fn insert(&mut self, k: K, v: V, mut credit: Credit)
-        -> (Option<V>, Credit)
+    pub fn insert<A, D>(
+        &mut self,
+        k: K,
+        v: V,
+        txg: TxgT,
+        dml: &D,
+        mut credit: Credit)
+        -> impl Future<Output = Result<(Option<V>, Credit)>> + Send
+        where D: DML<Addr=A> + 'static, A: 'static
     {
         self.assert_accredited();
         let v_space = v.allocated_space();
@@ -353,7 +373,14 @@ impl<K: Key, V: Value> LeafData<K, V> {
         self.assert_accredited();
         // Return excess credit, which might've resulted from an insertion
         // to an already-dirty record.
-        (old_v, excess_credit)
+        if V::NEEDS_FLUSH {
+            if let Some(v) = old_v {
+                return v.dpop(dml, txg)
+                    .map_ok(move |v| (Some(v), excess_credit))
+                    .boxed()
+            }
+        }
+        future::ok((old_v, excess_credit)).boxed()
     }
 
     pub fn get<Q>(&self, k: &Q) -> Option<V>
@@ -436,8 +463,14 @@ impl<K: Key, V: Value> LeafData<K, V> {
         self.range_delete_unaccredited(dml, txg, range)
     }
 
-    pub fn remove<Q>(&mut self, k: &Q) -> (Option<V>, Credit)
-        where K: Borrow<Q>, Q: Ord
+    pub async fn remove<D, Q>(
+        &mut self,
+        dml: &D,
+        txg: TxgT,
+        k: &Q
+    ) -> Result<(Option<V>, Credit)>
+        where D: DML + 'static,
+              K: Borrow<Q>, Q: Ord
     {
         self.assert_accredited();
         let old_v = self.items.remove(k);
@@ -450,7 +483,12 @@ impl<K: Key, V: Value> LeafData<K, V> {
             Credit::null()
         };
         self.assert_accredited();
-        (old_v, credit)
+        if V::NEEDS_FLUSH {
+            if let Some(v) = old_v {
+                return Ok((Some(v.dpop(dml, txg).await?), credit));
+            }
+        }
+        Ok((old_v, credit))
     }
 
     /// Split this LeafNode in two.  Returns the transaction range of the rump

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -1221,7 +1221,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
 
         if cg.is_leaf() {
             Tree::<A, D, K, V>::insert_leaf_no_split(&mut rg.elem, cg, k, v,
-                txg, &self.dml, credit).await
+                txg, self.dml.clone(), credit).await
         } else {
             drop(rg);
             self.insert_int_no_split(cg, k, v, txg, credit).await
@@ -1251,7 +1251,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
         } else if child.is_leaf() {
             let elem = &mut parent.as_int_mut().children[child_idx];
             Box::pin(Tree::<A, D, K, V>::insert_leaf_no_split(elem,
-                child, k, v, txg, &self.dml, credit))
+                child, k, v, txg, self.dml.clone(), credit))
         } else {
             drop(parent);
             Box::pin(Tree::insert_int_no_split(self, child, k, v, txg, credit))
@@ -1285,14 +1285,17 @@ impl<A, D, K, V> Tree<A, D, K, V>
         k: K,
         v: V,
         txg: TxgT,
-        dml: &D,
+        dml: Arc<D>,
         credit: Credit)
-        -> impl Future<Output=Result<Option<V>>>
+        -> impl Future<Output = Result<Option<V>>> + Send
     {
-        let (old_v, excess) = child.as_leaf_mut().insert(k, v, credit);
         elem.txgs = txg..txg + 1;
-        dml.repay(excess);
-        future::ok(old_v)
+        child.as_leaf_mut()
+        .insert(k, v, txg, dml.as_ref(), credit)
+        .map_ok(move |(old_v, excess)| {
+            dml.repay(excess);
+            old_v
+        })
     }
 
     /// Has the Tree been modified since the last time it was flushed to disk?
@@ -2083,7 +2086,8 @@ impl<A, D, K, V> Tree<A, D, K, V>
     {
 
         if node.is_leaf() {
-            let (old_v, leaf_credit) = node.as_leaf_mut().remove(&k);
+            let (old_v, leaf_credit) = node.as_leaf_mut()
+                .remove(self.dml.as_ref(), txg, &k).await?;
             credit.extend(leaf_credit);
             self.dml.repay(credit);
             Ok(old_v)

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -1958,7 +1958,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
     {
         if height == 0 {
             debug_assert!(guard.is_leaf());
-            if V::NEEDS_DCLONE {
+            if V::NEEDS_FLUSH {
                 guard.as_leaf_mut()
                     .range_delete(dml.as_ref(), txg, ..)
                     .map_ok(move |credit| {
@@ -1977,7 +1977,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
                 match elem.ptr {
                     TreePtr::Addr(addr) => {
                         // Delete on-disk leaves
-                        if V::NEEDS_DCLONE {
+                        if V::NEEDS_FLUSH {
                             dml.pop::<Arc<Node<A, K, V>>, Arc<Node<A, K, V>>>
                                 (&addr, txg)
                             .and_then(move |anode| {
@@ -1999,7 +1999,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
                     TreePtr::Mem(node) => {
                         let child_guard = node.0.try_unwrap().unwrap();
                         let mut leaf = child_guard.into_leaf();
-                        if V::NEEDS_DCLONE {
+                        if V::NEEDS_FLUSH {
                             // Must recurse into the leaves.
                             leaf.range_delete(dml.as_ref(), txg, ..).boxed()
                         } else {

--- a/bfffs-core/src/tree/tree/tests/mod.rs
+++ b/bfffs-core/src/tree/tree/tests/mod.rs
@@ -33,7 +33,7 @@ impl TypicalSize for NeedsDcloneV {
 }
 
 impl Value for NeedsDcloneV {
-    const NEEDS_DCLONE: bool = true;
+    const NEEDS_FLUSH: bool = true;
 
     fn ddrop<D>(&self, dml: &D, txg: TxgT)
         -> Pin<Box<dyn Future<Output=Result<()>> + Send>>


### PR DESCRIPTION
    The Fs needn't worry about manipulating blobs now.  Both writing them
    and removing them is entirely the responsibility of the Tree and IDML.
    It still needs to read from them, though.
    
    This was accomplished by adding a Value::dpop method, which is basically
    the opposite of Value::flush.  When removing a Value from a Tree, dpop
    ensures that it pops any blobs from the IDML at the same time.

Also, do some related stuff, and fix some storage leaks regarding extended attributes.