### PR TITLE
Fix issues with Pool::allocated

### DIFF
--- a/bfffs-core/src/database/database.rs
+++ b/bfffs-core/src/database/database.rs
@@ -294,8 +294,8 @@ pub struct Dirent {
 /// Information about the overall properties of a bfffs pool.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Stat {
-    /// Number of blocks have been allocated across the entire pool.
-    pub allocated: LbaT,
+    /// Number of blocks that are in-use across the entire pool.
+    pub used: LbaT,
     /// The approximate usable size of the Pool in blocks.
     pub size: LbaT,
 }
@@ -665,8 +665,8 @@ impl Database {
     /// Retrieve information about a pool's space usage
     pub fn stat(&self) -> Stat {
         Stat {
-            allocated: self.inner.idml.allocated(),
             size: self.inner.idml.size(),
+            used: self.inner.idml.used(),
         }
     }
 

--- a/bfffs-core/src/dataset/dataset.rs
+++ b/bfffs-core/src/dataset/dataset.rs
@@ -25,10 +25,6 @@ struct Dataset<K: Key, V: Value>  {
 }
 
 impl<K: Key, V: Value> Dataset<K, V> {
-    fn allocated(&self) -> LbaT {
-        self.idml.allocated()
-    }
-
     fn delete_blob(&self, rid: RID, txg: TxgT)
         -> impl Future<Output=Result<()>>
     {
@@ -99,6 +95,10 @@ impl<K: Key, V: Value> Dataset<K, V> {
     fn size(&self) -> LbaT {
         self.idml.size()
     }
+
+    fn used(&self) -> LbaT {
+        self.idml.used()
+    }
 }
 
 /// A dataset handle with read-only access
@@ -107,10 +107,6 @@ pub struct ReadOnlyDataset<K: Key, V: Value>  {
 }
 
 impl<K: Key, V: Value> ReadOnlyDataset<K, V> {
-    pub fn allocated(&self) -> LbaT {
-        self.dataset.allocated()
-    }
-
     pub fn last_key(&self) -> impl Future<Output=Result<Option<K>>> + Send
     {
         self.dataset.last_key()
@@ -122,6 +118,10 @@ impl<K: Key, V: Value> ReadOnlyDataset<K, V> {
 
     pub fn size(&self) -> LbaT {
         self.dataset.size()
+    }
+
+    pub fn used(&self) -> LbaT {
+        self.dataset.used()
     }
 }
 

--- a/bfffs-core/src/dataset/dataset_mock.rs
+++ b/bfffs-core/src/dataset/dataset_mock.rs
@@ -21,12 +21,12 @@ use super::{ITree, RangeQuery, ReadDataset, ReadOnlyDataset, ReadWriteDataset};
 
 mock! {
     pub ReadOnlyDataset<K: Key, V: Value> {
-        pub fn allocated(&self) -> LbaT;
         pub fn last_key(&self)
             -> Pin<Box<dyn Future<Output=Result<Option<K>>> + Send>>;
         pub fn new(idml: Arc<IDML>, tree: Arc<ITree<K, V>>)
             -> ReadOnlyDataset<K, V>;
         pub fn size(&self) -> LbaT;
+        pub fn used(&self) -> LbaT;
     }
     impl<K: Key, V: Value> ReadDataset<K, V> for ReadOnlyDataset<K, V> {
         fn get(&self, k: K)

--- a/bfffs-core/src/ddml/ddml.rs
+++ b/bfffs-core/src/ddml/ddml.rs
@@ -42,12 +42,6 @@ pub struct DDML {
 // instead by integration tests.
 #[cfg_attr(test, allow(unused))]
 impl DDML {
-    /// How many blocks have been allocated, including blocks that have been
-    /// freed but not erased?
-    pub fn allocated(&self) -> LbaT {
-        self.pool.allocated()
-    }
-
     /// Assert that the given zone was clean as of the given transaction
     #[cfg(debug_assertions)]
     pub fn assert_clean_zone(&self, cluster: ClusterT, zone: ZoneT, txg: TxgT) {
@@ -218,6 +212,11 @@ impl DDML {
         self.pool.size()
     }
 
+    /// How many blocks are currently used?
+    pub fn used(&self) -> LbaT {
+        self.pool.used()
+    }
+
     pub fn write_label(&self, labeller: LabelWriter)
         -> impl Future<Output=Result<()>> + Send
     {
@@ -309,7 +308,6 @@ impl DML for DDML {
 #[cfg(test)]
 mock! {
     pub DDML {
-        pub fn allocated(&self) -> LbaT;
         pub fn assert_clean_zone(&self, cluster: ClusterT, zone: ZoneT, txg: TxgT);
         pub fn delete_direct(&self, drp: &DRP, txg: TxgT) -> BoxVdevFut;
         pub fn flush(&self, idx: u32) -> BoxVdevFut;
@@ -327,6 +325,7 @@ mock! {
             -> Pin<Box<dyn Future<Output=Result<DRP>> + Send>>
             where T: borrow::Borrow<dyn CacheRef>;
         pub fn size(&self) -> LbaT;
+        pub fn used(&self) -> LbaT;
         pub fn write_label(&self, labeller: LabelWriter)
             -> Pin<Box<dyn Future<Output=Result<()>> + Send>>;
     }

--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -2318,10 +2318,10 @@ impl Fs {
         let rs = 1 << self.record_size.load(Ordering::Relaxed);
         self.db.fsread(self.tree, move |dataset| {
             let blocks = dataset.size();
-            let allocated = dataset.allocated();
+            let used = dataset.used();
             let r = libc::statvfs {
-                f_bavail: blocks - allocated,
-                f_bfree: blocks - allocated,
+                f_bavail: blocks - used,
+                f_bfree: blocks - used,
                 f_blocks: blocks,
                 f_favail: u64::max_value(),
                 f_ffree: u64::max_value(),

--- a/bfffs-core/src/pool.rs
+++ b/bfffs-core/src/pool.rs
@@ -3,7 +3,6 @@
 use crate::{
     label::*,
     types::*,
-    util::*,
     vdev::*
 };
 use futures::{
@@ -20,7 +19,7 @@ use std::{
     ops::Range,
     pin::Pin,
     sync::{
-        atomic::{AtomicU32, AtomicU64, Ordering},
+        atomic::{AtomicU32, Ordering},
         Arc
     }
 };
@@ -76,48 +75,9 @@ struct Stats {
 
     /// The total size of each `Cluster`
     size: Vec<LbaT>,
-
-    /// The total amount of allocated space in each `Cluster`, excluding
-    /// space that has already been freed but not erased.
-    allocated_space: Vec<AtomicU64>,
 }
 
 impl Stats {
-    /// How many blocks have been allocated, including blocks that have been
-    /// freed but not erased?
-    fn allocated(&self) -> LbaT {
-        self.allocated_space.iter()
-            .map(|alloc| alloc.load(Ordering::Relaxed))
-            .sum()
-    }
-
-    /// Choose the best Cluster for the next write
-    ///
-    /// This decision is subjective, but should strive to:
-    /// 1) Balance capacity utilization amongst all Clusters
-    /// 2) Balance IOPs amongst all Clusters
-    /// 3) Run quickly
-    fn choose_cluster(&self) -> ClusterT {
-        // This simple implementation weighs both capacity utilization and IOPs,
-        // though above 95% utilization it switches to weighing by capacity
-        // utilization only.  It's slow because it iterates through all clusters
-        // on every write.  A better implementation would perform the full
-        // calculation only occasionally, to update coefficients, and perform a
-        // quick calculation on each write.
-        (0..self.size.len()).map(|i| {
-            let alloc = self.allocated_space[i].load(Ordering::Relaxed) as f64;
-            let space_util = alloc / (self.size[i] as f64);
-            let qdepth = self.queue_depth[i].load(Ordering::Relaxed) as f64;
-            let queue_fraction = qdepth / self.optimum_queue_depth[i];
-            let q_coeff = if 0.95 > space_util {0.95 - space_util} else {0.0};
-            let weight = q_coeff * queue_fraction + space_util;
-            (i, weight)
-        })
-        .min_by(|&(_, x), &(_, y)| x.partial_cmp(&y).unwrap())
-        .map(|(i, _)| i)
-        .unwrap() as ClusterT
-    }
-
     /// The approximate usable size of the Pool
     fn size(&self) -> LbaT {
         self.size.iter().sum()
@@ -141,13 +101,44 @@ impl Pool {
     /// How many blocks have been allocated, including blocks that have been
     /// freed but not erased?
     pub fn allocated(&self) -> LbaT {
-        self.stats.allocated()
+        self.clusters.iter()
+            .map(Cluster::allocated)
+            .sum()
     }
 
     /// Assert that the given zone was clean as of the given transaction
     #[cfg(debug_assertions)]
     pub fn assert_clean_zone(&self, cluster: ClusterT, zone: ZoneT, txg: TxgT) {
         self.clusters[cluster as usize].assert_clean_zone(zone, txg)
+    }
+
+    /// Choose the best Cluster for the next write
+    ///
+    /// This decision is subjective, but should strive to:
+    /// 1) Balance capacity utilization amongst all Clusters
+    /// 2) Balance IOPs amongst all Clusters
+    /// 3) Run quickly
+    fn choose_cluster(&self) -> ClusterT {
+        // This simple implementation weighs both capacity utilization and IOPs,
+        // though above 95% utilization it switches to weighing by capacity
+        // utilization only.  It's slow because it iterates through all clusters
+        // on every write.  A better implementation might perform the full
+        // calculation only occasionally, to update coefficients, and perform a
+        // quick calculation on each write.
+        (0..self.clusters.len())
+        .map(|i| {
+            let alloc = self.clusters[i].allocated() as f64;
+            let space_util = alloc / (self.stats.size[i] as f64);
+            let qdepth = self.stats.queue_depth[i]
+                .load(Ordering::Relaxed) as f64;
+            let queue_fraction = qdepth / self.stats.optimum_queue_depth[i];
+            let q_coeff = if 0.95 > space_util {0.95 - space_util} else {0.0};
+            let weight = q_coeff * queue_fraction + space_util;
+            (i, weight)
+        })
+        .min_by(|&(_, x), &(_, y)| x.partial_cmp(&y).unwrap())
+        .map(|(i, _)| i)
+        .unwrap() as ClusterT
     }
 
     /// Create a new `Cluster` from unused files or devices.
@@ -208,8 +199,6 @@ impl Pool {
     // above the layer of the Pool.
     pub fn free(&self, pba: PBA, length: LbaT) -> BoxVdevFut
     {
-        let idx = pba.cluster as usize;
-        self.stats.allocated_space[idx].fetch_sub(length, Ordering::Relaxed);
         Box::pin(self.clusters[pba.cluster as usize].free(pba.lba, length))
     }
 
@@ -221,9 +210,6 @@ impl Pool {
         let size = clusters.iter()
             .map(Cluster::size)
             .collect::<Vec<_>>();
-        let allocated_space = clusters.iter()
-            .map(|cluster| AtomicU64::new(cluster.allocated()))
-            .collect::<Vec<_>>();
         let optimum_queue_depth = clusters.iter()
             .map(|cluster| f64::from(cluster.optimum_queue_depth()))
             .collect::<Vec<_>>();
@@ -234,7 +220,6 @@ impl Pool {
             queue_depth,
             optimum_queue_depth,
             size,
-            allocated_space,
         });
         Pool{clusters, name, stats, uuid}
     }
@@ -360,20 +345,15 @@ impl Pool {
     pub fn write(&self, buf: IoVec, txg: TxgT)
         -> Pin<Box<dyn Future<Output=Result<PBA>> + Send>>
     {
-        let cluster = self.stats.choose_cluster();
+        let cluster = self.choose_cluster();
         let cidx = cluster as usize;
-        let space = div_roundup(buf.len(), BYTES_PER_LBA) as LbaT;
         let stats2 = self.stats.clone();
         match self.clusters[cidx].write(buf, txg) {
             Ok((lba, wfut)) => {
                 self.stats.queue_depth[cidx].fetch_add(1, Ordering::Relaxed);
                 wfut.map(move |r: Result<()>| {
                     stats2.queue_depth[cidx].fetch_sub(1, Ordering::Relaxed);
-                    r.map(|_| {
-                        stats2.allocated_space[cidx]
-                            .fetch_add(space, Ordering::Relaxed);
-                        PBA::new(cluster, lba)
-                    })
+                    r.and(Ok(PBA::new(cluster, lba)))
                 }).boxed()
             },
             Err(e) => future::err(e).boxed()
@@ -420,11 +400,96 @@ mod label {
 
 mod pool {
     use super::super::*;
-    use crate::cluster;
+    use crate::{cluster, util::*};
     use divbuf::DivBufShared;
     use futures::future;
     use mockall::predicate::*;
     use pretty_assertions::assert_eq;
+
+    /// Two clusters, one full and one empty.  Choose the empty one
+    #[test]
+    fn choose_cluster_empty() {
+        let mut c0 = Cluster::default();
+        c0.expect_allocated().return_const(0u64);
+        c0.expect_size().return_const(1000u64);
+        c0.expect_optimum_queue_depth().return_const(10u32);
+        let mut c1 = Cluster::default();
+        c1.expect_allocated().return_const(1000u64);
+        c1.expect_size().return_const(1000u64);
+        c1.expect_optimum_queue_depth().return_const(10u32);
+        let clusters = vec![c0, c1];
+        let pool =  Pool::new("foo".to_string(), Uuid::new_v4(), clusters);
+        assert_eq!(pool.choose_cluster(), 0);
+
+        // Try the reverse, too
+        let mut c0 = Cluster::default();
+        c0.expect_allocated().return_const(1000u64);
+        c0.expect_size().return_const(1000u64);
+        c0.expect_optimum_queue_depth().return_const(10u32);
+        let mut c1 = Cluster::default();
+        c1.expect_allocated().return_const(0u64);
+        c1.expect_size().return_const(1000u64);
+        c1.expect_optimum_queue_depth().return_const(10u32);
+        let clusters = vec![c0, c1];
+        let pool =  Pool::new("foo".to_string(), Uuid::new_v4(), clusters);
+        assert_eq!(pool.choose_cluster(), 1);
+    }
+
+    /// Two clusters, one busy and one idle.  Choose the idle one
+    #[test]
+    fn choose_cluster_queue_depth() {
+        let clust = || {
+            let mut c = Cluster::default();
+            c.expect_allocated().return_const(0u64);
+            c.expect_size().return_const(1000u64);
+            c.expect_optimum_queue_depth().return_const(10u32);
+            c
+        };
+        let clusters = vec![clust(), clust()];
+        let pool = Pool::new("foo".to_string(), Uuid::new_v4(), clusters);
+        pool.stats.queue_depth[0].store(0, Ordering::Relaxed);
+        pool.stats.queue_depth[1].store(10, Ordering::Relaxed);
+        assert_eq!(pool.choose_cluster(), 0);
+
+        // Try the reverse, too
+        pool.stats.queue_depth[0].store(10, Ordering::Relaxed);
+        pool.stats.queue_depth[1].store(0, Ordering::Relaxed);
+        assert_eq!(pool.choose_cluster(), 1);
+    }
+
+    /// Two clusters, one nearly full and idle, the other busy but not very
+    /// full.  Choose the not very full one.
+    #[test]
+    fn choose_cluster_nearly_full() {
+        let mut c0 = Cluster::default();
+        c0.expect_allocated().return_const(960u64);
+        c0.expect_size().return_const(1000u64);
+        c0.expect_optimum_queue_depth().return_const(10u32);
+        let mut c1 = Cluster::default();
+        c1.expect_allocated().return_const(50u64);
+        c1.expect_size().return_const(1000u64);
+        c1.expect_optimum_queue_depth().return_const(10u32);
+        let clusters = vec![c0, c1];
+        let pool =  Pool::new("foo".to_string(), Uuid::new_v4(), clusters);
+        pool.stats.queue_depth[0].store(0, Ordering::Relaxed);
+        pool.stats.queue_depth[1].store(10, Ordering::Relaxed);
+        assert_eq!(pool.choose_cluster(), 1);
+
+        // Try the reverse, too
+        let mut c0 = Cluster::default();
+        c0.expect_allocated().return_const(50u64);
+        c0.expect_size().return_const(1000u64);
+        c0.expect_optimum_queue_depth().return_const(10u32);
+        let mut c1 = Cluster::default();
+        c1.expect_allocated().return_const(960u64);
+        c1.expect_size().return_const(1000u64);
+        c1.expect_optimum_queue_depth().return_const(10u32);
+        let clusters = vec![c0, c1];
+        let pool =  Pool::new("foo".to_string(), Uuid::new_v4(), clusters);
+        pool.stats.queue_depth[0].store(10, Ordering::Relaxed);
+        pool.stats.queue_depth[1].store(0, Ordering::Relaxed);
+        assert_eq!(pool.choose_cluster(), 0);
+    }
 
     #[test]
     fn find_closed_zone() {
@@ -492,7 +557,7 @@ mod pool {
     fn free() {
         let cluster = || {
             let mut c = Cluster::default();
-            c.expect_allocated().return_const(0u64);
+            c.expect_allocated().return_const(100u64);
             c.expect_optimum_queue_depth().return_const(10u32);
             c.expect_size().return_const(32_768_000u64);
             c.expect_uuid().return_const(Uuid::new_v4());
@@ -510,6 +575,8 @@ mod pool {
         let pool = Pool::new("foo".to_string(), Uuid::new_v4(), clusters);
 
         assert!(rt.block_on(pool.free(PBA::new(1, 12345), 16)).is_ok());
+        // Freeing bytes should not decrease allocated.  Only erasing should.
+        assert_eq!(pool.allocated(), 200);
     }
 
     // optimum_queue_depth is always a smallish integer, so exact equality
@@ -528,8 +595,6 @@ mod pool {
 
         let clusters = vec![ cluster(), cluster() ];
         let pool = Pool::new("foo".to_string(), Uuid::new_v4(), clusters);
-        assert_eq!(pool.stats.allocated_space[0].load(Ordering::Relaxed), 500);
-        assert_eq!(pool.stats.allocated_space[1].load(Ordering::Relaxed), 500);
         assert_eq!(pool.stats.optimum_queue_depth[0], 10.0);
         assert_eq!(pool.stats.optimum_queue_depth[1], 10.0);
         assert_eq!(pool.allocated(), 1000);
@@ -670,98 +735,6 @@ mod pool {
         let db0 = dbs.try_const().unwrap();
         let result = rt.block_on( pool.write(db0, TxgT::from(42)));
         assert_eq!(result.unwrap_err(), e);
-    }
-
-    // Make sure allocated space accounting is symmetric
-    #[test]
-    fn write_and_free() {
-        let mut cluster = Cluster::default();
-        cluster.expect_allocated().return_const(0u64);
-        cluster.expect_optimum_queue_depth().return_const(10u32);
-        cluster.expect_size().return_const(32_768_000u64);
-        cluster.expect_uuid().return_const(Uuid::new_v4());
-        cluster.expect_write()
-            .once()
-            .return_once(|_, _| Ok((0, Box::pin(future::ok(())))));
-        cluster.expect_free()
-            .once()
-            .return_once(|_, _| Box::pin(future::ok(())));
-
-        let rt = basic_runtime();
-        let pool = Pool::new("foo".to_string(), Uuid::new_v4(), vec![cluster]);
-
-        let dbs = DivBufShared::from(vec![0u8; 1024]);
-        let db0 = dbs.try_const().unwrap();
-        let drp = rt.block_on( pool.write(db0, TxgT::from(42))).unwrap();
-        assert!(pool.stats.allocated_space[0].load(Ordering::Relaxed) > 0);
-        rt.block_on( pool.free(drp, 1)).unwrap();
-        assert_eq!(pool.stats.allocated_space[0].load(Ordering::Relaxed), 0);
-    }
-}
-
-mod stats {
-    use pretty_assertions::assert_eq;
-    use super::super::*;
-
-    #[test]
-    fn allocated() {
-        let stats = Stats {
-            optimum_queue_depth: vec![10.0, 10.0],
-            queue_depth: vec![AtomicU32::new(0), AtomicU32::new(0)],
-            size: vec![1000, 1000],
-            allocated_space: vec![AtomicU64::new(10), AtomicU64::new(900)]
-        };
-        assert_eq!(stats.allocated(), 910);
-    }
-
-    #[test]
-    fn choose_cluster_empty() {
-        // Two clusters, one full and one empty.  Choose the empty one
-        let mut stats = Stats {
-            optimum_queue_depth: vec![10.0, 10.0],
-            queue_depth: vec![AtomicU32::new(0), AtomicU32::new(0)],
-            size: vec![1000, 1000],
-            allocated_space: vec![AtomicU64::new(0), AtomicU64::new(1000)]
-        };
-        assert_eq!(stats.choose_cluster(), 0);
-
-        // Try the reverse, too
-        stats.allocated_space = vec![AtomicU64::new(1000), AtomicU64::new(0)];
-        assert_eq!(stats.choose_cluster(), 1);
-    }
-
-    #[test]
-    fn choose_cluster_queue_depth() {
-        // Two clusters, one busy and one idle.  Choose the idle one
-        let mut stats = Stats {
-            optimum_queue_depth: vec![10.0, 10.0],
-            queue_depth: vec![AtomicU32::new(0), AtomicU32::new(10)],
-            size: vec![1000, 1000],
-            allocated_space: vec![AtomicU64::new(0), AtomicU64::new(0)]
-        };
-        assert_eq!(stats.choose_cluster(), 0);
-
-        // Try the reverse, too
-        stats.queue_depth = vec![AtomicU32::new(10), AtomicU32::new(0)];
-        assert_eq!(stats.choose_cluster(), 1);
-    }
-
-    #[test]
-    fn choose_cluster_nearly_full() {
-        // Two clusters, one nearly full and idle, the other busy but not very
-        // full.  Choose the not very full one.
-        let mut stats = Stats {
-            optimum_queue_depth: vec![10.0, 10.0],
-            queue_depth: vec![AtomicU32::new(0), AtomicU32::new(10)],
-            size: vec![1000, 1000],
-            allocated_space: vec![AtomicU64::new(960), AtomicU64::new(50)]
-        };
-        assert_eq!(stats.choose_cluster(), 1);
-
-        // Try the reverse, too
-        stats.queue_depth = vec![AtomicU32::new(10), AtomicU32::new(0)];
-        stats.allocated_space = vec![AtomicU64::new(50), AtomicU64::new(960)];
-        assert_eq!(stats.choose_cluster(), 0);
     }
 }
 }

--- a/bfffs-core/src/vdev_block.rs
+++ b/bfffs-core/src/vdev_block.rs
@@ -474,7 +474,7 @@ impl VdevBlock {
     fn check_iovec_bounds(&self, lba: LbaT, buf: &[u8]) {
         let buflen = buf.len() as u64;
         let last_lba : LbaT = lba + buflen / (BYTES_PER_LBA as u64);
-        assert!(last_lba < self.size as u64)
+        assert!(last_lba <= self.size as u64)
     }
 
     /// Helper function for readv and writev methods
@@ -484,7 +484,8 @@ impl VdevBlock {
         let len : u64 = bufs.iter().fold(0, |accumulator, buf| {
             accumulator + buf.len() as u64
         });
-        assert!(lba + len / (BYTES_PER_LBA as u64) < self.size as u64)
+        let last_lba = lba + len / (BYTES_PER_LBA as u64);
+        assert!(last_lba <= self.size as u64)
     }
 
     /// Create a new VdevBlock from an unused file or device

--- a/bfffs-core/tests/functional/fs.rs
+++ b/bfffs-core/tests/functional/fs.rs
@@ -710,7 +710,7 @@ mod fs {
         fs.sync().await;
 
         let stat2 = db.stat();
-        assert_eq!(stat2.allocated - stat1.allocated, 2);
+        assert_eq!(stat2.used - stat1.used, 2);
 
         drop(fs);
         let tree_id = db.lookup_fs("").await.unwrap().1.unwrap();
@@ -719,7 +719,7 @@ mod fs {
         // The fs tree and both blobs should've been deallocated.  Other
         // metadata stuff might've been deallocated too, in the forest or idml.
         let stat3 = db.stat();
-        assert!(stat3.allocated < stat1.allocated);
+        assert!(stat3.used < stat1.used);
     }
 
     // Dumps a nearly empty FS tree.  All of the real work is done in

--- a/bfffs-core/tests/functional/vdev_block.rs
+++ b/bfffs-core/tests/functional/vdev_block.rs
@@ -85,53 +85,70 @@ mod vdev_block {
         }).unwrap();
     }
 
-    #[should_panic]
     #[rstest]
-    fn check_iovec_bounds_over(vdev: (VdevBlock, TempDir)) {
+    #[tokio::test]
+    async fn check_iovec_bounds_within(vdev: (VdevBlock, TempDir)) {
         let dbs = DivBufShared::from(vec![42u8; 4096]);
         let wbuf = dbs.try_const().unwrap();
-        basic_runtime().block_on(async {
-            let size = vdev.0.size();
-            vdev.0.write_at(wbuf, size).await
-        }).unwrap();
+        let lba = vdev.0.size() - 1;
+        vdev.0.write_at(wbuf, lba).await.unwrap();
     }
 
     #[should_panic]
     #[rstest]
-    fn check_iovec_bounds_spans(vdev: (VdevBlock, TempDir)) {
+    #[tokio::test]
+    async fn check_iovec_bounds_over(vdev: (VdevBlock, TempDir)) {
+        let dbs = DivBufShared::from(vec![42u8; 4096]);
+        let wbuf = dbs.try_const().unwrap();
+        let lba = vdev.0.size();
+        vdev.0.write_at(wbuf, lba).await.unwrap();
+    }
+
+    #[should_panic]
+    #[rstest]
+    #[tokio::test]
+    async fn check_iovec_bounds_spans(vdev: (VdevBlock, TempDir)) {
         let dbs = DivBufShared::from(vec![42u8; 8192]);
         let wbuf = dbs.try_const().unwrap();
-        basic_runtime().block_on(async {
-            let size = vdev.0.size() - 1;
-            vdev.0.write_at(wbuf, size).await
-        }).unwrap();
+        let lba = vdev.0.size() - 1;
+        vdev.0.write_at(wbuf, lba).await.unwrap();
     }
 
-    #[should_panic]
     #[rstest]
-    fn check_sglist_bounds_over(vdev: (VdevBlock, TempDir)) {
+    #[tokio::test]
+    async fn check_sglist_bounds_within(vdev: (VdevBlock, TempDir)) {
         let dbs = DivBufShared::from(vec![42u8; 4096]);
         let wbuf = dbs.try_const().unwrap();
         let wbuf0 = wbuf.slice_to(1024);
         let wbuf1 = wbuf.slice_from(1024);
         let wbufs = vec![wbuf0, wbuf1];
-        basic_runtime().block_on(async {
-            let size = vdev.0.size();
-            vdev.0.writev_at(wbufs, size).await
-        }).unwrap();
+        let lba = vdev.0.size() - 1;
+        vdev.0.writev_at(wbufs, lba).await.unwrap();
     }
 
     #[should_panic]
     #[rstest]
-    fn check_sglist_bounds_spans(vdev: (VdevBlock, TempDir)) {
+    #[tokio::test]
+    async fn check_sglist_bounds_over(vdev: (VdevBlock, TempDir)) {
+        let dbs = DivBufShared::from(vec![42u8; 4096]);
+        let wbuf = dbs.try_const().unwrap();
+        let wbuf0 = wbuf.slice_to(1024);
+        let wbuf1 = wbuf.slice_from(1024);
+        let wbufs = vec![wbuf0, wbuf1];
+        let lba = vdev.0.size();
+        vdev.0.writev_at(wbufs, lba).await.unwrap();
+    }
+
+    #[should_panic]
+    #[rstest]
+    #[tokio::test]
+    async fn check_sglist_bounds_spans(vdev: (VdevBlock, TempDir)) {
         let dbs = DivBufShared::from(vec![42u8; 8192]);
         let wbuf = dbs.try_const().unwrap();
         let wbuf0 = wbuf.slice_to(5120);
         let wbuf1 = wbuf.slice_from(5120);
         let wbufs = vec![wbuf0, wbuf1];
-        basic_runtime().block_on(async {
-            let size = vdev.0.size() - 1;
-            vdev.0.writev_at(wbufs, size).await
-        }).unwrap();
+        let lba = vdev.0.size() - 1;
+        vdev.0.writev_at(wbufs, lba).await.unwrap();
     }
 }


### PR DESCRIPTION
* Fix the used space as shown by df if there are freed bytes
* Fix "bfffs fs check" if there are freed bytes
* Fix Pool's allocated space tracking by
  - Moving the calculations from Pool down into Cluster, where the stuff
      actually happens.  This also makes the unit testing easier, and saves
      one division operation on every write.
    
  -  Propertly accounting for freeing, erasing, finishing, and syncing
      operations.
* fix a fencepost error in VdevBlock
* asyncify the Cluster unit tests