### PR TITLE
Improve FS tree deserialize performance

### DIFF
--- a/bfffs-core/src/database/database.rs
+++ b/bfffs-core/src/database/database.rs
@@ -499,7 +499,7 @@ impl Database {
                 file_type: FileType::Dir,
                 perm: 0o755
             };
-            let inode_value = FSValue::Inode(inode);
+            let inode_value = FSValue::inode(inode);
 
             // Create the /. and /.. directory entries
             let dot_dirent = fs_tree::Dirent {

--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -652,7 +652,7 @@ impl Fs {
             perm: args.perm,
             file_type: args.file_type
         };
-        let inode_value = FSValue::Inode(inode);
+        let inode_value = FSValue::inode(inode);
 
         let ninsert = 5 + cb_credit.0;
         self.db.fswrite(self.tree, ninsert, cb_credit.1, cb_credit.2, bb,
@@ -841,7 +841,7 @@ impl Fs {
         };
 
         iv.bytes = iv.bytes.saturating_sub(freed_bytes);
-        dataset.insert(inode_key, FSValue::Inode(iv)).await
+        dataset.insert(inode_key, FSValue::inode(iv)).await
         .map(drop)
     }
 
@@ -1004,7 +1004,7 @@ impl Fs {
                 };
                 future::try_join(
                     fut,
-                    dataset.insert(key, FSValue::Inode(iv))
+                    dataset.insert(key, FSValue::inode(iv))
                     .map_ok(drop)
                 ).await?;
             } else {
@@ -1406,7 +1406,7 @@ impl Fs {
             // count.  The real VFS will provide a held vnode rather
             // than an inode.  So in neither case is there a race here.
             // XXX TODO: fuse3 is _not_ single-threaded
-            let ifut = ds.insert(inode_key, FSValue::Inode(iv));
+            let ifut = ds.insert(inode_key, FSValue::inode(iv));
 
             let dirent_objkey = ObjKey::dir_entry(&name);
             let dirent = Dirent { ino, dtype, name };

--- a/bfffs-core/src/fs/tests.rs
+++ b/bfffs-core/src/fs/tests.rs
@@ -113,7 +113,7 @@ async fn create() {
                 file_type: FileType::Dir,
                 perm: 0o755,
             };
-            future::ok(Some(FSValue::Inode(inode))).boxed()
+            future::ok(Some(FSValue::inode(inode))).boxed()
         });
     ds.expect_insert()
         .once()
@@ -193,7 +193,7 @@ async fn create_hash_collision() {
                 file_type: FileType::Dir,
                 perm: 0o755,
             };
-            future::ok(Some(FSValue::Inode(inode))).boxed()
+            future::ok(Some(FSValue::inode(inode))).boxed()
         });
     ds.expect_insert()
         .once()

--- a/bfffs-core/tests/cacheable_space.rs
+++ b/bfffs-core/tests/cacheable_space.rs
@@ -401,7 +401,7 @@ fn fs_leaf_inode(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
             perm: 0o644,
             file_type: FileType::Reg(17)
         };
-        let v = FSValue::Inode(inode);
+        let v = FSValue::inode(inode);
         let credit = borrow_credit(wb, &v);
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()


### PR DESCRIPTION
Dtrace shows that the cpu consumption of "fs destroy" is dominated by
memory allocations.  FSValue::Inode is almost three times larger than
the next largest variant, so box it, reducing the in-memory size of
FSValue, and reducing the amount of memory allocator activity when
working with large files.

Improves the throughput of Node::deserialize for an FS leaf node by
about 50%.