### PR TITLE
Don't use vectored writes to write the label

### DIFF
--- a/bfffs-core/src/label.rs
+++ b/bfffs-core/src/label.rs
@@ -134,29 +134,32 @@ impl LabelWriter {
         })
     }
 
-    /// Consume the `LabelWriter` and return an `SGList` suitable for writing to
-    /// the first sector of a disk.
-    pub fn into_sglist(self) -> SGList {
-        let mut sglist: SGList = Vec::with_capacity(self.buffers.len() + 2);
-        let header_len = MAGIC_LEN + CHECKSUM_LEN + LENGTH_LEN;
-        let header_dbs = DivBufShared::with_capacity(header_len);
-        let mut header = header_dbs.try_mut().unwrap();
-        header.extend(&MAGIC[..]);
-        let contents = self.buffers.into_iter().rev().collect::<Vec<_>>();
-        let contents_len: usize = contents.iter().map(DivBuf::len).sum();
+    /// Consume the `LabelWriter` and return a DivBuf suitable for writing to
+    /// the first sectors of the disk.
+    pub fn into_db(self) -> DivBuf {
+        let mut v = Vec::with_capacity(LABEL_SIZE);
+        v.extend(&MAGIC[..]);
+
         let mut hasher = MetroHash64::new();
+        let contents_len: usize = self.buffers.iter().map(DivBuf::len).sum();
         (contents_len as u64).to_be().hash(&mut hasher);
-        checksum_sglist(&contents, &mut hasher);
-        header.try_resize(MAGIC_LEN + CHECKSUM_LEN, 0).unwrap();
-        BigEndian::write_u64(&mut header[MAGIC_LEN..], hasher.finish());
-        header.try_resize(MAGIC_LEN + CHECKSUM_LEN + LENGTH_LEN, 0).unwrap();
+
+        for buf in self.buffers.iter().rev() {
+            checksum_iovec(buf, &mut hasher);
+        }
+        v.resize(MAGIC_LEN + CHECKSUM_LEN, 0);
+        BigEndian::write_u64(&mut v[MAGIC_LEN..], hasher.finish());
+
+        v.resize(MAGIC_LEN + CHECKSUM_LEN + LENGTH_LEN, 0);
         let length_start = MAGIC_LEN + CHECKSUM_LEN;
-        BigEndian::write_u64(&mut header[length_start..], contents_len as u64);
-        sglist.push(header.freeze());
-        sglist.extend(contents);
-        let len = MAGIC_LEN + CHECKSUM_LEN + LENGTH_LEN + contents_len;
-        let padlen = LABEL_SIZE - len;
-        sglist.append(&mut zero_sglist(padlen));
-        sglist
+        BigEndian::write_u64(&mut v[length_start..], contents_len as u64);
+
+        for buf in self.buffers.into_iter().rev() {
+            v.extend(&buf[..]);
+        }
+
+        v.resize(LABEL_SIZE, 0);
+        let dbs = DivBufShared::from(v);
+        dbs.try_const().unwrap()
     }
 }

--- a/bfffs-core/tests/functional/vdev_file.rs
+++ b/bfffs-core/tests/functional/vdev_file.rs
@@ -204,6 +204,17 @@ mod basic {
         }).unwrap();
     }
 
+    #[should_panic]
+    #[rstest]
+    fn writev_at_overwrite_label(harness: Harness) {
+        let dbs = DivBufShared::from(vec![42u8; 4096]);
+        let wbuf = dbs.try_const().unwrap();
+        let rt = runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            harness.0.writev_at(vec![wbuf], 0).await
+        }).unwrap();
+    }
+
     #[rstest]
     fn write_at_lba(harness: Harness) {
         let dbs = DivBufShared::from(vec![42u8; 4096]);


### PR DESCRIPTION
Instead, copy the label into a single buffer before writing.  This
entails some data copying, but it's only around 3 PPM of all the data
that a busy HDD might write.  Plus, the data was getting copied anyway,
in the tokio-file crate, because HDD's reject any writev or aio_writev
operation if any iovec isn't sector-aligned and sized.

Copying the data within bfffs allows simplifying tokio-file, and
eliminating the unaligned-write detection code from the non-label write
paths.