### PR TITLE
LeafData::insert: return excess credit on error, too.

### DIFF
--- a/bfffs-core/benches/serde.rs
+++ b/bfffs-core/benches/serde.rs
@@ -132,9 +132,9 @@ fn fs_leaf(c: &mut Criterion) {
         let key = FSKey::new(1, ObjKey::Extent(i << 17));
         let value = FSValue::BlobExtent(BlobExtent{lsize: 131072, rid: RID(i)});
         let credit = wb.borrow(99999999).now_or_never().unwrap();
-        let excess = ld.insert(key, value, txg, &dml, credit)
-            .now_or_never().unwrap()
-            .unwrap().1;
+        let (r, excess) = ld.insert(key, value, txg, &dml, credit)
+            .now_or_never().unwrap();
+        r.unwrap();
         wb.repay(excess);
     }
     let nd = NodeData::Leaf(ld);
@@ -176,7 +176,7 @@ fn alloct_leaf(c: &mut Criterion) {
         let credit = Credit::null();
         ld.insert(key, value, txg, &dml, credit)
             .now_or_never().unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let nd = NodeData::<DRP, _, _>::Leaf(ld);
     let node = Arc::new(Node::new(nd));
@@ -212,7 +212,7 @@ fn ridt_leaf(c: &mut Criterion) {
         let credit = Credit::null();
         ld.insert(key, value, txg, &dml, credit)
             .now_or_never().unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let nd = NodeData::<DRP, _, _>::Leaf(ld);
     let node = Arc::new(Node::new(nd));

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -351,7 +351,7 @@ impl<K: Key, V: Value> LeafData<K, V> {
         txg: TxgT,
         dml: &D,
         mut credit: Credit)
-        -> impl Future<Output = Result<(Option<V>, Credit)>> + Send
+        -> impl Future<Output = (Result<Option<V>>, Credit)> + Send
         where D: DML<Addr=A> + 'static, A: 'static
     {
         self.assert_accredited();
@@ -376,11 +376,11 @@ impl<K: Key, V: Value> LeafData<K, V> {
         if V::NEEDS_FLUSH {
             if let Some(v) = old_v {
                 return v.dpop(dml, txg)
-                    .map_ok(move |v| (Some(v), excess_credit))
+                    .map(move |r| (Some(r).transpose(), excess_credit))
                     .boxed()
             }
         }
-        future::ok((old_v, excess_credit)).boxed()
+        future::ready((Ok(old_v), excess_credit)).boxed()
     }
 
     pub fn get<Q>(&self, k: &Q) -> Option<V>

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -1292,9 +1292,9 @@ impl<A, D, K, V> Tree<A, D, K, V>
         elem.txgs = txg..txg + 1;
         child.as_leaf_mut()
         .insert(k, v, txg, dml.as_ref(), credit)
-        .map_ok(move |(old_v, excess)| {
+        .map(move |(r, excess)| {
             dml.repay(excess);
-            old_v
+            r
         })
     }
 

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -268,6 +268,46 @@ root:
 "#);
 }
 
+/// Insert an entry for a key that already exists.  The Value type needs dclone,
+/// but its value doesn't exist on disk.  That's an error.  Ensure that we repay
+/// writeback credit after the error.
+#[test]
+fn insert_dup_dclone_enoent() {
+    let txg = TxgT::from(42);
+    let mut mock = mock_dml();
+    mock.expect_pop::<DivBufShared, DivBuf>()
+        .with(eq(0), eq(txg))
+        .times(1)
+        .returning(|_, _| future::err(Error::ENOENT).boxed());
+    let dml = Arc::new(mock);
+    let tree = Arc::new(Tree::<u32, MockDML, u32, NeedsDcloneV>::from_str(
+        dml, false, r#"
+---
+limits:
+  min_int_fanout: 2
+  max_int_fanout: 5
+  min_leaf_fanout: 2
+  max_leaf_fanout: 5
+  _max_size: 4194304
+root:
+  height: 1
+  elem:
+    key: 0
+    txgs:
+      start: 0
+      end: 42
+    ptr:
+      Mem:
+        Leaf:
+          credit: 16
+          items:
+            0: 0
+"#));
+    let r = tree.insert(0, NeedsDcloneV(100), txg, Credit::forge(8))
+        .now_or_never().unwrap();
+    assert_eq!(r, Err(Error::ENOENT));
+}
+
 /// When overwriting an existing value, don't split the leaf node, even if it's
 /// full
 #[test]

--- a/bfffs-core/tests/cacheable_space.rs
+++ b/bfffs-core/tests/cacheable_space.rs
@@ -140,7 +140,7 @@ fn alloct_leaf(_wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         ld.insert(k, v, TxgT::from(0), &StubDML{}, Credit::null())
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<DRP, PBA, RID>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -184,7 +184,7 @@ fn ridt_leaf(_wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         ld.insert(k, v, TxgT::from(0), &StubDML{}, Credit::null())
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<DRP, RID, RidtEntry>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -217,7 +217,7 @@ fn fs_leaf_blob_extent(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable>
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -237,7 +237,7 @@ fn fs_leaf_direntry(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -262,7 +262,7 @@ fn fs_leaf_direntries(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> 
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -277,7 +277,7 @@ fn fs_leaf_dyinginode(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> 
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -302,7 +302,7 @@ fn fs_leaf_extattr_blob(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -325,7 +325,7 @@ fn fs_leaf_extattr_inline(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetab
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -360,7 +360,7 @@ fn fs_leaf_extattrs(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -377,7 +377,7 @@ fn fs_leaf_inline_extent(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetabl
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -406,7 +406,7 @@ fn fs_leaf_inode(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))
@@ -421,7 +421,7 @@ fn fs_leaf_property(wb: &WriteBack, n: usize) -> Box<dyn CacheableForgetable> {
         ld.insert(k, v, TxgT::from(0), &StubDML{}, credit)
             .now_or_never()
             .unwrap()
-            .unwrap();
+            .0.unwrap();
     }
     let node_data = NodeData::<RID, FSKey, FSValue>::Leaf(ld);
     Box::new(Arc::new(Node::new(node_data)))


### PR DESCRIPTION
It's illegal to drop WriteBack credit on error as well as on success.
There are more such paths to correct in the future.