### PR TITLE
Use aio_readv/aio_writev instead of faking it with lio_listio

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ task:
       env:
         VERSION: 1.56.0
       freebsd_instance:
-        image: freebsd-13-0-release-amd64
+        image: freebsd-13-1-release-amd64
   << : *SETUP
   cargo_cache:
     folder: $HOME/.cargo/registry
@@ -60,7 +60,7 @@ lint_task:
     VERSION: nightly
     CARGO_ARGS: --all-features
   freebsd_instance:
-    image: freebsd-13-0-release-amd64
+    image: freebsd-13-1-release-amd64
   << : *SETUP
   cargo_cache:
     folder: $HOME/.cargo/registry

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ task:
       env:
         VERSION: 1.56.0
       freebsd_instance:
-        image: freebsd-12-3-release-amd64
+        image: freebsd-13-0-release-amd64
   << : *SETUP
   cargo_cache:
     folder: $HOME/.cargo/registry
@@ -60,7 +60,7 @@ lint_task:
     VERSION: nightly
     CARGO_ARGS: --all-features
   freebsd_instance:
-    image: freebsd-12-3-release-amd64
+    image: freebsd-13-0-release-amd64
   << : *SETUP
   cargo_cache:
     folder: $HOME/.cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.121",
  "winapi",
 ]
 
@@ -78,9 +78,9 @@ dependencies = [
  "function_name",
  "fuse3",
  "futures",
- "libc",
+ "libc 0.2.121",
  "mockall",
- "nix 0.24.0",
+ "nix 0.24.1",
  "predicates",
  "regex",
  "rstest",
@@ -119,11 +119,11 @@ dependencies = [
  "isa-l",
  "itertools 0.7.11",
  "lazy_static",
- "libc",
+ "libc 0.2.121",
  "metrohash",
  "mockall",
  "mockall_double",
- "nix 0.24.0",
+ "nix 0.24.1",
  "num-traits",
  "num_cpus",
  "num_enum",
@@ -154,7 +154,7 @@ dependencies = [
  "cc",
  "futures",
  "lazy_static",
- "libc",
+ "libc 0.2.121",
  "memoffset 0.5.6",
  "tokio",
  "tracing-subscriber",
@@ -212,7 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa4be3ff6a15133256bcb58bdc8fefd074aebece453605386646bb96db0dc57"
 dependencies = [
  "blosc-sys",
- "libc",
+ "libc 0.2.121",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 dependencies = [
  "glob 0.3.0",
- "libc",
+ "libc 0.2.121",
  "libloading",
 ]
 
@@ -549,7 +549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
- "libc",
+ "libc 0.2.121",
  "winapi",
 ]
 
@@ -560,7 +560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.121",
 ]
 
 [[package]]
@@ -578,7 +578,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17d6dfea8da8b55b0c77800947567f282cad3940dc7edc37bf897a6933afee8d"
 dependencies = [
- "libc",
+ "libc 0.2.121",
 ]
 
 [[package]]
@@ -658,7 +658,7 @@ dependencies = [
  "cstr",
  "futures-channel",
  "futures-util",
- "libc",
+ "libc 0.2.121",
  "nix 0.23.1",
  "serde",
  "slab",
@@ -791,7 +791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.121",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
@@ -831,7 +831,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
- "libc",
+ "libc 0.2.121",
 ]
 
 [[package]]
@@ -930,6 +930,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
+name = "libc"
+version = "0.2.125"
+source = "git+http://github.com/rust-lang/libc.git?rev=cd99f681181c310abfba742aef11115d2eff03dc#cd99f681181c310abfba742aef11115d2eff03dc"
+
+[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,24 +1006,11 @@ checksum = "3ba553cb19e2acbc54baa16faef215126243fe45e53357a3b2e9f4ebc7b0506c"
 
 [[package]]
 name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
- "libc",
+ "libc 0.2.121",
  "log",
  "miow",
  "ntapi",
@@ -1029,11 +1021,11 @@ dependencies = [
 [[package]]
 name = "mio-aio"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a96b06afe630acaa6b7ecc349ac3af518965aacebeee1d227277d2a6e5c71f"
+source = "git+http://github.com/asomers/mio-aio?rev=604c410041322eb29d8421478b9b816dd75824b8#604c410041322eb29d8421478b9b816dd75824b8"
 dependencies = [
- "mio 0.8.2",
- "nix 0.24.0",
+ "mio",
+ "nix 0.24.1",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1093,19 +1085,19 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.121",
  "memoffset 0.6.5",
 ]
 
 [[package]]
 name = "nix"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d99b651ff9697d6710f9613a07c5b4e0d655040faf56b3b471af108d55597"
+version = "0.24.1"
+source = "git+http://github.com/nix-rust/nix?rev=69738c0fd03af19053c5701a984f923ecbbfada6#69738c0fd03af19053c5701a984f923ecbbfada6"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.125",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1149,7 +1141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.121",
 ]
 
 [[package]]
@@ -1179,7 +1171,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
 dependencies = [
- "libc",
+ "libc 0.2.121",
 ]
 
 [[package]]
@@ -1237,7 +1229,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 dependencies = [
- "libc",
+ "libc 0.2.121",
  "rand 0.4.6",
  "smallvec",
  "winapi",
@@ -1464,7 +1456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc",
+ "libc 0.2.121",
  "rand_core 0.3.1",
  "rdrand",
  "winapi",
@@ -1476,7 +1468,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
+ "libc 0.2.121",
  "rand_chacha",
  "rand_core 0.6.3",
 ]
@@ -1774,7 +1766,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc",
+ "libc 0.2.121",
 ]
 
 [[package]]
@@ -1798,7 +1790,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
- "libc",
+ "libc 0.2.121",
  "winapi",
 ]
 
@@ -1850,7 +1842,7 @@ checksum = "4bcf77d15d9b9261f4d32c0b4e3cf09050ee6aabb20cf21cb99dfe69c9a49d83"
 dependencies = [
  "byteorder",
  "errno",
- "libc",
+ "libc 0.2.121",
 ]
 
 [[package]]
@@ -1861,7 +1853,7 @@ checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "libc",
+ "libc 0.2.121",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1882,7 +1874,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
- "libc",
+ "libc 0.2.121",
  "winapi",
 ]
 
@@ -1946,7 +1938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
  "itoa 1.0.1",
- "libc",
+ "libc 0.2.121",
  "num_threads",
 ]
 
@@ -1966,8 +1958,8 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
- "libc",
- "mio 0.8.2",
+ "libc 0.2.121",
+ "mio",
  "num_cpus",
  "once_cell",
  "pin-project-lite",
@@ -1980,13 +1972,12 @@ dependencies = [
 [[package]]
 name = "tokio-file"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c4195507ab2e174a9586d3740bcbb378fa98302b568d417d2e6f5392429911"
+source = "git+http://github.com/asomers/tokio-file?rev=80498ae4fe6b76957f67e07a53417db22a049d61#80498ae4fe6b76957f67e07a53417db22a049d61"
 dependencies = [
  "futures",
- "mio 0.7.14",
+ "mio",
  "mio-aio",
- "nix 0.24.0",
+ "nix 0.24.1",
  "tokio",
 ]
 
@@ -2008,7 +1999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6c35a3e32adef32541a7491eaabccdb8e0a7ea10c3ad9814f9ab8f1c9174da"
 dependencies = [
  "filedesc",
- "libc",
+ "libc 0.2.121",
  "tokio",
 ]
 
@@ -2161,7 +2152,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
- "libc",
+ "libc 0.2.121",
 ]
 
 [[package]]
@@ -2257,7 +2248,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
- "libc",
+ "libc 0.2.121",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
  "futures",
  "libc 0.2.121",
  "mockall",
- "nix 0.24.1",
+ "nix",
  "predicates",
  "regex",
  "rstest",
@@ -123,7 +123,7 @@ dependencies = [
  "metrohash",
  "mockall",
  "mockall_double",
- "nix 0.24.1",
+ "nix",
  "num-traits",
  "num_cpus",
  "num_enum",
@@ -649,8 +649,8 @@ dependencies = [
 
 [[package]]
 name = "fuse3"
-version = "0.3.0"
-source = "git+https://github.com/asomers/fuse3.git?rev=8a80f2bcf1067847a5a704c749a22b9f69603873#8a80f2bcf1067847a5a704c749a22b9f69603873"
+version = "0.4.0"
+source = "git+https://github.com/asomers/fuse3.git?rev=452c6b280bc012c6aca6200c7d8a0464e5d5c173#452c6b280bc012c6aca6200c7d8a0464e5d5c173"
 dependencies = [
  "async-trait",
  "bincode",
@@ -659,7 +659,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "libc 0.2.121",
- "nix 0.23.1",
+ "nix",
  "serde",
  "slab",
  "tokio",
@@ -1024,7 +1024,7 @@ version = "0.7.0"
 source = "git+http://github.com/asomers/mio-aio?rev=604c410041322eb29d8421478b9b816dd75824b8#604c410041322eb29d8421478b9b816dd75824b8"
 dependencies = [
  "mio",
- "nix 0.24.1",
+ "nix",
  "pin-utils",
 ]
 
@@ -1078,21 +1078,8 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc 0.2.121",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
 version = "0.24.1"
-source = "git+http://github.com/nix-rust/nix?rev=69738c0fd03af19053c5701a984f923ecbbfada6#69738c0fd03af19053c5701a984f923ecbbfada6"
+source = "git+https://github.com/nix-rust/nix.git?rev=69738c0fd03af19053c5701a984f923ecbbfada6#69738c0fd03af19053c5701a984f923ecbbfada6"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1977,7 +1964,7 @@ dependencies = [
  "futures",
  "mio",
  "mio-aio",
- "nix 0.24.1",
+ "nix",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ lto = true
 members = ["bfffs-core", "bfffs-fio", "bfffs", "isa-l"]
 
 [patch.crates-io]
+nix = { git = "https://github.com/nix-rust/nix.git", rev = "69738c0fd03af19053c5701a984f923ecbbfada6" }

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = "1.0"
 libc = "0.2.105"
 metrohash = "1.0"
 mockall_double = "0.2.0"
-nix = { version = "0.24.0", default-features = false, features = ["fs", "ioctl", "mount", "time"] }
+nix = { git = "http://github.com/nix-rust/nix", rev = "69738c0fd03af19053c5701a984f923ecbbfada6", default-features = false, features = ["fs", "ioctl", "mount", "time"] }
 num_enum = "0.5.1"
 num-traits = "0.2.0"
 serde = "1.0.60"
@@ -38,7 +38,7 @@ serde_derive = "1.0"
 serde_yaml = "0.8.16"
 time = { version = "0.3.0", features = [ "formatting" ] }
 tokio = { version = "1.10.0", features = ["rt", "sync", "time"] }
-tokio-file = "0.8.0"
+tokio-file = { git = "http://github.com/asomers/tokio-file", rev = "80498ae4fe6b76957f67e07a53417db22a049d61" }
 tracing = "0.1.5"
 tracing-futures = "0.2.4"
 uuid = { version = "0.8.2", features = ["serde", "v4"]}
@@ -56,7 +56,7 @@ glob = "0.2"
 histogram = "0.6"
 itertools = "0.7.1"
 mockall = "0.11.0"
-nix = { version = "0.24.0", default-features = false, features = ["user"] }
+nix = { git = "http://github.com/nix-rust/nix", rev = "69738c0fd03af19053c5701a984f923ecbbfada6", default-features = false, features = ["user"] }
 num_cpus = "1"
 permutohedron = "0.2"
 pretty_assertions = "1.2"
@@ -73,7 +73,7 @@ default-features = false
 features = [ "ansi", "env-filter", "fmt", "tracing-log" ]
 
 [build-dependencies]
-nix = { version = "0.24.0", default-features = false, features = ["feature"] }
+nix = { git = "http://github.com/nix-rust/nix", rev = "69738c0fd03af19053c5701a984f923ecbbfada6", default-features = false, features = ["feature"] }
 
 
 [[test]]

--- a/bfffs-core/src/raid/vdev_onedisk.rs
+++ b/bfffs-core/src/raid/vdev_onedisk.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use crate::{
     label::*,
     types::*,
-    util::*,
     vdev::*,
 };
 use futures::future;
@@ -143,18 +142,7 @@ impl VdevRaidApi for VdevOneDisk {
 
     fn write_at(&self, buf: IoVec, _zone: ZoneT, lba: LbaT) -> BoxVdevFut
     {
-        // Pad up to a whole number of LBAs.  Upper layers don't do this because
-        // VdevRaidApi doesn't have a writev_at method.  But VdevBlock does, so
-        // the raid layer is the most efficient place to pad.
-        let partial = buf.len() % BYTES_PER_LBA;
-        if partial == 0 {
-            Box::pin(self.blockdev.write_at(buf, lba))
-        } else {
-            let remainder = BYTES_PER_LBA - partial;
-            let zbuf = ZERO_REGION.try_const().unwrap().slice_to(remainder);
-            let sglist = vec![buf, zbuf];
-            Box::pin(self.blockdev.writev_at(sglist, lba))
-        }
+        Box::pin(self.blockdev.write_at(buf, lba))
     }
 
     fn write_label(&self, mut labeller: LabelWriter) -> BoxVdevFut

--- a/bfffs-core/src/vdev_file.rs
+++ b/bfffs-core/src/vdev_file.rs
@@ -526,8 +526,8 @@ impl VdevFile {
         };
         label_writer.serialize(&label).unwrap();
         let lba = label_writer.lba();
-        let v = label_writer.into_db();
-        self.write_at_unchecked(v, lba)
+        let sglist = label_writer.into_sglist();
+        self.writev_at_unchecked(sglist, lba)
     }
 
     /// Asynchronously write to the Vdev's spacemap area.

--- a/bfffs-core/tests/functional/vdev_block.rs
+++ b/bfffs-core/tests/functional/vdev_block.rs
@@ -6,7 +6,6 @@ mod vdev_block {
     use pretty_assertions::assert_eq;
     use rstest::{fixture, rstest};
     use std::fs;
-    use super::super::*;
     use tempfile::{Builder, TempDir};
 
     #[fixture]
@@ -40,49 +39,6 @@ mod vdev_block {
     fn zone_limits(vdev: (VdevBlock, TempDir)) {
         assert_eq!(vdev.0.zone_limits(0), (10, 1 << 16));
         assert_eq!(vdev.0.zone_limits(1), (1 << 16, 2 << 16));
-    }
-
-    #[should_panic]
-    #[rstest]
-    fn check_block_granularity_under(vdev: (VdevBlock, TempDir)) {
-        let dbs = DivBufShared::from(vec![42u8; 4095]);
-        let wbuf = dbs.try_const().unwrap();
-        basic_runtime().block_on(async {
-            vdev.0.write_at(wbuf, 10).await
-        }).unwrap();
-    }
-
-    #[should_panic]
-    #[rstest]
-    fn check_block_granularity_over(vdev: (VdevBlock, TempDir)) {
-        let dbs = DivBufShared::from(vec![42u8; 4097]);
-        let wbuf = dbs.try_const().unwrap();
-        basic_runtime().block_on(async {
-            vdev.0.write_at(wbuf, 10).await
-        }).unwrap();
-    }
-
-    #[should_panic]
-    #[rstest]
-    fn check_block_granularity_over_multiple_sectors(vdev: (VdevBlock, TempDir)) {
-        let dbs = DivBufShared::from(vec![42u8; 16_385]);
-        let wbuf = dbs.try_const().unwrap();
-        basic_runtime().block_on(async {
-            vdev.0.write_at(wbuf, 10).await
-        }).unwrap();
-    }
-
-    #[should_panic]
-    #[rstest]
-    fn check_block_granularity_writev(vdev: (VdevBlock, TempDir)) {
-        let dbs = DivBufShared::from(vec![42u8; 4097]);
-        let wbuf = dbs.try_const().unwrap();
-        let wbuf0 = wbuf.slice_to(1024);
-        let wbuf1 = wbuf.slice_from(1024);
-        let wbufs = vec![wbuf0, wbuf1];
-        basic_runtime().block_on(async {
-            vdev.0.writev_at(wbufs, 10).await
-        }).unwrap();
     }
 
     #[rstest]

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -21,7 +21,7 @@ cfg-if = "1.0"
 fuse3 = { git = "https://github.com/asomers/fuse3.git", rev = "8a80f2bcf1067847a5a704c749a22b9f69603873", optional = true, features = ["tokio-runtime"] }
 futures = "0.3.0"
 libc = "0.2.44"
-nix = { version = "0.24.0", default-features = false, features = ["user"] }
+nix = { git = "http://github.com/nix-rust/nix", rev = "69738c0fd03af19053c5701a984f923ecbbfada6", default-features = false, features = ["user"] }
 time = { version = "0.3.0", features = [ "formatting" ] }
 tokio = { version = "1.10.0", features = ["macros", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-seqpacket = "0.5.4"
@@ -43,7 +43,7 @@ divbuf = { git = "https://github.com/asomers/divbuf.git", rev = "0a72fb5"}
 freebsd-libgeom = "0.2.0"
 function_name = "0.2.0"
 mockall = "0.11.0"
-nix = { version = "0.24.0", default-features = false, features = ["mount", "process", "signal", "user"] }
+nix = { git = "http://github.com/nix-rust/nix", rev = "69738c0fd03af19053c5701a984f923ecbbfada6", default-features = false, features = ["mount", "process", "signal", "user"] }
 predicates = "2.1.0"
 regex = "1.0"
 rstest = "0.11.0"

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -18,7 +18,7 @@ bincode = "1.0.1"
 bfffs-core = { path = "../bfffs-core" }
 bytes = "1.0"
 cfg-if = "1.0"
-fuse3 = { git = "https://github.com/asomers/fuse3.git", rev = "8a80f2bcf1067847a5a704c749a22b9f69603873", optional = true, features = ["tokio-runtime"] }
+fuse3 = { git = "https://github.com/asomers/fuse3.git", rev = "452c6b280bc012c6aca6200c7d8a0464e5d5c173", optional = true, features = ["tokio-runtime"] }
 futures = "0.3.0"
 libc = "0.2.44"
 nix = { git = "http://github.com/nix-rust/nix", rev = "69738c0fd03af19053c5701a984f923ecbbfada6", default-features = false, features = ["user"] }


### PR DESCRIPTION
It's more efficient and less falliable.  Most of the changes are upstream.  In bfffs, it's pretty much just type renaming.
