### PR TITLE
VdevBlock: accumulate multiple BlockOps before sending to VdevFile

### DIFF
--- a/bfffs-core/src/util.rs
+++ b/bfffs-core/src/util.rs
@@ -80,6 +80,15 @@ pub fn div_roundup<T>(dividend: T, divisor: T) -> T
 
 }
 
+/// Return the length of data in an sglist, not the number of iovecs
+pub fn sglist_len<T>(sglist: &[T]) -> usize
+    where T: std::ops::Deref<Target=[u8]>
+{
+    sglist.iter().fold(0usize, |accumulator, buf| {
+        accumulator + buf.len()
+    })
+}
+
 /// Create an SGList full of zeros, with the requested total length
 pub fn zero_sglist(len: usize) -> SGList {
     let zero_region_len = ZERO_REGION.len();
@@ -167,6 +176,14 @@ fn checksum_sglist_metrohash64() {
     use metrohash::MetroHash64;
 
     checksum_sglist_helper!(MetroHash64);
+}
+
+#[test]
+fn test_sglist_len() {
+    assert_eq!(0, sglist_len::<&[u8]>(&[]));
+    assert_eq!(0, sglist_len::<&[u8]>(&[&[][..]]));
+    assert_eq!(1, sglist_len(&[&[42u8][..]]));
+    assert_eq!(6, sglist_len(&[&[42u8, 43, 44, 45][..], &[46, 47][..]]));
 }
 
 #[test]

--- a/bfffs-core/src/vdev_block.rs
+++ b/bfffs-core/src/vdev_block.rs
@@ -218,7 +218,7 @@ struct Inner {
     // Pending operations are stored in a pair of priority queues.  They _could_
     // be stored in a single queue, _if_ the priority queue's comparison
     // function were allowed to be stateful, as in C++'s STL.  However, Rust's
-    // standard library does not have any way to create a priority queueful with
+    // standard library does not have any way to create a priority queue with
     // a stateful comparison function.
     /// Pending operations ahead of the scheduler's current LBA.
     ahead: BinaryHeap<BlockOp>,
@@ -255,9 +255,9 @@ impl Inner {
                 self.delayed = Some(d);
                 if self.queue_depth == 1 {
                     // Can't issue any I/O at all!  This means that other
-                    // processes outside of bfffs's control are using too many
-                    // disk resources.  In this case, the only thing we can do
-                    // is sleep and try again later.
+                    // VdevBlocks or other processes outside of bfffs's control
+                    // are using too many disk resources.  In this case, the
+                    // only thing we can do is sleep and try again later.
                     let duration = time::Duration::from_millis(10);
                     let schfut = self.reschedule();
                     let delay_fut = tokio::time::sleep(duration)

--- a/bfffs-core/src/vdev_block.rs
+++ b/bfffs-core/src/vdev_block.rs
@@ -475,9 +475,7 @@ impl VdevBlock {
     fn check_sglist_bounds<T>(&self, lba: LbaT, bufs: &[T])
         where T: ops::Deref<Target=[u8]> {
 
-        let len : u64 = bufs.iter().fold(0, |accumulator, buf| {
-            accumulator + buf.len() as u64
-        });
+        let len = sglist_len(bufs) as u64;
         let last_lba = lba + len / (BYTES_PER_LBA as u64);
         assert!(last_lba <= self.size as u64)
     }


### PR DESCRIPTION
    If two consecutive operations are of the same type (read, write, fsync)
    and contiguous, combine them into one.  This reduces the IOPs demanded
    by the disks.
