### PR TITLE
Eliminate duplicate disk reads coming from the DMLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,7 +1079,7 @@ dependencies = [
 [[package]]
 name = "nix"
 version = "0.24.1"
-source = "git+https://github.com/nix-rust/nix.git?rev=69738c0fd03af19053c5701a984f923ecbbfada6#69738c0fd03af19053c5701a984f923ecbbfada6"
+source = "git+http://github.com/nix-rust/nix?rev=69738c0fd03af19053c5701a984f923ecbbfada6#69738c0fd03af19053c5701a984f923ecbbfada6"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",

--- a/bfffs-core/src/cache/cache.rs
+++ b/bfffs-core/src/cache/cache.rs
@@ -1,6 +1,5 @@
 // vim: tw=80
 use metrohash::{MetroBuildHasher, MetroHash64};
-#[cfg(test)] use mockall::automock;
 use std::{
     collections::HashMap,
     fmt::{self, Debug},
@@ -43,7 +42,6 @@ pub struct Cache {
     store: HashMap<Key, LruEntry, BuildHasherDefault<MetroHash64>>,
 }
 
-#[cfg_attr(test, automock)]
 impl Cache {
     /// Get the maximum memory consumption of the cache, in bytes.
     pub fn capacity(&self) -> usize {

--- a/bfffs-core/src/cache/lru.rs
+++ b/bfffs-core/src/cache/lru.rs
@@ -23,14 +23,10 @@ impl Debug for LruEntry {
     }
 }
 
-/// Basic read-only block cache.
-///
-/// Caches on-disk blocks by either their address (cluster and LBA pair), or
-/// their Record ID.  The cache is read-only because any attempt to change a
-/// block would also require changing either its address or record ID.
+/// Basic LRU cache.
 #[derive(Debug)]
-pub struct Cache {
-    /// Capacity of the `Cache` in bytes, not number of entries
+pub struct LruCache {
+    /// Capacity of the `LruCache` in bytes, not number of entries
     capacity: usize,
     /// Pointer to the least recently used entry
     lru: Option<Key>,
@@ -42,15 +38,11 @@ pub struct Cache {
     store: HashMap<Key, LruEntry, BuildHasherDefault<MetroHash64>>,
 }
 
-impl Cache {
-    /// Get the maximum memory consumption of the cache, in bytes.
+impl LruCache {
     pub fn capacity(&self) -> usize {
         self.capacity
     }
 
-    /// Drop all data from the cache, for testing or benchmarking purposes
-    // NB: this should be called "drop", but that conflicts with
-    // "std::Drop::drop"
     pub fn drop_cache(&mut self) {
         self.store = HashMap::with_hasher(MetroBuildHasher::default());
         self.lru = None;
@@ -67,9 +59,6 @@ impl Cache {
         self.remove(&key.unwrap());
     }
 
-    /// Get a read-only reference to a cached block.
-    ///
-    /// The block will be marked as the most recently used.
     pub fn get<T: CacheRef>(&mut self, key: &Key) -> Option<Box<T>> {
         if self.mru == Some(*key) {
             Some(self.store[key].buf.make_ref().downcast::<T>().unwrap())
@@ -100,21 +89,12 @@ impl Cache {
         }
     }
 
-    /// Get a read-only generic reference to a cached block.
-    ///
-    /// The returned reference will not be downcastted to a concrete type, and
-    /// the cache's internal state will not be updated.  That is, this method
-    /// does not count as an access for the cache replacement algorithm.
     pub fn get_ref(&self, key: &Key) -> Option<Box<dyn CacheRef>> {
         self.store.get(key).map(|v| {
             v.buf.make_ref()
         })
     }
 
-    /// Add a new block to the cache.
-    ///
-    /// The block will be marked as the most recently used.
-    #[tracing::instrument(skip(self, buf))]
     pub fn insert(&mut self, key: Key, buf: Box<dyn Cacheable>) {
         let cache_space = buf.cache_space();
         assert!(cache_space <= self.capacity);
@@ -150,10 +130,6 @@ impl Cache {
         }
     }
 
-    /// Remove a block from the cache.
-    ///
-    /// Unlike `get`, the block will be returned in an owned form, if it was
-    /// present at all.
     pub fn remove(&mut self, key: &Key) -> Option<Box<dyn Cacheable>> {
         self.store.remove(key).map(|v| {
             self.size -= v.buf.cache_space();
@@ -173,18 +149,13 @@ impl Cache {
         })
     }
 
-    /// Get the current memory consumption of the cache, in bytes.
-    ///
-    /// Only the cached blocks themselves are included, not the overhead of
-    /// managing them.
     pub fn size(&self) -> usize {
         self.size
     }
 
-    /// Create a new cache with the given capacity, in bytes.
     pub fn with_capacity(capacity: usize) -> Self {
         let store = HashMap::with_hasher(MetroBuildHasher::default());
-        Cache{capacity, lru: None, mru: None, size: 0, store}
+        LruCache{capacity, lru: None, mru: None, size: 0, store}
     }
 }
 
@@ -199,7 +170,7 @@ use divbuf::{DivBuf, DivBufShared};
 // pet kcov
 #[test]
 fn debug() {
-    let cache = Cache::with_capacity(100);
+    let cache = LruCache::with_capacity(100);
     format!("{:?}", cache);
     assert_eq!(100, cache.capacity());
     let dbs = DivBufShared::from(Vec::new());
@@ -209,7 +180,7 @@ fn debug() {
 
 #[test]
 fn test_drop_cache() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let key3 = Key::Rid(RID(3));
@@ -230,7 +201,7 @@ fn test_drop_cache() {
 
 #[test]
 fn test_get_lru() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let dbs = Box::new(DivBufShared::from(vec![0u8; 5]));
@@ -256,7 +227,7 @@ fn test_get_lru() {
 /// Get an entry which is neither the MRU nor LRU
 #[test]
 fn test_get_middle() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let key3 = Key::Rid(RID(3));
@@ -288,7 +259,7 @@ fn test_get_middle() {
 /// On insertion, old entries should be expired to prevent overflow
 #[test]
 fn test_expire_one() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let dbs = Box::new(DivBufShared::from(vec![0u8; 53]));
@@ -303,7 +274,7 @@ fn test_expire_one() {
 /// expire multiple entries if necessary
 #[test]
 fn test_expire_two() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let key3 = Key::Rid(RID(3));
@@ -322,7 +293,7 @@ fn test_expire_two() {
 /// Get the most recently used entry
 #[test]
 fn test_get_mru() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let dbs = Box::new(DivBufShared::from(vec![0u8; 5]));
@@ -346,7 +317,7 @@ fn test_get_mru() {
 /// Get multiple references to the same entry, which isn't the MRU
 #[test]
 fn test_get_multiple() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let dbs = Box::new(DivBufShared::from(vec![0u8; 5]));
@@ -367,16 +338,16 @@ fn test_get_multiple() {
 /// Get a nonexistent key
 #[test]
 fn test_get_nonexistent() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key = Key::Rid(RID(0));
     assert!(cache.get::<DivBuf>(&key).is_none());
 }
 
-/// Cache::get_ref on an entry in the middle.  Its position in the list should
-/// not be changed.
+/// LruCache::get_ref on an entry in the middle.  Its position in the list
+/// should not be changed.
 #[test]
 fn test_get_ref_middle() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let key3 = Key::Rid(RID(3));
@@ -408,7 +379,7 @@ fn test_get_ref_middle() {
 
 #[test]
 fn test_get_ref_nonexistent() {
-    let cache = Cache::with_capacity(100);
+    let cache = LruCache::with_capacity(100);
     let key = Key::Rid(RID(0));
     assert!(cache.get_ref(&key).is_none());
 }
@@ -417,7 +388,7 @@ fn test_get_ref_nonexistent() {
 #[test]
 #[should_panic(expected = "Conflicting value cached with key=Rid(RID(0))")]
 fn test_insert_dup_key() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let dbs1 = Box::new(DivBufShared::from(vec![0u8; 6]));
     let dbs2 = Box::new(DivBufShared::from(vec![0u8; 11]));
     let key = Key::Rid(RID(0));
@@ -428,7 +399,7 @@ fn test_insert_dup_key() {
 /// Insert the same key/value pair twice
 #[test]
 fn test_insert_dup_value() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let len = 6;
     let dbs1 = Box::new(DivBufShared::from(vec![0u8; len]));
     let dbs2 = Box::new(DivBufShared::from(vec![0u8; len]));
@@ -452,7 +423,7 @@ fn test_insert_dup_value() {
 /// Insert the first value into an empty cache
 #[test]
 fn test_insert_empty() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let dbs = Box::new(DivBufShared::from(vec![0u8; 6]));
     let key = Key::Rid(RID(0));
     cache.insert(key, dbs);
@@ -470,7 +441,7 @@ fn test_insert_empty() {
 /// Insert into a cache that already has 1 item.
 #[test]
 fn test_insert_one() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let dbs = Box::new(DivBufShared::from(vec![0u8; 5]));
@@ -491,7 +462,7 @@ fn test_insert_one() {
 /// Remove a nonexistent key.  Unlike inserting a dup, this is not an error
 #[test]
 fn test_remove_nonexistent() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key = Key::Rid(RID(0));
     assert!(cache.remove(&key).is_none());
 }
@@ -499,7 +470,7 @@ fn test_remove_nonexistent() {
 /// Remove the last key from a cache
 #[test]
 fn test_remove_last() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let dbs = Box::new(DivBufShared::from(vec![0u8; 6]));
     let key = Key::Rid(RID(0));
     cache.insert(key, dbs);
@@ -513,7 +484,7 @@ fn test_remove_last() {
 /// Remove the least recently used entry
 #[test]
 fn test_remove_lru() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let dbs = Box::new(DivBufShared::from(vec![0u8; 5]));
@@ -534,7 +505,7 @@ fn test_remove_lru() {
 /// Remove an entry which is neither the MRU nor the LRU
 #[test]
 fn test_remove_middle() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let key3 = Key::Rid(RID(3));
@@ -563,7 +534,7 @@ fn test_remove_middle() {
 /// Remove the most recently used entry
 #[test]
 fn test_remove_mru() {
-    let mut cache = Cache::with_capacity(100);
+    let mut cache = LruCache::with_capacity(100);
     let key1 = Key::Rid(RID(1));
     let key2 = Key::Rid(RID(2));
     let dbs = Box::new(DivBufShared::from(vec![0u8; 5]));

--- a/bfffs-core/src/cache/mod.rs
+++ b/bfffs-core/src/cache/mod.rs
@@ -6,15 +6,12 @@
 use crate::types::{PBA, RID};
 use divbuf::{DivBuf, DivBufShared};
 use downcast::*;
-use mockall_double::*;
 use std::{
     borrow::Borrow,
     fmt::Debug,
 };
 
 mod cache;
-
-#[double]
 pub use self::cache::Cache;
 
 /// Key types used by `Cache`

--- a/bfffs-core/src/cache/mod.rs
+++ b/bfffs-core/src/cache/mod.rs
@@ -11,8 +11,7 @@ use std::{
     fmt::Debug,
 };
 
-mod cache;
-pub use self::cache::Cache;
+mod lru;
 
 /// Key types used by `Cache`
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -114,5 +113,72 @@ impl CacheRef for DivBuf {
 impl Borrow<dyn CacheRef> for DivBuf {
     fn borrow(&self) -> &dyn CacheRef {
         self as &dyn CacheRef
+    }
+}
+
+/// Basic read-only block cache.
+///
+/// Caches on-disk blocks by either their address (cluster and LBA pair), or
+/// their Record ID.  The cache is read-only because any attempt to change a
+/// block would also require changing either its address or record ID.
+#[derive(Debug)]
+pub struct Cache(self::lru::LruCache);
+
+impl Cache {
+    /// Get the maximum memory consumption of the cache, in bytes.
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    /// Drop all data from the cache, for testing or benchmarking purposes
+    // NB: this should be called "drop", but that conflicts with
+    // "std::Drop::drop"
+    pub fn drop_cache(&mut self) {
+        self.0.drop_cache()
+    }
+
+    /// Get a read-only reference to a cached block.
+    ///
+    /// The block will be marked as the most recently used.
+    pub fn get<T: CacheRef>(&mut self, key: &Key) -> Option<Box<T>> {
+        self.0.get(key)
+    }
+
+    /// Get a read-only generic reference to a cached block.
+    ///
+    /// The returned reference will not be downcastted to a concrete type, and
+    /// the cache's internal state will not be updated.  That is, this method
+    /// does not count as an access for the cache replacement algorithm.
+    pub fn get_ref(&self, key: &Key) -> Option<Box<dyn CacheRef>> {
+        self.0.get_ref(key)
+    }
+
+    /// Add a new block to the cache.
+    ///
+    /// The block will be marked as the most recently used.
+    #[tracing::instrument(skip(self, buf))]
+    pub fn insert(&mut self, key: Key, buf: Box<dyn Cacheable>) {
+        self.0.insert(key, buf)
+    }
+
+    /// Remove a block from the cache.
+    ///
+    /// Unlike `get`, the block will be returned in an owned form, if it was
+    /// present at all.
+    pub fn remove(&mut self, key: &Key) -> Option<Box<dyn Cacheable>> {
+        self.0.remove(key)
+    }
+
+    /// Get the current memory consumption of the cache, in bytes.
+    ///
+    /// Only the cached blocks themselves are included, not the overhead of
+    /// managing them.
+    pub fn size(&self) -> usize {
+        self.0.size()
+    }
+
+    /// Create a new cache with the given capacity, in bytes.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(self::lru::LruCache::with_capacity(capacity))
     }
 }

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -770,165 +770,174 @@ mod t {
                    bincode::serialized_size(&typical).unwrap() as usize);
     }
 
-    #[tokio::test]
-    async fn check_ridt_ok() {
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let cache = Cache::default();
-        let mut ddml = mock_ddml();
-        ddml.expect_used().return_const(1u64);
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp, 2);
+    mod check_ridt {
+        use super::*;
 
-        assert!(idml.check_ridt().await.unwrap());
-    }
+        #[tokio::test]
+        async fn ok() {
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let cache = Cache::default();
+            let mut ddml = mock_ddml();
+            ddml.expect_used().return_const(1u64);
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp, 2);
 
-    #[tokio::test]
-    async fn check_ridt_allocation_mismatch() {
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let cache = Cache::default();
-        let mut ddml = mock_ddml();
-        ddml.expect_used().return_const(42u64);
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp, 2);
+            assert!(idml.check_ridt().await.unwrap());
+        }
 
-        assert!(!idml.check_ridt().await.unwrap());
-    }
+        #[tokio::test]
+        async fn allocation_mismatch() {
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let cache = Cache::default();
+            let mut ddml = mock_ddml();
+            ddml.expect_used().return_const(42u64);
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp, 2);
 
-    #[tokio::test]
-    async fn check_ridt_extraneous_alloct() {
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let cache = Cache::default();
-        let mut ddml = mock_ddml();
-        ddml.expect_used().return_const(1u64);
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        // Inject a record into the AllocT but not the RIDT
-        let txg = TxgT::from(0);
-        idml.alloct.clone().insert(drp.pba(), rid, txg, Credit::null())
-            .now_or_never().unwrap()
-            .unwrap();
+            assert!(!idml.check_ridt().await.unwrap());
+        }
 
-        assert!(!idml.check_ridt().await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn check_ridt_extraneous_ridt() {
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let cache = Cache::default();
-        let mut ddml = mock_ddml();
-        ddml.expect_used().return_const(1u64);
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        // Inject a record into the RIDT but not the AllocT
-        let entry = RidtEntry{drp, refcount: 2};
-        let txg = TxgT::from(0);
-        idml.ridt.clone().insert(rid, entry, txg, Credit::null())
-            .now_or_never().unwrap()
-            .unwrap();
-
-        assert!(!idml.check_ridt().await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn check_ridt_mismatch() {
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let drp2 = DRP::random(Compression::None, 4096);
-        let cache = Cache::default();
-        let mut ddml = mock_ddml();
-        ddml.expect_used().return_const(1u64);
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        // Inject a mismatched pair of records
-        let entry = RidtEntry{drp, refcount: 2};
-        let txg = TxgT::from(0);
-        idml.ridt.clone().insert(rid, entry, txg, Credit::null())
-            .now_or_never().unwrap()
-            .unwrap();
-        idml.alloct.clone().insert(drp2.pba(), rid, txg, Credit::null())
-            .now_or_never().unwrap()
-            .unwrap();
-
-        assert!(!idml.check_ridt().await.unwrap());
-    }
-
-    /// Delete a record that does not exist.  This typically indicate a
-    /// double-free, and it is a fatal error.
-    #[test]
-    #[should_panic(expected = "Double delete")]
-    fn delete_double() {
-        let rid = RID(42);
-        let cache = Cache::default();
-        let ddml = mock_ddml();
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-
-        let _r = idml.delete(&rid, TxgT::from(42))
-            .now_or_never().unwrap();
-    }
-
-    #[test]
-    fn delete_last() {
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let mut cache = Cache::default();
-        cache.expect_remove()
-            .once()
-            .with(eq(Key::Rid(RID(42))))
-            .returning(|_| {
-                Some(Box::new(DivBufShared::from(vec![0u8; 4096])))
-            });
-        let mut ddml = mock_ddml();
-        ddml.expect_delete_direct()
-            .once()
-            .with(eq(drp), eq(TxgT::from(42)))
-            .returning(|_, _| Box::pin(future::ok::<(), Error>(())));
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp, 1);
-
-        idml.delete(&rid, TxgT::from(42))
-            .now_or_never().unwrap()
-            .unwrap();
-        // Now verify the contents of the RIDT and AllocT
-        assert!(idml.ridt.get(rid)
+        #[tokio::test]
+        async fn extraneous_alloct() {
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let cache = Cache::default();
+            let mut ddml = mock_ddml();
+            ddml.expect_used().return_const(1u64);
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            // Inject a record into the AllocT but not the RIDT
+            let txg = TxgT::from(0);
+            idml.alloct.clone().insert(drp.pba(), rid, txg, Credit::null())
                 .now_or_never().unwrap()
-                .unwrap().is_none());
-        let alloc_rec = idml.alloct.get(drp.pba())
-            .now_or_never().unwrap()
-            .unwrap();
-        assert!(alloc_rec.is_none());
+                .unwrap();
+
+            assert!(!idml.check_ridt().await.unwrap());
+        }
+
+        #[tokio::test]
+        async fn extraneous_ridt() {
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let cache = Cache::default();
+            let mut ddml = mock_ddml();
+            ddml.expect_used().return_const(1u64);
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            // Inject a record into the RIDT but not the AllocT
+            let entry = RidtEntry{drp, refcount: 2};
+            let txg = TxgT::from(0);
+            idml.ridt.clone().insert(rid, entry, txg, Credit::null())
+                .now_or_never().unwrap()
+                .unwrap();
+
+            assert!(!idml.check_ridt().await.unwrap());
+        }
+
+        #[tokio::test]
+        async fn mismatch() {
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let drp2 = DRP::random(Compression::None, 4096);
+            let cache = Cache::default();
+            let mut ddml = mock_ddml();
+            ddml.expect_used().return_const(1u64);
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            // Inject a mismatched pair of records
+            let entry = RidtEntry{drp, refcount: 2};
+            let txg = TxgT::from(0);
+            idml.ridt.clone().insert(rid, entry, txg, Credit::null())
+                .now_or_never().unwrap()
+                .unwrap();
+            idml.alloct.clone().insert(drp2.pba(), rid, txg, Credit::null())
+                .now_or_never().unwrap()
+                .unwrap();
+
+            assert!(!idml.check_ridt().await.unwrap());
+        }
     }
 
-    #[test]
-    fn delete_notlast() {
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let cache = Cache::default();
-        let ddml = mock_ddml();
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp, 2);
+    mod delete {
+        use super::*;
+        use pretty_assertions::assert_eq;
 
-        idml.delete(&rid, TxgT::from(42))
-            .now_or_never().unwrap().unwrap();
-        // Now verify the contents of the RIDT and AllocT
-        let entry2 = idml.ridt.get(rid)
-            .now_or_never().unwrap()
-            .unwrap()
-            .unwrap();
-        assert_eq!(entry2.drp, drp);
-        assert_eq!(entry2.refcount, 1);
-        let alloc_rec = idml.alloct.get(drp.pba())
-            .now_or_never().unwrap()
-            .unwrap();
-        assert_eq!(alloc_rec.unwrap(), rid);
+        /// Delete a record that does not exist.  This typically indicate a
+        /// double-free, and it is a fatal error.
+        #[test]
+        #[should_panic(expected = "Double delete")]
+        fn double() {
+            let rid = RID(42);
+            let cache = Cache::default();
+            let ddml = mock_ddml();
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+
+            let _r = idml.delete(&rid, TxgT::from(42))
+                .now_or_never().unwrap();
+        }
+
+        #[test]
+        fn last() {
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let mut cache = Cache::default();
+            cache.expect_remove()
+                .once()
+                .with(eq(Key::Rid(RID(42))))
+                .returning(|_| {
+                    Some(Box::new(DivBufShared::from(vec![0u8; 4096])))
+                });
+            let mut ddml = mock_ddml();
+            ddml.expect_delete_direct()
+                .once()
+                .with(eq(drp), eq(TxgT::from(42)))
+                .returning(|_, _| Box::pin(future::ok::<(), Error>(())));
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp, 1);
+
+            idml.delete(&rid, TxgT::from(42))
+                .now_or_never().unwrap()
+                .unwrap();
+            // Now verify the contents of the RIDT and AllocT
+            assert!(idml.ridt.get(rid)
+                    .now_or_never().unwrap()
+                    .unwrap().is_none());
+            let alloc_rec = idml.alloct.get(drp.pba())
+                .now_or_never().unwrap()
+                .unwrap();
+            assert!(alloc_rec.is_none());
+        }
+
+        #[test]
+        fn notlast() {
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let cache = Cache::default();
+            let ddml = mock_ddml();
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp, 2);
+
+            idml.delete(&rid, TxgT::from(42))
+                .now_or_never().unwrap().unwrap();
+            // Now verify the contents of the RIDT and AllocT
+            let entry2 = idml.ridt.get(rid)
+                .now_or_never().unwrap()
+                .unwrap()
+                .unwrap();
+            assert_eq!(entry2.drp, drp);
+            assert_eq!(entry2.refcount, 1);
+            let alloc_rec = idml.alloct.get(drp.pba())
+                .now_or_never().unwrap()
+                .unwrap();
+            assert_eq!(alloc_rec.unwrap(), rid);
+        }
     }
 
     #[test]
@@ -948,63 +957,67 @@ mod t {
         idml.evict(&rid);
     }
 
-    #[test]
-    fn get_hot() {
-        let rid = RID(42);
-        let mut cache = Cache::default();
-        let dbs = DivBufShared::from(vec![0u8; 4096]);
-        cache.expect_get()
-            .once()
-            .with(eq(Key::Rid(RID(42))))
-            .returning(move |_| {
-                Some(Box::new(dbs.try_const().unwrap()))
-            });
-        let ddml = mock_ddml();
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+    mod get {
+        use super::*;
 
-        idml.get::<DivBufShared, DivBuf>(&rid)
-            .now_or_never().unwrap()
-            .unwrap();
-    }
+        #[test]
+        fn hot() {
+            let rid = RID(42);
+            let mut cache = Cache::default();
+            let dbs = DivBufShared::from(vec![0u8; 4096]);
+            cache.expect_get()
+                .once()
+                .with(eq(Key::Rid(RID(42))))
+                .returning(move |_| {
+                    Some(Box::new(dbs.try_const().unwrap()))
+                });
+            let ddml = mock_ddml();
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
 
-    #[test]
-    fn get_cold() {
-        let mut seq = Sequence::new();
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let mut cache = Cache::default();
-        let owned_by_cache = Arc::new(
-            Mutex::new(Vec::<Box<dyn Cacheable>>::new())
-        );
-        let owned_by_cache2 = owned_by_cache.clone();
-        cache.expect_get::<DivBuf>()
-            .once()
-            .in_sequence(&mut seq)
-            .with(eq(Key::Rid(RID(42))))
-            .returning(move |_| None);
-        cache.expect_insert()
-            .once()
-            .in_sequence(&mut seq)
-            .with(eq(Key::Rid(RID(42))), always())
-            .returning(move |_, dbs| {
-                owned_by_cache2.lock().unwrap().push(dbs);
-            });
-        let mut ddml = mock_ddml();
-        ddml.expect_get_direct::<DivBufShared>()
-            .once()
-            .with(eq(drp))
-            .returning(move |_| {
-                let dbs = Box::new(DivBufShared::from(vec![0u8; 4096]));
-                Box::pin(future::ok::<Box<DivBufShared>, Error>(dbs))
-            });
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp, 1);
+            idml.get::<DivBufShared, DivBuf>(&rid)
+                .now_or_never().unwrap()
+                .unwrap();
+        }
 
-        idml.get::<DivBufShared, DivBuf>(&rid)
-            .now_or_never().unwrap()
-            .unwrap();
+        #[test]
+        fn cold() {
+            let mut seq = Sequence::new();
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let mut cache = Cache::default();
+            let owned_by_cache = Arc::new(
+                Mutex::new(Vec::<Box<dyn Cacheable>>::new())
+            );
+            let owned_by_cache2 = owned_by_cache.clone();
+            cache.expect_get::<DivBuf>()
+                .once()
+                .in_sequence(&mut seq)
+                .with(eq(Key::Rid(RID(42))))
+                .returning(move |_| None);
+            cache.expect_insert()
+                .once()
+                .in_sequence(&mut seq)
+                .with(eq(Key::Rid(RID(42))), always())
+                .returning(move |_, dbs| {
+                    owned_by_cache2.lock().unwrap().push(dbs);
+                });
+            let mut ddml = mock_ddml();
+            ddml.expect_get_direct::<DivBufShared>()
+                .once()
+                .with(eq(drp))
+                .returning(move |_| {
+                    let dbs = Box::new(DivBufShared::from(vec![0u8; 4096]));
+                    Box::pin(future::ok::<Box<DivBufShared>, Error>(dbs))
+                });
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp, 1);
+
+            idml.get::<DivBufShared, DivBuf>(&rid)
+                .now_or_never().unwrap()
+                .unwrap();
+        }
     }
 
     #[test]
@@ -1046,301 +1059,311 @@ mod t {
         assert_eq!(r, vec![rid1, rid2]);
     }
 
-    /// When moving a record not resident in cache, get it from disk
-    #[test]
-    fn move_indirect_record_cold() {
-        let v = vec![42u8; 4096];
-        let dbs = DivBufShared::from(v);
-        let rid = RID(1);
-        let drp0 = DRP::random(Compression::None, 4096);
-        let drp1 = DRP::random(Compression::None, 4096);
-        let drp1_c = drp1;
-        let mut seq = Sequence::new();
-        let mut cache = Cache::default();
-        let mut ddml = mock_ddml();
-        cache.expect_get_ref()
-            .once()
-            .with(eq(Key::Rid(rid)))
-            .returning(|_| None);
-        ddml.expect_get_direct()
-            .once()
-            .in_sequence(&mut seq)
-            .withf(move |key| key.pba() == drp0.pba() &&
-                   !key.is_compressed())
-            .returning(move |_| {
-                let r = DivBufShared::from(&dbs.try_const().unwrap()[..]);
-                Box::pin(future::ok::<Box<DivBufShared>, Error>(Box::new(r)))
-            });
-        ddml.expect_put_direct::<DivBuf>()
-            .once()
-            .in_sequence(&mut seq)
-            .with(always(), eq(Compression::None), always())
-            .returning(move |_, _, _|
-                Box::pin(future::ok(drp1))
-            );
-        ddml.expect_delete_direct()
-            .once()
-            .in_sequence(&mut seq)
-            .with(eq(drp0), always())
-            .returning(move |_, _| {
-                Box::pin(future::ok::<(), Error>(()))
-            });
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp0, 1);
+    mod move_indirect_record {
+        use super::*;
+        use pretty_assertions::assert_eq;
 
-        IDML::move_record(&idml.cache, idml.ridt.clone(), idml.alloct.clone(),
-            &idml.ddml, rid, TxgT::from(0))
-        .now_or_never().unwrap().unwrap();
+        /// When moving a record not resident in cache, get it from disk
+        #[test]
+        fn cold() {
+            let v = vec![42u8; 4096];
+            let dbs = DivBufShared::from(v);
+            let rid = RID(1);
+            let drp0 = DRP::random(Compression::None, 4096);
+            let drp1 = DRP::random(Compression::None, 4096);
+            let drp1_c = drp1;
+            let mut seq = Sequence::new();
+            let mut cache = Cache::default();
+            let mut ddml = mock_ddml();
+            cache.expect_get_ref()
+                .once()
+                .with(eq(Key::Rid(rid)))
+                .returning(|_| None);
+            ddml.expect_get_direct()
+                .once()
+                .in_sequence(&mut seq)
+                .withf(move |key| key.pba() == drp0.pba() &&
+                       !key.is_compressed())
+                .returning(move |_| {
+                    let r = DivBufShared::from(&dbs.try_const().unwrap()[..]);
+                    Box::pin(future::ok::<Box<DivBufShared>, Error>(Box::new(r)))
+                });
+            ddml.expect_put_direct::<DivBuf>()
+                .once()
+                .in_sequence(&mut seq)
+                .with(always(), eq(Compression::None), always())
+                .returning(move |_, _, _|
+                    Box::pin(future::ok(drp1))
+                );
+            ddml.expect_delete_direct()
+                .once()
+                .in_sequence(&mut seq)
+                .with(eq(drp0), always())
+                .returning(move |_, _| {
+                    Box::pin(future::ok::<(), Error>(()))
+                });
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp0, 1);
 
-        // Now verify the RIDT and alloct entries
-        let entry = idml.ridt.get(rid)
-            .now_or_never().unwrap()
-            .unwrap()
-            .unwrap();
-        assert_eq!(entry.refcount, 1);
-        assert_eq!(entry.drp, drp1_c);
-        let alloc_rec = idml.alloct.get(drp1_c.pba())
-            .now_or_never().unwrap().unwrap();
-        assert_eq!(alloc_rec.unwrap(), rid);
-    }
-
-    /// When moving compressed records, the cache should be bypassed
-    #[test]
-    fn move_indirect_record_compressed() {
-        let v = vec![42u8; 4096];
-        let dbs = DivBufShared::from(v);
-        let rid = RID(1);
-        let drp0 = DRP::random(Compression::Zstd(None), 4096);
-        let drp1 = DRP::random(Compression::Zstd(None), 4096);
-        let drp1_c = drp1;
-        let mut seq = Sequence::new();
-        let cache = Cache::default();
-        let mut ddml = mock_ddml();
-        ddml.expect_get_direct()
-            .once()
-            .in_sequence(&mut seq)
-            .withf(move |key| key.pba() == drp0.pba() &&
-                   !key.is_compressed())
-            .returning(move |_| {
-                let r = DivBufShared::from(&dbs.try_const().unwrap()[..]);
-                Box::pin(future::ok(Box::new(r)))
-            });
-        ddml.expect_put_direct::<DivBuf>()
-            .once()
-            .in_sequence(&mut seq)
-            .with(always(), eq(Compression::None), always())
-            .returning(move |_, _, _| Box::pin(future::ok(drp1)));
-        ddml.expect_delete_direct()
-            .once()
-            .in_sequence(&mut seq)
-            .with(eq(drp0), always())
-            .returning(move |_, _| Box::pin(future::ok::<(), Error>(())));
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp0, 1);
-
-        IDML::move_record(&idml.cache, idml.ridt.clone(), idml.alloct.clone(),
-            &idml.ddml, rid, TxgT::from(0))
+            IDML::move_record(&idml.cache, idml.ridt.clone(), idml.alloct.clone(),
+                &idml.ddml, rid, TxgT::from(0))
             .now_or_never().unwrap().unwrap();
 
-        // Now verify the RIDT and alloct entries
-        let entry = idml.ridt.get(rid)
-            .now_or_never().unwrap()
-            .unwrap()
-            .unwrap();
-        assert_eq!(entry.refcount, 1);
-        assert_eq!(entry.drp, drp1_c);
-        let alloc_rec = idml.alloct.get(drp1_c.pba())
-            .now_or_never().unwrap()
-            .unwrap();
-        assert_eq!(alloc_rec.unwrap(), rid);
-    }
-
-    /// When moving records, check the cache first.
-    #[test]
-    fn move_indirect_record_hot() {
-        let v = vec![42u8; 4096];
-        let dbs = DivBufShared::from(v);
-        let rid = RID(1);
-        let drp0 = DRP::random(Compression::None, 4096);
-        let drp1 = DRP::random(Compression::None, 4096);
-        let mut seq = Sequence::new();
-        let mut cache = Cache::default();
-        let mut ddml = mock_ddml();
-        cache.expect_get_ref()
-            .once()
-            .in_sequence(&mut seq)
-            .with(eq(Key::Rid(rid)))
-            .returning(move |_| {
-                Some(Box::new(dbs.try_const().unwrap()))
-            });
-        ddml.expect_put_direct::<DivBuf>()
-            .once()
-            .in_sequence(&mut seq)
-            .returning(move |_, _, _|
-                       Box::pin(future::ok(drp1))
-            );
-        ddml.expect_delete_direct()
-            .once()
-            .in_sequence(&mut seq)
-            .with(eq(drp0), always())
-            .returning(move |_, _| Box::pin(future::ok::<(), Error>(())));
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp0, 1);
-
-        IDML::move_record(&idml.cache, idml.ridt.clone(), idml.alloct.clone(),
-            &idml.ddml, rid, TxgT::from(0))
-            .now_or_never().unwrap().unwrap();
-
-        // Now verify the RIDT and alloct entries
-        let entry = idml.ridt.get(rid)
-            .now_or_never().unwrap()
-            .unwrap().unwrap();
-        assert_eq!(entry.refcount, 1);
-        assert_eq!(entry.drp, drp1);
-        let alloc_rec = idml.alloct.get(drp1.pba())
-            .now_or_never().unwrap()
-            .unwrap();
-        assert_eq!(alloc_rec.unwrap(), rid);
-    }
-
-    #[test]
-    fn pop_hot_last() {
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let mut cache = Cache::default();
-        let mut ddml = mock_ddml();
-        cache.expect_remove()
-            .once()
-            .with(eq(Key::Rid(RID(42))))
-            .returning(|_| {
-                Some(Box::new(DivBufShared::from(vec![0u8; 4096])))
-            });
-        ddml.expect_delete()
-            .once()
-            .with(eq(drp), eq(TxgT::from(42)))
-            .returning(|_, _| Box::pin(future::ok::<(), Error>(())));
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp, 1);
-
-        idml.pop::<DivBufShared, DivBuf>(&rid, TxgT::from(42))
-            .now_or_never().unwrap()
-            .unwrap();
-        // Now verify the contents of the RIDT and AllocT
-        assert!(idml.ridt.get(rid)
+            // Now verify the RIDT and alloct entries
+            let entry = idml.ridt.get(rid)
                 .now_or_never().unwrap()
-                .unwrap().is_none());
-        let alloc_rec = idml.alloct.get(drp.pba())
-            .now_or_never().unwrap()
-            .unwrap();
-        assert!(alloc_rec.is_none());
-    }
+                .unwrap()
+                .unwrap();
+            assert_eq!(entry.refcount, 1);
+            assert_eq!(entry.drp, drp1_c);
+            let alloc_rec = idml.alloct.get(drp1_c.pba())
+                .now_or_never().unwrap().unwrap();
+            assert_eq!(alloc_rec.unwrap(), rid);
+        }
 
-    #[test]
-    fn pop_hot_notlast() {
-        let dbs = DivBufShared::from(vec![42u8; 4096]);
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let mut cache = Cache::default();
-        cache.expect_get()
-            .once()
-            .with(eq(Key::Rid(RID(42))))
-            .returning(move |_| {
-                Some(Box::new(dbs.try_const().unwrap()))
-            });
-        let ddml = mock_ddml();
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp, 2);
+        /// When moving compressed records, the cache should be bypassed
+        #[test]
+        fn compressed() {
+            let v = vec![42u8; 4096];
+            let dbs = DivBufShared::from(v);
+            let rid = RID(1);
+            let drp0 = DRP::random(Compression::Zstd(None), 4096);
+            let drp1 = DRP::random(Compression::Zstd(None), 4096);
+            let drp1_c = drp1;
+            let mut seq = Sequence::new();
+            let cache = Cache::default();
+            let mut ddml = mock_ddml();
+            ddml.expect_get_direct()
+                .once()
+                .in_sequence(&mut seq)
+                .withf(move |key| key.pba() == drp0.pba() &&
+                       !key.is_compressed())
+                .returning(move |_| {
+                    let r = DivBufShared::from(&dbs.try_const().unwrap()[..]);
+                    Box::pin(future::ok(Box::new(r)))
+                });
+            ddml.expect_put_direct::<DivBuf>()
+                .once()
+                .in_sequence(&mut seq)
+                .with(always(), eq(Compression::None), always())
+                .returning(move |_, _, _| Box::pin(future::ok(drp1)));
+            ddml.expect_delete_direct()
+                .once()
+                .in_sequence(&mut seq)
+                .with(eq(drp0), always())
+                .returning(move |_, _| Box::pin(future::ok::<(), Error>(())));
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp0, 1);
 
-        idml.pop::<DivBufShared, DivBuf>(&rid, TxgT::from(0))
-            .now_or_never().unwrap()
-            .unwrap();
-        // Now verify the contents of the RIDT and AllocT
-        let entry2 = idml.ridt.get(rid)
-            .now_or_never().unwrap()
-            .unwrap().unwrap();
-        assert_eq!(entry2.drp, drp);
-        assert_eq!(entry2.refcount, 1);
-        let alloc_rec = idml.alloct.get(drp.pba())
-            .now_or_never().unwrap()
-            .unwrap();
-        assert_eq!(alloc_rec.unwrap(), rid);
-    }
+            IDML::move_record(&idml.cache, idml.ridt.clone(), idml.alloct.clone(),
+                &idml.ddml, rid, TxgT::from(0))
+                .now_or_never().unwrap().unwrap();
 
-    #[test]
-    fn pop_cold_last() {
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let mut cache = Cache::default();
-        let mut ddml = mock_ddml();
-        cache.expect_remove()
-            .once()
-            .with(eq(Key::Rid(RID(42))))
-            .returning(|_| None);
-        ddml.expect_pop_direct::<DivBufShared>()
-            .once()
-            .with(eq(drp))
-            .returning(|_| {
-                let dbs = DivBufShared::from(vec![42u8; 4096]);
-                Box::pin(future::ok::<Box<DivBufShared>, Error>(
-                        Box::new(dbs))
-                )
-            });
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp, 1);
-
-        idml.pop::<DivBufShared, DivBuf>(&rid, TxgT::from(0))
-            .now_or_never().unwrap()
-            .unwrap();
-        // Now verify the contents of the RIDT and AllocT
-        assert!(idml.ridt.get(rid)
+            // Now verify the RIDT and alloct entries
+            let entry = idml.ridt.get(rid)
                 .now_or_never().unwrap()
-                .unwrap().is_none());
-        let alloc_rec = idml.alloct.get(drp.pba())
-            .now_or_never().unwrap()
-            .unwrap();
-        assert!(alloc_rec.is_none());
+                .unwrap()
+                .unwrap();
+            assert_eq!(entry.refcount, 1);
+            assert_eq!(entry.drp, drp1_c);
+            let alloc_rec = idml.alloct.get(drp1_c.pba())
+                .now_or_never().unwrap()
+                .unwrap();
+            assert_eq!(alloc_rec.unwrap(), rid);
+        }
+
+        /// When moving records, check the cache first.
+        #[test]
+        fn hot() {
+            let v = vec![42u8; 4096];
+            let dbs = DivBufShared::from(v);
+            let rid = RID(1);
+            let drp0 = DRP::random(Compression::None, 4096);
+            let drp1 = DRP::random(Compression::None, 4096);
+            let mut seq = Sequence::new();
+            let mut cache = Cache::default();
+            let mut ddml = mock_ddml();
+            cache.expect_get_ref()
+                .once()
+                .in_sequence(&mut seq)
+                .with(eq(Key::Rid(rid)))
+                .returning(move |_| {
+                    Some(Box::new(dbs.try_const().unwrap()))
+                });
+            ddml.expect_put_direct::<DivBuf>()
+                .once()
+                .in_sequence(&mut seq)
+                .returning(move |_, _, _|
+                           Box::pin(future::ok(drp1))
+                );
+            ddml.expect_delete_direct()
+                .once()
+                .in_sequence(&mut seq)
+                .with(eq(drp0), always())
+                .returning(move |_, _| Box::pin(future::ok::<(), Error>(())));
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp0, 1);
+
+            IDML::move_record(&idml.cache, idml.ridt.clone(), idml.alloct.clone(),
+                &idml.ddml, rid, TxgT::from(0))
+                .now_or_never().unwrap().unwrap();
+
+            // Now verify the RIDT and alloct entries
+            let entry = idml.ridt.get(rid)
+                .now_or_never().unwrap()
+                .unwrap().unwrap();
+            assert_eq!(entry.refcount, 1);
+            assert_eq!(entry.drp, drp1);
+            let alloc_rec = idml.alloct.get(drp1.pba())
+                .now_or_never().unwrap()
+                .unwrap();
+            assert_eq!(alloc_rec.unwrap(), rid);
+        }
     }
 
-    #[test]
-    fn pop_cold_notlast() {
-        let rid = RID(42);
-        let drp = DRP::random(Compression::None, 4096);
-        let mut cache = Cache::default();
-        let mut ddml = mock_ddml();
-        cache.expect_get::<DivBuf>()
-            .once()
-            .with(eq(Key::Rid(RID(42))))
-            .returning(|_| None);
-        ddml.expect_get_direct()
-            .once()
-            .with(eq(drp))
-            .returning(move |_| {
-                let dbs = Box::new(DivBufShared::from(vec![42u8; 4096]));
-                Box::pin(future::ok::<Box<DivBufShared>, Error>(dbs))
-            });
-        let arc_ddml = Arc::new(ddml);
-        let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
-        inject_record(&idml, rid, &drp, 2);
+    mod pop {
+        use super::*;
+        use pretty_assertions::assert_eq;
 
-        idml.pop::<DivBufShared, DivBuf>(&rid, TxgT::from(0))
-            .now_or_never().unwrap()
-            .unwrap();
-        // Now verify the contents of the RIDT and AllocT
-        let entry2 = idml.ridt.get(rid)
-            .now_or_never().unwrap()
-            .unwrap().unwrap();
-        assert_eq!(entry2.drp, drp);
-        assert_eq!(entry2.refcount, 1);
-        let alloc_rec = idml.alloct.get(drp.pba())
-            .now_or_never().unwrap()
-            .unwrap();
-        assert_eq!(alloc_rec.unwrap(), rid);
+        #[test]
+        fn hot_last() {
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let mut cache = Cache::default();
+            let mut ddml = mock_ddml();
+            cache.expect_remove()
+                .once()
+                .with(eq(Key::Rid(RID(42))))
+                .returning(|_| {
+                    Some(Box::new(DivBufShared::from(vec![0u8; 4096])))
+                });
+            ddml.expect_delete()
+                .once()
+                .with(eq(drp), eq(TxgT::from(42)))
+                .returning(|_, _| Box::pin(future::ok::<(), Error>(())));
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp, 1);
+
+            idml.pop::<DivBufShared, DivBuf>(&rid, TxgT::from(42))
+                .now_or_never().unwrap()
+                .unwrap();
+            // Now verify the contents of the RIDT and AllocT
+            assert!(idml.ridt.get(rid)
+                    .now_or_never().unwrap()
+                    .unwrap().is_none());
+            let alloc_rec = idml.alloct.get(drp.pba())
+                .now_or_never().unwrap()
+                .unwrap();
+            assert!(alloc_rec.is_none());
+        }
+
+        #[test]
+        fn hot_notlast() {
+            let dbs = DivBufShared::from(vec![42u8; 4096]);
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let mut cache = Cache::default();
+            cache.expect_get()
+                .once()
+                .with(eq(Key::Rid(RID(42))))
+                .returning(move |_| {
+                    Some(Box::new(dbs.try_const().unwrap()))
+                });
+            let ddml = mock_ddml();
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp, 2);
+
+            idml.pop::<DivBufShared, DivBuf>(&rid, TxgT::from(0))
+                .now_or_never().unwrap()
+                .unwrap();
+            // Now verify the contents of the RIDT and AllocT
+            let entry2 = idml.ridt.get(rid)
+                .now_or_never().unwrap()
+                .unwrap().unwrap();
+            assert_eq!(entry2.drp, drp);
+            assert_eq!(entry2.refcount, 1);
+            let alloc_rec = idml.alloct.get(drp.pba())
+                .now_or_never().unwrap()
+                .unwrap();
+            assert_eq!(alloc_rec.unwrap(), rid);
+        }
+
+        #[test]
+        fn cold_last() {
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let mut cache = Cache::default();
+            let mut ddml = mock_ddml();
+            cache.expect_remove()
+                .once()
+                .with(eq(Key::Rid(RID(42))))
+                .returning(|_| None);
+            ddml.expect_pop_direct::<DivBufShared>()
+                .once()
+                .with(eq(drp))
+                .returning(|_| {
+                    let dbs = DivBufShared::from(vec![42u8; 4096]);
+                    Box::pin(future::ok::<Box<DivBufShared>, Error>(
+                            Box::new(dbs))
+                    )
+                });
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp, 1);
+
+            idml.pop::<DivBufShared, DivBuf>(&rid, TxgT::from(0))
+                .now_or_never().unwrap()
+                .unwrap();
+            // Now verify the contents of the RIDT and AllocT
+            assert!(idml.ridt.get(rid)
+                    .now_or_never().unwrap()
+                    .unwrap().is_none());
+            let alloc_rec = idml.alloct.get(drp.pba())
+                .now_or_never().unwrap()
+                .unwrap();
+            assert!(alloc_rec.is_none());
+        }
+
+        #[test]
+        fn cold_notlast() {
+            let rid = RID(42);
+            let drp = DRP::random(Compression::None, 4096);
+            let mut cache = Cache::default();
+            let mut ddml = mock_ddml();
+            cache.expect_get::<DivBuf>()
+                .once()
+                .with(eq(Key::Rid(RID(42))))
+                .returning(|_| None);
+            ddml.expect_get_direct()
+                .once()
+                .with(eq(drp))
+                .returning(move |_| {
+                    let dbs = Box::new(DivBufShared::from(vec![42u8; 4096]));
+                    Box::pin(future::ok::<Box<DivBufShared>, Error>(dbs))
+                });
+            let arc_ddml = Arc::new(ddml);
+            let idml = IDML::create(arc_ddml, Arc::new(Mutex::new(cache)));
+            inject_record(&idml, rid, &drp, 2);
+
+            idml.pop::<DivBufShared, DivBuf>(&rid, TxgT::from(0))
+                .now_or_never().unwrap()
+                .unwrap();
+            // Now verify the contents of the RIDT and AllocT
+            let entry2 = idml.ridt.get(rid)
+                .now_or_never().unwrap()
+                .unwrap().unwrap();
+            assert_eq!(entry2.drp, drp);
+            assert_eq!(entry2.refcount, 1);
+            let alloc_rec = idml.alloct.get(drp.pba())
+                .now_or_never().unwrap()
+                .unwrap();
+            assert_eq!(alloc_rec.unwrap(), rid);
+        }
     }
 
     #[test]


### PR DESCRIPTION
    *DML::get would first check the cache.  If the requested block weren't
    there, then it would read from disk and insert the result into the
    cache.  However, it is possible that many tasks simultaneously attempt
    to read the same block from cache.  When that happened the result would
    be a flood of disks reads reading the same exact LBA over and over.
    
    Fix this performance bug by adding a queue of tasks that are waiting on
    the same cache insertion.  Speeds up fs_destroy by about 4.5x .
    
    Fixes #198