### PR TITLE
Only use one thread with Tokio

### DIFF
--- a/bfffs-fio/src/lib.rs
+++ b/bfffs-fio/src/lib.rs
@@ -166,7 +166,7 @@ pub extern "C" fn rust_ctor() {
 
 lazy_static! {
     static ref RUNTIME: RwLock<Runtime> = RwLock::new(
-        Builder::new_multi_thread()
+        Builder::new_current_thread()
             .enable_time()
             .enable_io()
             .build()

--- a/bfffs/benches/fs_destroy.rs
+++ b/bfffs/benches/fs_destroy.rs
@@ -316,7 +316,7 @@ fn fs_destroy(
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .pretty()

--- a/bfffs/src/bin/bfffsd/main.rs
+++ b/bfffs/src/bin/bfffsd/main.rs
@@ -353,7 +353,7 @@ impl Bfffsd {
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     tracing_subscriber::fmt()
         .pretty()


### PR DESCRIPTION
When Tokio gets event notification from kevent, the pending future may
belong to a different thread.  If so, it signals the other thread and
pends on kevent again.  But the other thread may not have had time to
call aio_return yet.  In that case, the first thread's kevent will
immediately return again.

The correct solution is to set EV_ONESHOT on the aiocb.  But Rust's libc
doesn't currently expose the necessary field.  Until it does, restrict
Tokio to just a single thread.

https://github.com/rust-lang/libc/pull/2813