### PR TITLE
Always set -C force-frame-pointers in RUSTFLAGS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+# Needed so that dtrace's ustack() function can unwind stack frames.
+rustflags = ["-C", "force-frame-pointers"]


### PR DESCRIPTION
Without it, ever since rustc 1.56.0 dtrace's ustack() function cannot
unwind stack frames.

https://github.com/rust-lang/rust/issues/97723