### PR TITLE
Improve performance when writing to many different files at once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "permutohedron",
+ "pin-project",
  "pretty_assertions",
  "rand 0.8.5",
  "rand_xorshift",

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -33,6 +33,7 @@ mockall_double = "0.2.0"
 nix = { git = "http://github.com/nix-rust/nix", rev = "69738c0fd03af19053c5701a984f923ecbbfada6", default-features = false, features = ["fs", "ioctl", "mount", "time"] }
 num_enum = "0.5.1"
 num-traits = "0.2.0"
+pin-project = "1.0.10"
 serde = "1.0.60"
 serde_derive = "1.0"
 serde_yaml = "0.8.16"

--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -1766,8 +1766,7 @@ impl Fs {
                 FSValue::Property(_) => {
                     panic!("Directories should not have properties")
                 },
-                #[cfg(test)]
-                FSValue::Invalid => unimplemented!()
+                FSValue::Invalid => unreachable!()
             }
         }).map_ok(move |found_inode| {
             assert!(found_inode,

--- a/bfffs-core/src/tree/mod.rs
+++ b/bfffs-core/src/tree/mod.rs
@@ -99,7 +99,7 @@ impl<A: Addr> TypicalSize for TreeOnDisk<A> {
     const TYPICAL_SIZE: usize = 32 + A::TYPICAL_SIZE;
 }
 
-impl<A: Addr> Value for TreeOnDisk<A> {}
+impl<A: Addr> Value for TreeOnDisk<A> { }
 
 // LCOV_EXCL_START
 #[cfg(test)]

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -324,11 +324,11 @@ impl<K: Key, V: Value> LeafData<K, V> {
                 v.flush(d, txg)
                 .map_ok(move |v| (k, v))
             }).collect::<FuturesOrdered<_>>()
-            .try_collect::<Vec<_>>()
+            .try_collect::<BTreeMap<_, _>>()
             .map_ok(|items| {
                 let ld = LeafData{
                     credit: Credit::null(),
-                    items: items.into_iter().collect()
+                    items
                 };
                 (ld, credit)
             }).boxed()

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -323,7 +323,7 @@ impl<K: Key, V: Value> LeafData<K, V> {
             self.items.into_iter().map(|(k, v)| {
                 v.flush(d, txg)
                 .map_ok(move |v| (k, v))
-            }).collect::<FuturesOrdered<_>>()
+            }).collect::<FuturesUnordered<_>>()
             .try_collect::<BTreeMap<_, _>>()
             .map_ok(|items| {
                 let ld = LeafData{

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -412,7 +412,8 @@ impl<A: Addr, D: DML<Addr=A>, K: Key, V: Value> Future for WriteLeaf<A, D, K, V>
                     if let Err(e) = r {
                         break Err(e);
                     }
-                    let (ld, credit) = r.unwrap();
+                    let mut ld = r.unwrap();
+                    let credit = ld.take_credit();
                     let node = Node::new(NodeData::Leaf(ld));
                     let arc: Arc<Node<A, K, V>> = Arc::new(node);
                     let dp = dml.put(arc, *compressor, *txg);


### PR DESCRIPTION
Writing to many different files at once dirties many different BTree leaf nodes.  The problem is most noticeable when each file is very large, or there are many unaltered files in between each updated file.  This exposed inefficiencies in LeafData::flush.  Chiefly, it would flush every single Value, even those that didn't need to be flushed.  That didn't result in any extra disk I/O, but it did cause extra malloc/free activity, which dominated CPU time.