### PR TITLE
Add a --parseable output flag to "bfffs fs list"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "rstest",
  "si-scale",
  "sysctl",
+ "tabular",
  "tempfile",
  "time",
  "tokio",
@@ -1831,6 +1832,15 @@ dependencies = [
  "byteorder",
  "errno",
  "libc 0.2.121",
+]
+
+[[package]]
+name = "tabular"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a2882c514780a1973df90de9d68adcd8871bacc9a6331c3f28e6d2ff91a3d1"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -22,6 +22,7 @@ fuse3 = { git = "https://github.com/asomers/fuse3.git", rev = "90f4c22", optiona
 futures = "0.3.0"
 libc = "0.2.44"
 nix = { git = "http://github.com/nix-rust/nix", rev = "69738c0fd03af19053c5701a984f923ecbbfada6", default-features = false, features = ["user"] }
+tabular = "0.2.0"
 time = { version = "0.3.0", features = [ "formatting" ] }
 tokio = { version = "1.10.0", features = ["macros", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-seqpacket = "0.5.4"

--- a/bfffs/tests/integration/bfffs/fs/list.rs
+++ b/bfffs/tests/integration/bfffs/fs/list.rs
@@ -85,7 +85,11 @@ async fn child() {
         .arg("mypool")
         .assert()
         .success()
-        .stdout("mypool\nmypool/child\n");
+        .stdout(
+            "NAME\n\
+             mypool\n\
+             mypool/child\n",
+        );
 }
 
 #[rstest]
@@ -100,7 +104,11 @@ async fn grandchild() {
         .arg("mypool/child")
         .assert()
         .success()
-        .stdout("mypool/child\nmypool/child/grandchild\n");
+        .stdout(
+            "NAME\n\
+             mypool/child\n\
+             mypool/child/grandchild\n",
+        );
 }
 
 #[test]
@@ -127,8 +135,11 @@ async fn multi_arg() {
         .assert()
         .success()
         .stdout(
-            "mypool/brother\nmypool/brother/grandson\nmypool/sister\nmypool/\
-             sister/granddaughter\n",
+            "NAME\n\
+             mypool/brother\n\
+             mypool/brother/grandson\n\
+             mypool/sister\n\
+             mypool/sister/granddaughter\n",
         );
 }
 
@@ -145,7 +156,7 @@ async fn lots() {
     }
     let h = harness(&dsnames);
     dsnames.sort();
-    let mut expected = vec![String::from("mypool")];
+    let mut expected = vec![String::from("NAME"), String::from("mypool")];
     expected.extend(dsnames.into_iter());
     let mut expected = expected.join("\n");
     expected.push('\n');
@@ -158,6 +169,26 @@ async fn lots() {
         .assert()
         .success()
         .stdout(expected);
+}
+
+/// With -H the header row should not be printed, and the columns should be
+/// separated by tabs.
+#[rstest]
+#[tokio::test]
+async fn parseable() {
+    let h = harness::<&'static str>(&[]);
+    bfffs()
+        .arg("--sock")
+        .arg(h.sockpath.to_str().unwrap())
+        .arg("fs")
+        .arg("list")
+        .arg("-p")
+        .arg("-o")
+        .arg("atime,mountpoint")
+        .arg("mypool")
+        .assert()
+        .success()
+        .stdout("mypool\ton\t/mypool\n");
 }
 
 #[rstest]
@@ -174,7 +205,10 @@ async fn props() {
         .arg("mypool")
         .assert()
         .success()
-        .stdout("mypool on /mypool\n");
+        .stdout(
+            "NAME   ATIME MOUNTPOINT\n\
+             mypool on    /mypool\n",
+        );
 }
 
 #[rstest]
@@ -189,7 +223,10 @@ async fn pool_only() {
         .arg("mypool")
         .assert()
         .success()
-        .stdout("mypool\n");
+        .stdout(
+            "NAME\n\
+             mypool\n",
+        );
 }
 
 #[rstest]
@@ -204,5 +241,10 @@ async fn siblings() {
         .arg("mypool")
         .assert()
         .success()
-        .stdout("mypool\nmypool/brother\nmypool/sister\n");
+        .stdout(
+            "NAME\n\
+             mypool\n\
+             mypool/brother\n\
+             mypool/sister\n",
+        );
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -10,7 +10,7 @@ ignore = [
 	"bfffs-core",
 ]
 force_multiline_blocks = true
-format_strings = true
+format_strings = false
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"
 imports_layout = "HorizontalVertical"


### PR DESCRIPTION
This is like a combination of zfs's -H and -p flags.  It suppresses the
header row, joins columns by tabs, and prints exact values of numeric
properties.

Also, add the header row itself, which was never printed before.