### PR TITLE
Add recursion to "bfffs fs get" and "bfffs fs list"

### DIFF
--- a/bfffs-core/src/controller.rs
+++ b/bfffs-core/src/controller.rs
@@ -204,7 +204,7 @@ impl Controller {
         })
     }
 
-    /// List a dataset and all of its immediate childen
+    /// List a dataset's immediate childen
     ///
     /// # Arguments
     ///
@@ -246,20 +246,7 @@ impl Controller {
                             Poll::Ready(Ok((_, Some(tree_id)))) => {
                                 let offs = self.offs.unwrap_or(0);
                                 let mut s = self.db.readdir(tree_id, offs);
-                                let o = if self.offs.is_some() {
-                                    Pin::new(&mut s).poll_next(cx)
-                                } else {
-                                    // BUG: using 0 as the offset for the parent
-                                    // create a potential for a hash collision
-                                    // with a child that happens to have an offs
-                                    // of zero, too.
-                                    let de = database::Dirent {
-                                        name: String::new(),
-                                        id: tree_id,
-                                        offs: 0
-                                    };
-                                    Poll::Ready(Some(Ok(de)))
-                                };
+                                let o = Pin::new(&mut s).poll_next(cx);
                                 self.lol = LookupOrList::List(Box::pin(s));
                                 o
                             }

--- a/bfffs-core/src/rpc.rs
+++ b/bfffs-core/src/rpc.rs
@@ -48,6 +48,12 @@ pub mod fs {
         pub offset: Option<u64>
     }
 
+    /// Like `readdirplus`, list all of a dataset's children with the requested
+    /// properties.
+    ///
+    /// The named dataset itself will not be included.  If `offset` is provided,
+    /// it can be used to resume a previous listing, as in `getdirentries`.
+    ///
     pub fn list(name: String, props: Vec<PropertyName>, offset: Option<u64>)
         -> Request
     {
@@ -82,6 +88,17 @@ pub mod fs {
             name,
             props
         })
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct Stat {
+        pub name: String,
+        pub props: Vec<PropertyName>,
+    }
+
+    /// Lookup the requested properties for a single dataset
+    pub fn stat(name: String, props: Vec<PropertyName>) -> Request {
+        Request::FsStat(Stat{name, props})
     }
 
     #[derive(Debug, Deserialize, Serialize)]
@@ -126,6 +143,7 @@ pub enum Request {
     FsList(fs::List),
     FsMount(fs::Mount),
     FsSet(fs::Set),
+    FsStat(fs::Stat),
     FsUnmount(fs::Unmount),
     PoolClean(pool::Clean)
 }
@@ -138,6 +156,7 @@ pub enum Response {
     FsList(Result<Vec<fs::DsInfo>>),
     FsMount(Result<()>),
     FsSet(Result<()>),
+    FsStat(Result<fs::DsInfo>),
     FsUnmount(Result<()>),
     PoolClean(Result<()>),
 }
@@ -181,6 +200,13 @@ impl Response {
     pub fn into_fs_set(self) -> Result<()> {
         match self {
             Response::FsSet(r) => r,
+            x => panic!("Unexpected response type {:?}", x)
+        }
+    }
+
+    pub fn into_fs_stat(self) -> Result<fs::DsInfo> {
+        match self {
+            Response::FsStat(r) => r,
             x => panic!("Unexpected response type {:?}", x)
         }
     }

--- a/bfffs-core/tests/functional/controller.rs
+++ b/bfffs-core/tests/functional/controller.rs
@@ -350,8 +350,7 @@ mod list_fs {
             .try_collect::<Vec<_>>()
             .await
             .unwrap();
-        assert_eq!(1, datasets.len());
-        assert_eq!(POOLNAME, datasets[0].name);
+        assert_eq!(0, datasets.len());
     }
 
     #[rstest]
@@ -364,11 +363,8 @@ mod list_fs {
             .try_collect::<Vec<_>>()
             .await
             .unwrap();
-        assert_eq!(2, datasets.len());
-        // The order of results is determined by a hash function and is
-        // reproducible but not meaningful
-        assert_eq!(POOLNAME, datasets[0].name);
-        assert_eq!(dsname, datasets[1].name);
+        assert_eq!(1, datasets.len());
+        assert_eq!(dsname, datasets[0].name);
     }
 
     #[rstest]
@@ -383,24 +379,14 @@ mod list_fs {
             .try_collect::<Vec<_>>()
             .await
             .unwrap();
-        assert_eq!(3, datasets1.len());
+        assert_eq!(2, datasets1.len());
         // The order of results is determined by a hash function and is
         // reproducible but not meaningful
-        assert_eq!(POOLNAME, datasets1[0].name);
-        assert_eq!(dsname1, datasets1[1].name);
-        assert_eq!(dsname2, datasets1[2].name);
+        assert_eq!(dsname1, datasets1[0].name);
+        assert_eq!(dsname2, datasets1[1].name);
 
-        // Now read results again, but providing an offset to skip the parent
-        let datasets2 = harness.0.list_fs(POOLNAME, Some(datasets1[0].offs))
-            .try_collect::<Vec<_>>()
-            .await
-            .unwrap();
-        assert_eq!(2, datasets2.len());
-        assert_eq!(dsname1, datasets2[0].name);
-        assert_eq!(dsname2, datasets2[1].name);
-
-        // And again, but skipping the first child
-        let datasets3 = harness.0.list_fs(POOLNAME, Some(datasets2[0].offs))
+        // Now read results again, but providing an offset to skip the first
+        let datasets3 = harness.0.list_fs(POOLNAME, Some(datasets1[0].offs))
             .try_collect::<Vec<_>>()
             .await
             .unwrap();
@@ -420,18 +406,14 @@ mod list_fs {
             .try_collect::<Vec<_>>()
             .await
             .unwrap();
-        assert_eq!(2, l1datasets.len());
-        // The order of results is determined by a hash function and is
-        // reproducible but not meaningful
-        assert_eq!(POOLNAME, l1datasets[0].name);
-        assert_eq!(childname, l1datasets[1].name);
+        assert_eq!(1, l1datasets.len());
+        assert_eq!(childname, l1datasets[0].name);
         let l2datasets = harness.0.list_fs(&childname, None)
             .try_collect::<Vec<_>>()
             .await
             .unwrap();
-        assert_eq!(2, l2datasets.len());
-        assert_eq!(childname, l2datasets[0].name);
-        assert_eq!(grandchildname, l2datasets[1].name);
+        assert_eq!(1, l2datasets.len());
+        assert_eq!(grandchildname, l2datasets[0].name);
     }
 }
 


### PR DESCRIPTION
To both of these commands, add "--recursive" and "--depth" options.

Also, add an FsStat RPC

It isn't directly exposed to the bfffs binary, but it is used by
Bfffs::fs_list.

Finally, Controller::list_fs no longer reports the parent dataset.