### PR TITLE
Replace custom "bfffs pool create" parsing code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +87,8 @@ dependencies = [
  "function_name",
  "fuse3",
  "futures",
+ "lalrpop",
+ "lalrpop-util",
  "libc",
  "mockall",
  "nix 0.25.0",
@@ -111,7 +122,7 @@ dependencies = [
  "divbuf",
  "downcast 0.10.0",
  "enum-primitive-derive",
- "fixedbitset",
+ "fixedbitset 0.1.9",
  "futures",
  "futures-locks",
  "futures-test",
@@ -194,6 +205,21 @@ dependencies = [
  "shlex",
  "which",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitfield"
@@ -437,6 +463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "cstr"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +535,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "divbuf"
 version = "0.3.2-pre"
 source = "git+https://github.com/asomers/divbuf.git?rev=0a72fb5#0a72fb5520bd42e0af78a1f109cac6652e100cdb"
@@ -530,6 +583,15 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "ena"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "enum-primitive-derive"
@@ -599,6 +661,12 @@ name = "fixedbitset"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "float-cmp"
@@ -925,6 +993,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "ena",
+ "itertools 0.10.3",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid 0.2.2",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
 name = "nix"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1320,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,12 +1356,38 @@ checksum = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 
 [[package]]
 name = "pest"
-version = "2.1.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
 dependencies = [
+ "thiserror",
  "ucd-trie",
 ]
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
@@ -1312,6 +1454,12 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
@@ -1513,6 +1661,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1753,12 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.6",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"
@@ -1724,6 +1889,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1914,19 @@ checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
 ]
 
 [[package]]
@@ -1814,6 +1998,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,18 +2053,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.16",
@@ -1894,6 +2089,15 @@ dependencies = [
  "itoa 1.0.1",
  "libc",
  "num_threads",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -20,6 +20,7 @@ bytes = "1.0"
 cfg-if = "1.0"
 fuse3 = { git = "https://github.com/asomers/fuse3.git", rev = "90f4c22", optional = true, features = ["tokio-runtime"] }
 futures = "0.3.0"
+lalrpop-util = "0.19.7"
 libc = "0.2.44"
 nix = { version = "0.25.0", default-features = false, features = ["user"] }
 si-scale = "0.1.5"
@@ -38,6 +39,9 @@ features=  [ "cargo", "derive", "wrap_help"]
 version = "0.2.15"
 default-features = false
 features = [ "ansi", "env-filter", "fmt", "tracing-log" ]
+
+[build-dependencies]
+lalrpop = "0.19.7"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/bfffs/build.rs
+++ b/bfffs/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    lalrpop::process_root().unwrap();
+}

--- a/bfffs/src/bin/bfffs/pool_create_ast.rs
+++ b/bfffs/src/bin/bfffs/pool_create_ast.rs
@@ -1,0 +1,42 @@
+// vim: tw=80
+//! Abstract Syntax Tree for the vdev specification in the "bfffs pool create"
+//! command.
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct Disk<'a>(pub &'a str);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Mirror<'a>(pub Vec<&'a str>);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RaidChild<'a> {
+    Disk(Disk<'a>),
+    Mirror(Mirror<'a>),
+}
+
+impl<'a> RaidChild<'a> {
+    pub fn as_disk(&'a self) -> Option<&'a Disk<'a>> {
+        match self {
+            RaidChild::Disk(d) => Some(d),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Raid<'a> {
+    pub k:     i16,
+    pub f:     i16,
+    pub vdevs: Vec<RaidChild<'a>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Tlv<'a> {
+    Raid(Raid<'a>),
+    Mirror(Mirror<'a>),
+    Disk(&'a str),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Pool<'a>(pub Vec<Tlv<'a>>);

--- a/bfffs/src/pool_create_parser.lalrpop
+++ b/bfffs/src/pool_create_parser.lalrpop
@@ -1,0 +1,42 @@
+// vim: filetype=rust
+
+use std::str::FromStr;
+use crate::pool_create_ast::{Disk, Mirror, Raid, RaidChild, Tlv, Pool};
+
+grammar;
+
+Num: i16 = r"[0-9]+" => i16::from_str(<>).unwrap();
+
+Disk: Disk<'input> = {
+    r"[/a-zA-Z][^ \t\n]*" => Disk(<>)
+}
+
+Mirror: Mirror<'input> = {
+    "mirror" <d:r"[/a-zA-Z][^ \t\n]*"+> => Mirror(d),
+}
+
+Raid: Raid<'input> = {
+    "raid" <k:Num> <f:Num> <d:Disk+> => {
+        let vdevs = d.into_iter().map(RaidChild::Disk).collect::<Vec<_>>();
+        Raid{k, f, vdevs}
+    },
+    "raid" <k:Num> <f:Num> <m:Mirror+> => {
+        let vdevs = m.into_iter().map(RaidChild::Mirror).collect::<Vec<_>>();
+        Raid{k, f, vdevs}
+    }
+}
+
+pub Pool: Pool<'input> = {
+    <d:r"[/a-zA-Z][^ \t\n]*"+> => {
+        let vdevs = d.into_iter().map(Tlv::Disk).collect::<Vec<_>>();
+        Pool(vdevs)
+    },
+    <m:Mirror+> => {
+        let vdevs = m.into_iter().map(Tlv::Mirror).collect::<Vec<_>>();
+        Pool(vdevs)
+    },
+    <r:Raid+> => {
+        let vdevs = r.into_iter().map(Tlv::Raid).collect::<Vec<_>>();
+        Pool(vdevs)
+    }
+}


### PR DESCRIPTION
Parse the vdev specification using lalrpop, instead of hand-rolled code.
It probably could be simplified further, but I'm going to wait until
mirror support is done before trying.