### PR TITLE
Eliminate unnecessary path copying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,8 +1152,7 @@ dependencies = [
 [[package]]
 name = "mockall"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2be9a9090bc1cac2930688fa9478092a64c6a92ddc6ae0692d46b37d9cab709"
+source = "git+https://github.com/asomers/mockall.git?rev=3b8da11#3b8da11f45c54f50b79d9e94bb9b910ddf3b2906"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast 0.11.0",
@@ -1167,8 +1166,7 @@ dependencies = [
 [[package]]
 name = "mockall_derive"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d702a0530a0141cf4ed147cf5ec7be6f2c187d4e37fcbefc39cf34116bfe8f"
+source = "git+https://github.com/asomers/mockall.git?rev=3b8da11#3b8da11f45c54f50b79d9e94bb9b910ddf3b2906"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ lto = true
 members = ["bfffs-core", "bfffs-fio", "bfffs", "isa-l"]
 
 [patch.crates-io]
+mockall = { git = "https://github.com/asomers/mockall.git", rev = "3b8da11" }

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -29,6 +29,7 @@ isa-l = { path = "../isa-l" }
 lazy_static = "1.0"
 libc = "0.2.105"
 metrohash = "1.0"
+mockall = "0.11.2"
 mockall_double = "0.2.0"
 nix = { version = "0.25.0", default-features = false, features = ["fs", "ioctl", "mount", "time"] }
 num_enum = "0.5.1"
@@ -56,7 +57,6 @@ futures-test = "0.3.7"
 glob = "0.2"
 histogram = "0.6"
 itertools = "0.7.1"
-mockall = "0.11.2"
 nix = { version = "0.25.0", default-features = false, features = ["user"] }
 num_cpus = "1"
 permutohedron = "0.2"

--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -747,10 +747,11 @@ impl Cluster {
     ///                         disks may fail before the array becomes
     ///                         inoperable.
     /// * `paths`:              Slice of pathnames of files and/or devices
+    #[mockall::concretize]
     pub fn create<P>(chunksize: Option<NonZeroU64>, disks_per_stripe: i16,
-        lbas_per_zone: Option<NonZeroU64>, redundancy: i16, paths: Vec<P>)
+        lbas_per_zone: Option<NonZeroU64>, redundancy: i16, paths: &[P])
         -> Self
-        where P: AsRef<Path> + 'static
+        where P: AsRef<Path>
     {
         let vdev = raid::create(chunksize, disks_per_stripe, lbas_per_zone,
                                 redundancy, paths);

--- a/bfffs-core/src/pool.rs
+++ b/bfffs-core/src/pool.rs
@@ -27,7 +27,7 @@ use std::{
 };
 #[cfg(not(test))] use std::{
     num::NonZeroU64,
-    path::{Path, PathBuf},
+    path::Path,
 };
 use std::collections::BTreeMap;
 
@@ -168,11 +168,8 @@ impl Pool {
         -> Cluster
         where P: AsRef<Path> + Sync
     {
-        let owned_paths = paths.iter()
-            .map(|p| p.as_ref().to_owned())
-            .collect::<Vec<PathBuf>>();
         Cluster::create(chunksize, disks_per_stripe,
-                lbas_per_zone, redundancy, owned_paths)
+                lbas_per_zone, redundancy, paths)
     }
 
     /// Create a new `Pool` from some freshly created `Cluster`s.

--- a/bfffs-core/src/raid/mod.rs
+++ b/bfffs-core/src/raid/mod.rs
@@ -80,13 +80,13 @@ impl<'a> Label {
 /// * `paths`:              Slice of pathnames of files and/or devices
 pub fn create<P>(chunksize: Option<NonZeroU64>, disks_per_stripe: i16,
     lbas_per_zone: Option<NonZeroU64>, redundancy: i16,
-    mut paths: Vec<P>) -> Arc<dyn VdevRaidApi>
-    where P: AsRef<Path> + 'static
+    paths: &[P]) -> Arc<dyn VdevRaidApi>
+    where P: AsRef<Path>
 {
     if paths.len() == 1 {
         assert_eq!(disks_per_stripe, 1);
         assert_eq!(redundancy, 0);
-        Arc::new(VdevOneDisk::create(lbas_per_zone, paths.pop().unwrap()))
+        Arc::new(VdevOneDisk::create(lbas_per_zone, &paths[0]))
     } else {
         Arc::new(VdevRaid::create(chunksize, disks_per_stripe, lbas_per_zone,
                                  redundancy, paths))

--- a/bfffs-core/src/raid/vdev_onedisk.rs
+++ b/bfffs-core/src/raid/vdev_onedisk.rs
@@ -54,7 +54,7 @@ impl VdevOneDisk {
     // function technically needs to be public for testing purposes.
     #[doc(hidden)]
     pub fn create<P>(lbas_per_zone: Option<NonZeroU64>, path: P) -> Self
-        where P: AsRef<Path> + 'static
+        where P: AsRef<Path>
     {
         let uuid = Uuid::new_v4();
         let blockdev = VdevBlock::create(path, lbas_per_zone).unwrap();

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -282,15 +282,15 @@ impl VdevRaid {
     // function technically needs to be public for testing purposes.
     #[doc(hidden)]
     pub fn create<P>(chunksize: Option<NonZeroU64>, disks_per_stripe: i16,
-        lbas_per_zone: Option<NonZeroU64>, redundancy: i16, paths: Vec<P>)
+        lbas_per_zone: Option<NonZeroU64>, redundancy: i16, paths: &[P])
         -> Self
-        where P: AsRef<Path> + 'static
+        where P: AsRef<Path>
     {
         let num_disks = paths.len() as i16;
         let (layout, chunksize) = VdevRaid::choose_layout(num_disks,
             disks_per_stripe, redundancy, chunksize);
         let uuid = Uuid::new_v4();
-        let blockdevs = paths.into_iter().map(|path| {
+        let blockdevs = paths.iter().map(|path| {
             VdevBlock::create(path, lbas_per_zone).unwrap()
         }).collect::<Vec<_>>();
         VdevRaid::new(chunksize, disks_per_stripe, redundancy, uuid,

--- a/bfffs-core/src/vdev_block.rs
+++ b/bfffs-core/src/vdev_block.rs
@@ -741,7 +741,7 @@ impl VdevBlock {
     ///                     zones.
     pub fn create<P>(path: P, lbas_per_zone: Option<NonZeroU64>)
         -> io::Result<Self>
-        where P: AsRef<Path> + 'static
+        where P: AsRef<Path>
     {
         let leaf = VdevLeaf::create(path, lbas_per_zone)?;
         Ok(VdevBlock::new(leaf))
@@ -989,9 +989,10 @@ impl Vdev for VdevBlock {
 #[cfg(test)]
 mock! {
     pub VdevBlock {
+        #[mockall::concretize]
         pub fn create<P>(path: P, lbas_per_zone: Option<NonZeroU64>)
             -> io::Result<Self>
-            where P: AsRef<Path> + 'static;
+            where P: AsRef<Path>;
         pub fn erase_zone(&self, start: LbaT, end: LbaT) -> BoxVdevFut;
         pub fn finish_zone(&self, start: LbaT, end: LbaT) -> BoxVdevFut;
         pub fn new(leaf: VdevLeaf) -> Self;

--- a/bfffs-core/src/vdev_file.rs
+++ b/bfffs-core/src/vdev_file.rs
@@ -706,13 +706,15 @@ impl Future for WritevAt {
 #[cfg(test)]
 mock!{
     pub VdevFile {
+        #[mockall::concretize]
         pub fn create<P>(path: P, lbas_per_zone: Option<NonZeroU64>)
             -> io::Result<Self>
-            where P: AsRef<Path> + 'static;
+            where P: AsRef<Path>;
         pub fn erase_zone(&mut self, lba: LbaT) -> BoxVdevFut;
         pub fn finish_zone(&self, _lba: LbaT) -> BoxVdevFut;
+        #[mockall::concretize]
         pub async fn open<P>(path: P) -> Result<(Self, LabelReader)>
-            where P: AsRef<Path> + 'static;
+            where P: AsRef<Path>;
         pub fn open_zone(&self, _lba: LbaT) -> BoxVdevFut;
         pub fn read_at(&self, buf: IoVecMut, lba: LbaT) -> BoxVdevFut;
         pub fn read_spacemap(&self, buf: IoVecMut, idx: u32) -> BoxVdevFut;

--- a/bfffs-core/tests/functional/cluster.rs
+++ b/bfffs-core/tests/functional/cluster.rs
@@ -59,8 +59,7 @@ mod persistence {
         t!(file.set_len(len));
         let rt = basic_runtime();
         let lpz = NonZeroU64::new(65536);
-        let paths = vec![fname.clone()];
-        let cluster = Cluster::create(None, 1, lpz, 0, paths);
+        let cluster = Cluster::create(None, 1, lpz, 0, &[&fname]);
         (rt, cluster, tempdir, fname)
     }
 

--- a/bfffs/src/bin/bfffs/main.rs
+++ b/bfffs/src/bin/bfffs/main.rs
@@ -754,7 +754,7 @@ mod pool {
 
         pub fn do_create_cluster(&mut self, k: i16, f: i16, devs: &[&str]) {
             let zone_size = self.zone_size;
-            let c = Pool::create_cluster(None, k, zone_size, f, devs);
+            let c = Cluster::create(None, k, zone_size, f, devs);
             self.clusters.push(c);
         }
 


### PR DESCRIPTION
Certain functions take a "where P: AsRef<Path? + 'static", where the static part is just necessary for Mockall.  The latest Mockall enhancement eliminates the need for the 'static part.