### PR TITLE
Two tweaks to the RAID codec

### DIFF
--- a/bfffs-core/examples/hash_collision.rs
+++ b/bfffs-core/examples/hash_collision.rs
@@ -63,7 +63,6 @@ impl Collidable for CDirent {
     fn new(seed: &[u8; 16]) -> Self {
         let this_rng = XorShiftRng::from_seed(*seed);
         let v: Vec<u8> = this_rng.sample_iter(&Alphanumeric)
-            .map(|c| c as u8)
             .take(10)
             .collect();
         let name = OsStr::from_bytes(&v[..]);
@@ -88,7 +87,6 @@ impl Collidable for CExtattr {
     fn new(seed: &[u8; 16]) -> Self {
         let mut this_rng = XorShiftRng::from_seed(*seed);
         let v: Vec<u8> = (&mut this_rng).sample_iter(&Alphanumeric)
-            .map(|c| c as u8)
             .take(10)
             .collect();
         let name = OsStr::from_bytes(&v[..]);

--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -551,7 +551,7 @@ impl Display for FreeSpaceMap {
         let max_txg: u32 = cmp::max(1, (0..self.zones.len())
             .filter(|zid| !self.is_empty(*zid as ZoneT))
             .map(|zid| {
-                let z = &self.zones[zid as usize];
+                let z = &self.zones[zid];
                 if self.is_open(zid as ZoneT) {
                     z.txgs.start
                 } else {

--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -309,7 +309,7 @@ impl Uio {
 
     /// Across how many records will this UIO be spread?
     fn nrecs(&self, offset0: usize, rs: usize) -> usize {
-        (div_roundup(offset0 + self.len(), rs) - (offset0 / rs)) as usize
+        div_roundup(offset0 + self.len(), rs) - (offset0 / rs)
     }
 }
 

--- a/bfffs-core/src/fs_tree.rs
+++ b/bfffs-core/src/fs_tree.rs
@@ -256,7 +256,7 @@ impl FSKey {
 
 impl Debug for FSKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let objtype = ObjKeyDiscriminant::from(self.objtype() as u8);
+        let objtype = ObjKeyDiscriminant::from(self.objtype());
         write!(f, "FSKey {{ object: {:#x}, objtype: {:?}, offset: {:#x} }}",
                self.object(), objtype, self.offset())
     }

--- a/bfffs-core/src/raid/codec.rs
+++ b/bfffs-core/src/raid/codec.rs
@@ -352,14 +352,14 @@ mod tests {
                     }
                 }
                 let data_errs = erasures.count_ones(..k as usize);
-                let mut decoded = Vec::<*mut u8>::with_capacity(data_errs as usize);
-                for x in reconstructed.iter_mut().take(data_errs as usize) {
+                let mut decoded = Vec::<*mut u8>::with_capacity(data_errs);
+                for x in reconstructed.iter_mut().take(data_errs) {
                     decoded.push(x.as_mut_ptr());
                 }
                 unsafe { codec.decode(len, &surviving, &mut decoded, &erasures); }
 
                 // Finally, compare
-                for i in 0..(data_errs as usize) {
+                for i in 0..data_errs {
                     assert_eq!(&data[erasures_vec[i] as usize], &reconstructed[i],
                         "miscompare for m={:?}, f={:?}, erasures={:?}",
                         m, f, erasures_vec);

--- a/bfffs-core/src/raid/prime_s.rs
+++ b/bfffs-core/src/raid/prime_s.rs
@@ -334,7 +334,7 @@ impl Locator for PrimeS {
         let b = (disk * y_inv - i32::from(s) * i32::from(self.m))
             .rem_euclid(i32::from(self.n)) as u8;
         // number of data chunks preceding this repetition
-        let o = r * self.datachunks() as u64;
+        let o = r * self.datachunks();
         if b >= self.m {
             ChunkId::Parity(o + (s as u64 * u64::from(self.m)),
                             i16::from(b - self.m))

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -519,18 +519,18 @@ impl VdevRaid {
                 let end = (chunk + 1) * col_len;
                 let col = buf.slice(begin, end);
                 data_refs[i] = col.as_ptr();
-                for p in 0..f {
-                    let begin = s * col_len;
-                    debug_assert!(begin + col_len <= parity[p].capacity());
-                    // Safe because the assertion passed
-                    unsafe {
-                        parity_refs[p] = parity[p].as_mut_ptr().add(begin);
-                    }
+            }
+            for p in 0..f {
+                let begin = s * col_len;
+                debug_assert!(begin + col_len <= parity[p].capacity());
+                // Safe because the assertion passed
+                unsafe {
+                    parity_refs[p] = parity[p].as_mut_ptr().add(begin);
                 }
             }
             // Safe because the above assertion passed
             unsafe {
-                self.codec.encode(col_len, &data_refs, &parity_refs);
+                self.codec.encode(col_len, &data_refs, &mut parity_refs);
             }
         }
 
@@ -601,13 +601,13 @@ impl VdevRaid {
                 .collect();
             debug_assert_eq!(dcols.len(), m);
 
-            let prefs = parity.iter_mut()
+            let mut prefs = parity.iter_mut()
                 .map(|v| v.as_mut_ptr())
                 .collect::<Vec<_>>();
 
             // Safe because each parity column is sized for `col_len`
             unsafe {
-                self.codec.encode(col_len, &drefs, &prefs);
+                self.codec.encode(col_len, &drefs, &mut prefs);
             }
         }
         let pw = parity.into_iter()

--- a/bfffs-core/src/vdev_block.rs
+++ b/bfffs-core/src/vdev_block.rs
@@ -721,7 +721,7 @@ impl VdevBlock {
     fn check_iovec_bounds(&self, lba: LbaT, buf: &[u8]) {
         let buflen = buf.len() as u64;
         let last_lba : LbaT = lba + buflen / (BYTES_PER_LBA as u64);
-        assert!(last_lba <= self.size as u64)
+        assert!(last_lba <= self.size)
     }
 
     /// Helper function for readv and writev methods
@@ -730,7 +730,7 @@ impl VdevBlock {
 
         let len = sglist_len(bufs) as u64;
         let last_lba = lba + len / (BYTES_PER_LBA as u64);
-        assert!(last_lba <= self.size as u64)
+        assert!(last_lba <= self.size)
     }
 
     /// Create a new VdevBlock from an unused file or device

--- a/bfffs-core/src/vdev_file.rs
+++ b/bfffs-core/src/vdev_file.rs
@@ -146,7 +146,7 @@ pub struct VdevFile {
 impl Vdev for VdevFile {
     fn lba2zone(&self, lba: LbaT) -> Option<ZoneT> {
         if lba >= self.reserved_space() {
-            Some((lba / (self.lbas_per_zone as u64)) as ZoneT)
+            Some((lba / self.lbas_per_zone) as ZoneT)
         } else {
             None
         }
@@ -480,7 +480,7 @@ impl VdevFile {
     }
 
     fn reserved_space(&self) -> LbaT {
-        LABEL_COUNT * (LABEL_LBAS as u64 + self.spacemap_space)
+        LABEL_COUNT * (LABEL_LBAS + self.spacemap_space)
     }
 
     /// Size of a single serialized spacemap, in LBAs, rounded up.

--- a/bfffs/src/bin/bfffsd/fs.rs
+++ b/bfffs/src/bin/bfffsd/fs.rs
@@ -968,7 +968,7 @@ impl Filesystem for FuseFs {
             .expect("setattr before lookup or after forget")
             .handle();
         let attr = fs::SetAttr {
-            perm:      set_attr.mode.map(|m| (m & 0o7777) as u16),
+            perm:      set_attr.mode.map(|m| m & 0o7777),
             uid:       set_attr.uid,
             gid:       set_attr.gid,
             size:      set_attr.size,

--- a/bfffs/src/bin/bfffsd/fs/tests.rs
+++ b/bfffs/src/bin/bfffsd/fs/tests.rs
@@ -1701,7 +1701,7 @@ mod lseek {
                 .times(1)
                 .with(
                     predicate::function(move |fd: &FileData| fd.ino() == ino),
-                    predicate::eq(ofs as u64),
+                    predicate::eq(ofs),
                     predicate::eq(SeekWhence::Hole),
                 )
                 .returning(|_ino, _ofs, _whence| Ok(4096));
@@ -2293,7 +2293,7 @@ mod read {
                 .times(1)
                 .with(
                     predicate::function(move |fd: &FileData| fd.ino() == ino),
-                    predicate::eq(ofs as u64),
+                    predicate::eq(ofs),
                     predicate::eq(len as usize),
                 )
                 .return_const(Err(libc::EIO));
@@ -2329,7 +2329,7 @@ mod read {
                 .times(1)
                 .with(
                     predicate::function(move |fd: &FileData| fd.ino() == ino),
-                    predicate::eq(ofs as u64),
+                    predicate::eq(ofs),
                     predicate::eq(len as usize),
                 )
                 .return_const(Ok(SGList::new()));
@@ -2365,7 +2365,7 @@ mod read {
                 .times(1)
                 .with(
                     predicate::function(move |fd: &FileData| fd.ino() == ino),
-                    predicate::eq(ofs as u64),
+                    predicate::eq(ofs),
                     predicate::eq(len as usize),
                 )
                 .returning(|_ino, _ofs, _len| {
@@ -2406,7 +2406,7 @@ mod read {
                 .times(1)
                 .with(
                     predicate::function(move |fd: &FileData| fd.ino() == ino),
-                    predicate::eq(ofs as u64),
+                    predicate::eq(ofs),
                     predicate::eq(len as usize),
                 )
                 .returning(|_ino, _ofs, _len| {
@@ -3665,7 +3665,7 @@ mod write {
                 .times(1)
                 .with(
                     predicate::function(move |fd: &FileData| fd.ino() == ino),
-                    predicate::eq(ofs as u64),
+                    predicate::eq(ofs),
                     predicate::eq(DATA),
                     predicate::always(),
                 )
@@ -3700,7 +3700,7 @@ mod write {
                 .times(1)
                 .with(
                     predicate::function(move |fd: &FileData| fd.ino() == ino),
-                    predicate::eq(ofs as u64),
+                    predicate::eq(ofs),
                     predicate::eq(DATA),
                     predicate::always(),
                 )

--- a/isa-l/src/lib.rs
+++ b/isa-l/src/lib.rs
@@ -36,13 +36,20 @@ pub const fn version() -> u32 {
 ///
 /// Caller must ensure that the `data` and `parity` fields are of sufficient
 /// size and point to allocated memory.  `parity` need not be initialized.
+// Note:
+// * `data`'s type can't be `&[&[u8]]`, because the memory layout of `&[u8]`
+//   is a fat pointer, not a plain pointer, and we don't want to allocate new
+//   storage here for an array of pointers.  That can be done more cheaply
+//   upstack.
+// * `parity`'s type can't be &mut[&mut [u8]] for the same reason, and also
+//   because we want to operate on potentially uninitialized parity arrays.
 pub unsafe fn ec_encode_data(
     len: usize,
     k: u32,
     f: u32,
     gftbls: &[u8],
     data: &[*const u8],
-    parity: &[*mut u8],
+    parity: &mut [*mut u8],
 ) {
     assert_eq!(gftbls.len(), (32 * f * k) as usize);
     assert_eq!(data.len(), k as usize);
@@ -93,7 +100,7 @@ pub unsafe fn ec_encode_data_update(
     vec_i: u32,
     gftbls: &[u8],
     data: &[u8],
-    parity: &[*mut u8],
+    parity: &mut [*mut u8],
 ) {
     assert_eq!(gftbls.len(), (32 * f * k) as usize);
     assert_eq!(data.len(), len);


### PR DESCRIPTION
* parity needs to be a mutable reference.  It isn't actually safe to put a mutable reference behind an immutable one, but we didn't notice because of an unsafe pointer cast.

* Move some loop-independent code out of the loop in VdevRaid::write_at_multi.