### PR TITLE
Fix an insufficient credit bug in Fs::deallocate

### DIFF
--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -570,7 +570,7 @@ impl Fs {
     {
         let ino = fd.ino;
         let inode_key = FSKey::new(ino, ObjKey::Inode);
-        self.db.fswrite(self.tree, 3, 0, 2, 1,
+        self.db.fswrite(self.tree, 3, 1, 2, 0,
         move |dataset| async move {
             let ds = Arc::new(dataset);
             let mut inode_value = ds.get(inode_key).await?.unwrap();


### PR DESCRIPTION
The credit requirements were wrong; apparently I typed them in the wrong order.  The bug is triggered by deallocating a whole extent and portions of two others, and apparently can only be triggered with 128 kB records.

Reported by:	FSX