### PR TITLE
Fix two bugs in Fs::deallocate

### DIFF
--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -931,10 +931,15 @@ impl Fs {
             .map_ok(move |_| old_len)
         }).boxed();
 
-        // Deallocate any partial record on the right side of the range, if the
-        // range ends in a different record than it started.
+        // Deallocate any partial record on the right side of the range:
+        // if the right end of the range does not run to a record boundary, AND
+        // either the left edge is a record boundary or the left edge is in a
+        // different record.
         let right_fut = match len {
-            Some(l) if ((offset + l) / rs > offset / rs) &&
+            Some(l) if (
+                            offset % rs == 0 ||
+                            (offset + l) / rs > offset / rs
+                       ) &&
                        (offset + l) % rs != 0 =>
             {
                 let len = (offset + l) % rs;
@@ -947,7 +952,7 @@ impl Fs {
                     },
                     Some(FSValue::InlineExtent(ile)) => async move {
                         let mut b = ile.buf.try_mut().unwrap();
-                        for i in 0..len {
+                        for i in 0..len.min(b.len() as u64) {
                             b[i as usize] = 0;
                         }
                         let extent = InlineExtent::new(ile.buf);

--- a/bfffs-core/tests/functional/fs.rs
+++ b/bfffs-core/tests/functional/fs.rs
@@ -321,9 +321,7 @@ mod fs {
         assert!(fs.deallocate(&fdh, 4096, 2048).await.is_ok());
 
         let attr = fs.getattr(&fdh).await.unwrap();
-        // The partially deallocated extent still takes up space
-        // TODO: remove the extent entirely
-        assert_eq!(attr.bytes, 6144);
+        assert_eq!(attr.bytes, 4096);
         assert_eq!(attr.size, 6144);
         assert_ts_changed(&fs, &fdh, false, true, true, false).await;
         // Finally, verify that the deallocated space is zeroes.
@@ -469,17 +467,14 @@ mod fs {
         assert!(fs.deallocate(&fdh, 0, 2048).await.is_ok());
 
         let attr = fs.getattr(&fdh).await.unwrap();
-        // The partially deallocated extent still takes up space
-        // TODO: remove the extent entirely
-        assert_eq!(attr.bytes, 1024);
+        assert_eq!(attr.bytes, 0);
         assert_eq!(attr.size, 4096);
         assert_ts_changed(&fs, &fdh, false, true, true, false).await;
         // Finally, read the deallocated record.  It should be zeros
         let sglist = fs.read(&fdh, 0, 4096).await.unwrap();
         let zbuf = [0u8; 4096];
-        assert_eq!(sglist[0].len(), 1024);
-        assert_eq!(&sglist[0][..], &zbuf[0..1024]);
-        assert_eq!(&sglist[1][..], &zbuf[1024..]);
+        assert_eq!(sglist[0].len(), 4096);
+        assert_eq!(&sglist[0][..], &zbuf[..]);
     }
 
     /// Deallocate the right part of an extent


### PR DESCRIPTION
* If a deallocation started at a record boundary and continued for less
  than a full record, it would not actually be deallocated.
* If an operation tried to deallocate a sparse region of a partial
  extent, it would trigger a out-of-bounds array access and crash.

Also, when deallocating from an extent on the right side of the deallocation region, if the entire thing will be deallocated, remove the extent entirely instead of writing zeros.