### PR TITLE
Update rstest to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,15 +1587,28 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.11.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -63,7 +63,7 @@ permutohedron = "0.2"
 pretty_assertions = "1.3"
 rand = "0.8"
 rand_xorshift = "0.3"
-rstest = "0.11.0"
+rstest = "0.16.0"
 rstest_reuse = "0.2.0"
 tempfile = "3.2"
 tokio = { version = "1.23.1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -52,7 +52,7 @@ mockall = "0.11.0"
 nix = { version = "0.26.1", default-features = false, features = ["mount", "process", "signal", "user"] }
 predicates = "2.1.0"
 regex = "1.0"
-rstest = "0.11.0"
+rstest = "0.16.0"
 sysctl = "0.1"
 tempfile = "3.2"
 


### PR DESCRIPTION
Because the old version contains deprecated
semicolon-in-expression-position syntax.