### PR TITLE
Make credit underflows into non-fatal errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Where `OPTIONS` can be:
   an in-kernel file system bfffsd will never shrink the cache in response to
   memory pressure.  The kernel will simply kill bfffsd or some other process
   instead.
-* `writeback_size` - Set the maximum amount of cached dirty data in bytes.
-  This is completely independent of `cache_size`.  Generally it should be at
-  least several seconds' worth of your disks' maximum throughput.
+* `writeback_size` - Set the soft limit for the amount of cached dirty data in
+  bytes.  This is completely independent of `cache_size`.  Generally it should
+  be at least several seconds' worth of your disks' maximum throughput.  The
+  actual amount of dirty data may exceed this limit, but not by more than a few
+  MB.
 
 # License
 BFFFS is primarily distributed under the terms of both the MIT license

--- a/bfffs-core/src/database/database.rs
+++ b/bfffs-core/src/database/database.rs
@@ -794,7 +794,7 @@ impl Database {
     }
     // LCOV_EXCL_STOP
 
-    /// Get the maximum size of the writeback cache
+    /// Get the soft limit for the size of the writeback cache
     pub fn writeback_size(&self) -> usize {
         self.inner.idml.writeback_size()
     }

--- a/bfffs-core/src/fs_tree.rs
+++ b/bfffs-core/src/fs_tree.rs
@@ -354,14 +354,6 @@ impl Dirent {
     pub fn allocated_space(&self) -> usize {
         self.name.len()
     }
-
-    pub const fn max_allocated_space() -> usize {
-        // XXX BUG BFFFS doesn't internally impose any limit on the length of
-        // name, so it isn't really possible to guarantee a max allocated length
-        // limit.
-        256
-    }
-
 }
 
 impl HTItem for Dirent {
@@ -454,13 +446,6 @@ impl InlineExtAttr {
         self.extent.len()
     }
 
-    pub const fn max_allocated_space() -> usize {
-        // XXX BUG: there isn't anything within bfffs that limits the length of
-        // Name.  So it isn't really possible to guarantee a firm upper bound
-        // here.
-        256 + InlineExtent::max_allocated_space()
-    }
-
     pub fn needs_flush(&self) -> bool {
         self.len() > BLOB_THRESHOLD
     }
@@ -481,15 +466,16 @@ pub enum ExtAttr {
 }
 
 impl<'a> ExtAttr {
-    const FUDGE: usize = 64;    // Experimentally determined
 
     pub fn allocated_space(&self) -> usize {
+        const FUDGE: usize = 64;    // Experimentally determined
+
         match self {
             ExtAttr::Blob(blob_extattr) => blob_extattr.name.len(),
             ExtAttr::Inline(inline_extattr) =>
                 inline_extattr.name.len() +
                 inline_extattr.extent.len() +
-                Self::FUDGE
+                FUDGE
         }
     }
 
@@ -533,10 +519,6 @@ impl<'a> ExtAttr {
                 (k, FSValue::ExtAttr(ExtAttr::Blob(bea)))
             ).boxed()
         }
-    }
-
-    pub const fn max_allocated_space() -> usize {
-        InlineExtAttr::max_allocated_space() + Self::FUDGE
     }
 
     pub fn name(&'a self) -> &'a OsStr {
@@ -828,10 +810,6 @@ impl InlineExtent {
         self.buf.len()
     }
 
-    pub const fn max_allocated_space() -> usize {
-        BLOB_THRESHOLD + Self::FUDGE
-    }
-
     pub fn needs_flush(&self) -> bool {
         self.len() > BLOB_THRESHOLD
     }
@@ -1086,17 +1064,10 @@ impl TypicalSize for FSValue {
 impl Value for FSValue {
     const NEEDS_FLUSH: bool = true;
 
-    const MAX_ALLOCATED_SPACE: usize =
-        Dirent::max_allocated_space().max(
-            InlineExtent::max_allocated_space()).max(
-            mem::size_of::<Inode>()).max(
-            ExtAttr::max_allocated_space())
-            // XXX BUG: there is no limit to the size of a hash bucket, so we
-            // can't guarantee any particular limit to allocated space for
-            // ExtAttrs and DirEntries values.
-            /*.max(
-            FSValue::ExtAttrs::max_allocated_space()).max(
-            FSValue::DirEntries::max_allocated_space())*/;
+    // The most allocated space possible under normal circumstances is that used
+    // by a full InlineExtent.  Theoretically, though, more could be used for
+    // example by an ExtAttr hash bucket.
+    const MAX_ALLOCATED_SPACE: usize = BLOB_THRESHOLD + InlineExtent::FUDGE;
 
     fn allocated_space(&self) -> usize {
         match self {

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -313,7 +313,8 @@ impl<'a> IDML {
     ///
     /// * `ddml`:           An already-opened `DDML`
     /// * `cache`:          An already-constrcuted `Cache`
-    /// * `writeback_size`: Maximum amount of cached dirty data in bytes.
+    /// * `writeback_size`: Soft limit for the amount of cached dirty data in
+    ///                     bytes.
     /// * `label_reader`:   A `LabelReader` that has already consumed all labels
     ///                     prior to this layer.
     pub fn open(
@@ -478,7 +479,7 @@ impl<'a> IDML {
         self.ddml.write_label(labeller)
     }
 
-    /// Get the maximum size of bytes in the writeback cache
+    /// Get the soft limit for the bytes in the writeback cache
     pub fn writeback_size(&self) -> usize {
         self.writeback.capacity()
     }

--- a/bfffs-core/src/lib.rs
+++ b/bfffs-core/src/lib.rs
@@ -1,6 +1,8 @@
 // vim: tw=80
 
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
+#![feature(const_cmp)]
+#![feature(const_trait_impl)]
 
 // Disable the range_plus_one lint until this bug is fixed.  It generates many
 // false positive in the Tree code.

--- a/bfffs-core/src/lib.rs
+++ b/bfffs-core/src/lib.rs
@@ -1,8 +1,6 @@
 // vim: tw=80
 
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
-#![feature(const_cmp)]
-#![feature(const_trait_impl)]
 
 // Disable the range_plus_one lint until this bug is fixed.  It generates many
 // false positive in the Tree code.

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -107,6 +107,9 @@ pub trait Value: Clone + Debug + DeserializeOwned + PartialEq + Send + Sync +
     /// Does this Value type require flushing?
     const NEEDS_FLUSH: bool = false;
 
+    /// What is the maximum value that V::allocated_space() should ever return ?
+    const MAX_ALLOCATED_SPACE: usize = 0;
+
     /// How much allocated space does this object own, excluding the object
     /// itself?
     fn allocated_space(&self) -> usize {

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -107,7 +107,8 @@ pub trait Value: Clone + Debug + DeserializeOwned + PartialEq + Send + Sync +
     /// Does this Value type require flushing?
     const NEEDS_FLUSH: bool = false;
 
-    /// What is the maximum value that V::allocated_space() should ever return ?
+    /// What is the maximum value that V::allocated_space() is likely to return?
+    /// In extreme cases it is allowed to return more.
     const MAX_ALLOCATED_SPACE: usize = 0;
 
     /// How much allocated space does this object own, excluding the object

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -2255,8 +2255,6 @@ impl<A, D, K, V> Tree<A, D, K, V>
 
     /// Lock the root `IntElem` exclusively.  If it is not already resident in
     /// memory, then COW it.
-    // Ignore credit.  The root will rarely be a Leaf, and if it is then we
-    // shouldn't be worried about memory consumption anyway.
     fn xlock_root(
         dml: &Arc<D>,
         mut guard: RwLockWriteGuard<TreeRoot<A, K, V>>,

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -712,10 +712,8 @@ impl<A, D, K, V> Tree<A, D, K, V>
     ///
     /// The returned structure may vary from Tree-to-Tree, but will never vary
     /// within the lifetime of a given Tree.
-    // XXX BUG does not account for the memory requirements of values
-    // themselves, such as in FSValue::allocated_space.
     pub fn credit_requirements(&self) -> CreditRequirements {
-        let kvs = mem::size_of::<(K, V)>();
+        let kvs = mem::size_of::<(K, V)>() + V::MAX_ALLOCATED_SPACE;
         let x = usize::from(self.limits.max_leaf_fanout()) * kvs;
         CreditRequirements {
             insert: 2 * x,

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -712,6 +712,8 @@ impl<A, D, K, V> Tree<A, D, K, V>
     ///
     /// The returned structure may vary from Tree-to-Tree, but will never vary
     /// within the lifetime of a given Tree.
+    // XXX BUG does not account for the memory requirements of values
+    // themselves, such as in FSValue::allocated_space.
     pub fn credit_requirements(&self) -> CreditRequirements {
         let kvs = mem::size_of::<(K, V)>();
         let x = usize::from(self.limits.max_leaf_fanout()) * kvs;

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -407,8 +407,8 @@ root:
 "#);
 }
 
-/// The caller does not supply enough credit.
-#[should_panic(expected = "insufficient credit was provided")]
+/// The caller does not supply enough credit.  This should work, but log a
+/// warning.
 #[test]
 fn insert_insufficient_credit() {
     let mock = mock_dml();

--- a/bfffs-core/src/writeback/writeback.rs
+++ b/bfffs-core/src/writeback/writeback.rs
@@ -12,7 +12,7 @@ use std::{
     cmp::Ordering,
     collections::VecDeque,
     mem,
-    ops::Add,
+    ops::{Add, Sub},
     pin::Pin,
     sync::{
         Mutex,
@@ -105,6 +105,16 @@ impl Add<usize> for &mut Credit {
 
     fn add(self, other: usize) -> Self::Output {
         (*self.0.get_mut() >> 1) + other
+    }
+}
+
+// Doesn't actually mutate Self, but needs mutable access to avoid atomic
+// instructions.
+impl Sub<usize> for &mut Credit {
+    type Output = usize;
+
+    fn sub(self, other: usize) -> Self::Output {
+        (*self.0.get_mut() >> 1) - other
     }
 }
 

--- a/bfffs-core/src/writeback/writeback.rs
+++ b/bfffs-core/src/writeback/writeback.rs
@@ -16,7 +16,7 @@ use std::{
     pin::Pin,
     sync::{
         Mutex,
-        atomic::{AtomicIsize, AtomicUsize, Ordering::*}
+        atomic::{AtomicIsize, Ordering::*}
     }
 };
 #[cfg(test)]
@@ -29,7 +29,7 @@ use std::fmt::Debug;
 #[derive(Debug)]
 #[derive(Serialize)]
 #[cfg_attr(test, derive(Deserialize))]
-pub struct Credit(AtomicUsize);
+pub struct Credit(AtomicIsize);
 
 impl Credit {
     /// Like [`split`], but slower since it uses atomic instructions.  Does not
@@ -38,11 +38,12 @@ impl Credit {
     pub fn atomic_split(&self, credit: usize) -> Credit {
         // Saturate the subtraction, because we don't want any credit to ever be
         // negative.
+        let icredit = isize::try_from(credit).unwrap();
         let old = self.0.fetch_update(Relaxed, Relaxed, |old| {
-            let new = old.saturating_sub(credit << 1usize);
+            let new = (old - (icredit << 1usize)).max(0);
             Some(new)
         }).unwrap();
-        Credit(AtomicUsize::new((credit << 1).min(old)))
+        Credit(AtomicIsize::new((icredit << 1).min(old)))
     }
 
     pub fn extend(&mut self, mut other: Credit) {
@@ -54,15 +55,15 @@ impl Credit {
     ///
     /// For use in unit tests only!
     #[cfg(test)]
-    pub fn forge(size: usize) -> Credit {
-        Credit(AtomicUsize::new(size << 1usize))
+    pub fn forge(size: isize) -> Credit {
+        Credit(AtomicIsize::new(size << 1usize))
     }
 
     /// Split this Credit into two nearly equal pieces
     #[must_use]
     pub fn halve(&mut self) -> Credit {
         let old = *self.0.get_mut();
-        self.split(old >> 2)
+        self.isplit(old >> 2)
     }
 
     pub fn is_null(&self) -> bool {
@@ -75,7 +76,7 @@ impl Credit {
     // real `Credit`.  Using this instead of `Option<Credit>` lets the `Tree`
     // be more generic.
     pub fn null() -> Self {
-        Credit(AtomicUsize::new(0))
+        Credit(AtomicIsize::new(0))
     }
 
     #[must_use]
@@ -83,9 +84,19 @@ impl Credit {
         // Saturate the subtraction, because we don't want any credit to ever be
         // negative.
         let old = *self.0.get_mut();
-        let new = old.saturating_sub(credit << 1usize);
-        self.0 = AtomicUsize::new(new);
-        Credit(AtomicUsize::new(old - new))
+        let icredit = isize::try_from(credit).unwrap();
+        self.isplit(icredit.min(old >> 1))
+    }
+
+    /// Signed split.  Split self into `credit` and the remainder, returning
+    /// `credit` with `remainder` in self.  If insufficient credit is available,
+    /// self will go negative.
+    #[must_use]
+    pub fn isplit(&mut self, credit: isize) -> Credit {
+        let old = *self.0.get_mut();
+        let new = old - (credit << 1usize);
+        self.0 = AtomicIsize::new(new);
+        Credit(AtomicIsize::new(old - new))
     }
 
     /// Takes all of this `Credit`'s credit out into a new `Credit`.
@@ -94,27 +105,29 @@ impl Credit {
     #[must_use]
     pub fn take(&mut self) -> Credit {
         let old = *self.0.get_mut();
-        self.split(old >> 1)
+        self.isplit(old >> 1)
     }
 }
 
 // Doesn't actually mutate Self, but needs mutable access to avoid atomic
 // instructions.
 impl Add<usize> for &mut Credit {
-    type Output = usize;
+    type Output = isize;
 
     fn add(self, other: usize) -> Self::Output {
-        (*self.0.get_mut() >> 1) + other
+        let iother = isize::try_from(other).unwrap();
+        (*self.0.get_mut() >> 1) + iother
     }
 }
 
 // Doesn't actually mutate Self, but needs mutable access to avoid atomic
 // instructions.
 impl Sub<usize> for &mut Credit {
-    type Output = usize;
+    type Output = isize;
 
     fn sub(self, other: usize) -> Self::Output {
-        (*self.0.get_mut() >> 1) - other
+        let iother = isize::try_from(other).unwrap();
+        (*self.0.get_mut() >> 1) - iother
     }
 }
 
@@ -134,13 +147,23 @@ impl Drop for Credit {
 impl PartialEq<usize> for Credit {
     /// Is this credit correct for `other` bytes' worth of data?
     fn eq(&self, other: &usize) -> bool {
+        let iother = isize::try_from(*other).unwrap();
+        (self.0.load(Relaxed) >> 1) == iother
+    }
+}
+
+#[cfg(test)]
+impl PartialEq<isize> for Credit {
+    /// Is this credit correct for `other` bytes' worth of data?
+    fn eq(&self, other: &isize) -> bool {
         (self.0.load(Relaxed) >> 1) == *other
     }
 }
 
 impl PartialOrd<usize> for Credit {
     fn partial_cmp(&self, other: &usize) -> Option<Ordering> {
-        Some((self.0.load(Relaxed) >> 1).cmp(other))
+        let iother = isize::try_from(*other).unwrap();
+        Some((self.0.load(Relaxed) >> 1).cmp(&iother))
     }
 }
 
@@ -197,7 +220,7 @@ impl WriteBack {
     {
         let wants = size << 1;
         debug_assert!(self.capacity >= wants.try_into().unwrap());
-        let iwants = wants as isize;
+        let iwants = isize::try_from(wants).unwrap();
 
         loop {
             // NB: To be strictly correct, we ought to use Acquire here in order
@@ -229,11 +252,11 @@ impl WriteBack {
                     let sleeper = Sleeper { tx, wants: iwants };
                     guard.push_back(sleeper);
                     self.supply.fetch_or(1, Release);
-                    break rx.map(move |_| Credit(AtomicUsize::new(wants)))
+                    break rx.map(move |_| Credit(AtomicIsize::new(iwants)))
                         .boxed();
                 }
             } else {
-                break future::ready(Credit(AtomicUsize::new(wants))).boxed();
+                break future::ready(Credit(AtomicIsize::new(iwants))).boxed();
             }
         }
     }
@@ -253,7 +276,7 @@ impl WriteBack {
             // Short-circuit this common case
             return;
         }
-        let iwants = *credit.0.get_mut() as isize;
+        let iwants = *credit.0.get_mut();
         let old_supply = self.supply.fetch_add(iwants, Acquire);
         debug_assert!(self.capacity >= (old_supply & !0x1) + iwants);
 
@@ -288,7 +311,7 @@ fn debug() {
     format!("{wb:?}");
 }
 
-/// A borrow must sleep, but abandon his loan application (drops his future)
+/// A borrower must sleep, but abandons his loan application (drops his future)
 /// before being awakened.  This might happen in production if we ever support
 /// I/O cancellation.
 #[test]
@@ -472,6 +495,49 @@ fn split_saturate() {
     assert_eq!(credit1.0.load(Relaxed), 20);
     writeback.repay(credit0);
     writeback.repay(credit1);
+    assert_eq!(writeback.supply.load(Relaxed), writeback.capacity)
+}
+
+/// It should be possible to split off negative credit.
+#[test]
+fn isplit_negative() {
+    let writeback = WriteBack::with_capacity(10);
+    let mut credit0 = writeback.borrow(10).now_or_never().unwrap();
+    let credit1 = credit0.isplit(-1);
+    assert_eq!(credit1.0.load(Relaxed), -2);
+    assert_eq!(credit0.0.load(Relaxed), 22);
+    // Note: negative credits must be repayed first
+    writeback.repay(credit1);
+    writeback.repay(credit0);
+    assert_eq!(writeback.supply.load(Relaxed), writeback.capacity)
+}
+
+/// Withdraw too much credit, leaving the original negative
+#[test]
+fn isplit_overdraft() {
+    let writeback = WriteBack::with_capacity(10);
+    let mut credit0 = writeback.borrow(10).now_or_never().unwrap();
+    let credit1 = credit0.isplit(11);
+    assert_eq!(credit1.0.load(Relaxed), 22);
+    assert_eq!(credit0.0.load(Relaxed), -2);
+    writeback.repay(credit0);
+    writeback.repay(credit1);
+    assert_eq!(writeback.supply.load(Relaxed), writeback.capacity)
+}
+
+/// It should be possible to repeatedly overdraft
+#[test]
+fn isplit_overdraft_again() {
+    let writeback = WriteBack::with_capacity(10);
+    let mut credit0 = writeback.borrow(10).now_or_never().unwrap();
+    let credit1 = credit0.isplit(11);
+    let credit2 = credit0.isplit(11);
+    assert_eq!(credit1.0.load(Relaxed), 22);
+    assert_eq!(credit2.0.load(Relaxed), 22);
+    assert_eq!(credit0.0.load(Relaxed), -24);
+    writeback.repay(credit0);
+    writeback.repay(credit1);
+    writeback.repay(credit2);
     assert_eq!(writeback.supply.load(Relaxed), writeback.capacity)
 }
 


### PR DESCRIPTION
And fix credit underflows caused by large numbers of files < 1 kB in size.