### PR TITLE
Fix "bfffs fs list -o name" for a dataset that does not exist

### DIFF
--- a/bfffs-core/src/controller.rs
+++ b/bfffs-core/src/controller.rs
@@ -139,10 +139,6 @@ impl Controller {
     pub async fn get_prop(&self, dataset: String, propname: PropertyName)
         -> Result<(Property, PropertySource)>
     {
-        if propname == PropertyName::Name {
-            // Hard-code this pseudoproperty
-            return Ok((Property::Name(dataset), PropertySource::None));
-        }
         let dsname = self.strip_pool_name(&dataset)?;
         let guard = self.filesystems.read().await;
         match self.db.lookup_fs(dsname).await? {
@@ -165,6 +161,12 @@ impl Controller {
         -> Result<(Property, PropertySource)>
         where T: Deref<Target = BTreeMap<TreeID, Weak<Fs>>>
     {
+        if propname == PropertyName::Name {
+            // Hard-code this pseudoproperty
+            return Ok((Property::Name(dataset.to_owned()),
+                       PropertySource::None));
+        }
+
         let inheritable_propname = propname.inheritable();
         if let Some(fs) = guard.get(&tree_id).and_then(Weak::upgrade) {
             fs.get_prop(inheritable_propname).await

--- a/bfffs-core/tests/functional/controller.rs
+++ b/bfffs-core/tests/functional/controller.rs
@@ -134,6 +134,17 @@ mod get_prop {
         );
     }
 
+    /// Try to lookup the Name property for a dataset that does not exist.
+    #[rstest]
+    #[tokio::test]
+    async fn enoent_name(harness: Harness) {
+        let dsname = String::from("TestPool/foo");
+        assert_eq!(
+            Err(Error::ENOENT),
+            harness.0.get_prop(dsname, PropertyName::Name).await
+        );
+    }
+
     #[template]
     #[rstest(propname,
         case(PropertyName::Atime),

--- a/bfffs/tests/integration/bfffs/fs/list.rs
+++ b/bfffs/tests/integration/bfffs/fs/list.rs
@@ -109,6 +109,19 @@ async fn depth() {
         );
 }
 
+#[rstest]
+#[tokio::test]
+async fn enoent() {
+    let h = harness::<&'static str>(&[]);
+    bfffs()
+        .arg("--sock")
+        .arg(h.sockpath.as_os_str())
+        .args(["fs", "list", "-o", "name", "mypoolx"])
+        .assert()
+        .failure()
+        .stderr("Error: ENOENT\n");
+}
+
 #[test]
 fn help() {
     bfffs().args(["fs", "list", "-h"]).assert().success();


### PR DESCRIPTION
No information from the Database is required to determine a dataset's name property.  However, we should still check for the dataset's existence.  Otherwise, "bfffs fs list -o name XXX" will make it look like the XXX dataset exists, even if it does not.