### PR TITLE
Delay the erase and reuse of freed zones

### DIFF
--- a/bfffs-core/src/ddml/ddml.rs
+++ b/bfffs-core/src/ddml/ddml.rs
@@ -47,6 +47,13 @@ pub struct DDML {
 // instead by integration tests.
 #[cfg_attr(test, allow(unused))]
 impl DDML {
+    /// Cleanup stuff from the previous transaction.
+    pub fn advance_transaction(&self, txg: TxgT)
+        -> impl Future<Output=Result<()>> + Send + Sync
+    {
+        self.pool.advance_transaction(txg)
+    }
+
     /// Assert that the given zone was clean as of the given transaction
     #[cfg(debug_assertions)]
     pub fn assert_clean_zone(&self, cluster: ClusterT, zone: ZoneT, txg: TxgT) {
@@ -362,6 +369,7 @@ impl DML for DDML {
 #[cfg(test)]
 mock! {
     pub DDML {
+        pub fn advance_transaction(&self, txg: TxgT) -> BoxVdevFut;
         pub fn assert_clean_zone(&self, cluster: ClusterT, zone: ZoneT, txg: TxgT);
         pub fn delete_direct(&self, drp: &DRP, txg: TxgT) -> BoxVdevFut;
         pub fn flush(&self, idx: u32) -> BoxVdevFut;

--- a/bfffs-core/src/device_manager.rs
+++ b/bfffs-core/src/device_manager.rs
@@ -216,7 +216,7 @@ impl DevManager {
 
     /// Set the maximum amount of dirty cached data, in bytes.
     ///
-    /// This is independent of [`cache_size`].
+    /// This is independent of [`self.cache_size`].
     pub fn writeback_size(&mut self, writeback_size: usize) {
         self.writeback_size = Some(writeback_size);
     }

--- a/bfffs-core/src/dml.rs
+++ b/bfffs-core/src/dml.rs
@@ -115,7 +115,7 @@ pub trait DML: Send + Sync {
                              txg: TxgT)
         -> Pin<Box<dyn Future<Output=Result<<Self as DML>::Addr>> + Send>>;
 
-    /// Repay [`WriteBack`] [`Credit`]
+    /// Repay [`Credit`] to [`WriteBack`](crate::writeback::WriteBack)
     fn repay(&self, credit: Credit);
 
     /// Sync all records written so far to stable storage.

--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -2018,7 +2018,7 @@ impl Fs {
     /// # Arguments
     ///
     /// - `parent`:     `FileData` of the parent directory, as returned by
-    ///                 [`lookup`].
+    ///                 [`Fs::lookup`].
     /// - `fd`:         `FileData` of the directory entry to be moved, if
     ///                 known.  Must be provided if the file has been looked up!
     /// - `name`:       Name of the directory entry to move.
@@ -2200,7 +2200,7 @@ impl Fs {
     /// Remove a directory entry for a directory
     ///
     /// - `parent_fd`:  `FileData` of the parent directory, as returned by
-    ///                 [`lookup`].
+    ///                 [`Fs::lookup`].
     /// - `name`:       Name of the directory entry to remove.
     // Note, unlike unlink, rmdir takes no Option<&FileData> argument, because
     // there is no need to support open-but-deleted directories.
@@ -2388,7 +2388,7 @@ impl Fs {
     /// Remove a directory entry for a non-directory
     ///
     /// - `parent_fd`:  `FileData` of the parent directory, as returned by
-    ///                 [`lookup`].
+    ///                 [`Fs::lookup`].
     /// - `fd`:         `FileData` of the directory entry to be removed, if
     ///                 known.  Must be provided if the file has been looked up!
     /// - `name`:       Name of the directory entry to remove.

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -153,7 +153,7 @@ pub trait Value: Clone + Debug + DeserializeOwned + PartialEq + Send + Sync +
     }
 
     /// Drop a reference to the on-disk data, and read it into `self`, like the
-    /// opposite of [`flush`].
+    /// opposite of a `flush` method.
     fn dpop<D>(self, _dml: &D, _txg: TxgT)
         -> Pin<Box<dyn Future<Output=Result<Self>> + Send>>
         where D: DML + 'static, D::Addr: 'static
@@ -448,9 +448,8 @@ impl<K: Key, V: Value> LeafData<K, V> {
         }
     }
 
-    /// Like [`range_delete`], but for nodes that may be dirty yet unaccredited.
-    // XXX This causes a huge quantity of duplicate cache insertions.
-    // https://github.com/bfffs/bfffs/issues/198
+    /// Like [`range_delete`](Self::range_delete), but for nodes that may be
+    /// dirty yet unaccredited.
     #[tracing::instrument(skip(self, dml, range))]
     pub fn range_delete_unaccredited<D, R, T>(
         &mut self,

--- a/bfffs-core/src/writeback/writeback.rs
+++ b/bfffs-core/src/writeback/writeback.rs
@@ -32,8 +32,8 @@ use std::fmt::Debug;
 pub struct Credit(AtomicIsize);
 
 impl Credit {
-    /// Like [`split`], but slower since it uses atomic instructions.  Does not
-    /// require mutable access.
+    /// Like [`split`](Self::split), but slower since it uses atomic
+    /// instructions.  Does not require mutable access.
     #[must_use]
     pub fn atomic_split(&self, credit: usize) -> Credit {
         // Saturate the subtraction, because we don't want any credit to ever be


### PR DESCRIPTION
    After freeing the last lba from a zone, it must not be erased or reused
    until after the start of the next transaction, so the file system may be
    rolled back if it crashes before the next transaction sync.
    
    Instead, mark such zones as "dead", and erase them at the end of the
    current transaction.
    
    Fixes #261