### PR TITLE
Fix Database::check with dirty trees

### DIFF
--- a/bfffs-core/tests/functional/database.rs
+++ b/bfffs-core/tests/functional/database.rs
@@ -210,6 +210,18 @@ root:
         db.fsread(tree_id, |_| future::ok(())).await.unwrap();
     }
 
+    mod check {
+        use super::*;
+
+        /// A newly created Database with a single file system should check
+        /// successfully.
+        #[tokio::test]
+        async fn empty() {
+            let (db, _tempdir, _first_tree_id, _paths) = harness().await;
+            assert!(db.check().await.unwrap());
+        }
+    }
+
     mod create_fs {
         use super::*;
 


### PR DESCRIPTION
It always worked for a pool where everything was clean.  But if any Tree was dirty, the operation would fail with ENOENT.

The problem was that the Forest stores the serialized head of each tree, _even_ if that tree is dirty.  But if dirty, then its root node won't actually be on disk.  That is, when a Tree is dirty, the Forest stores an out-of-date head.  That's by-design; the database isn't supposed to access the Forest for dirty trees.  But the Database's check method did anyway.  Fix the bug in Database::check.