### PR TITLE
Update blosc to 0.2.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,9 @@ task:
     - . $HOME/.cargo/env
     - cargo +$VERSION test $CARGO_ARGS --all --all-targets
   fio_script:
-    - if [ `fio --version | sed 's:fio-3.::'` -ge 30 ]; then
+    # Temporarily restrict the fio job to fio-3.34.0, due to bug
+    # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271927
+    - if [ `fio --version | sed 's:fio-3.::'` -eq 34 ]; then
     -   . $HOME/.cargo/env
     -   truncate -s 1g /tmp/bfffs.img
     -   cargo +$VERSION run $CARGO_ARGS --bin bfffs -- pool create testpool /tmp/bfffs.img

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blosc"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa4be3ff6a15133256bcb58bdc8fefd074aebece453605386646bb96db0dc57"
+checksum = "e35aa1ac22858b0fa4f4e74d96c84d93b86a27093989a3f2b812b00ff7c6d2fe"
 dependencies = [
  "blosc-sys",
  "libc",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "blosc-sys"
-version = "1.14.4"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb47d18e3b7382569d8ee19671514a1633b9ddcfbd8b87d4708bdf5c0a90bc8"
+checksum = "76569aca625203c979c5c37343cdfdf4d2f9f4fd5f6a4eb89b68e7f2549d37e9"
 
 [[package]]
 name = "bstr"

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -15,7 +15,7 @@ nightly = [ "mockall/nightly" ]
 async-trait = "0.1.40"
 bincode = { version = "1.0.1", features = ["i128"] }
 bitfield = "0.13.1"
-blosc = "0.1.3"
+blosc = "0.2.0"
 byteorder = "1.2.3"
 cfg-if = "1.0"
 divbuf = { git = "https://github.com/asomers/divbuf.git", rev = "0a72fb5"}

--- a/bfffs-core/src/fs_tree.rs
+++ b/bfffs-core/src/fs_tree.rs
@@ -134,7 +134,7 @@ impl ObjKey {
         // SAFETY: Because `Self` is marked `repr(u8)`, its layout is a `repr(C)` `union`
         // between `repr(C)` structs, each of which has the `u8` discriminant as its first
         // field, so we can read the discriminant without offsetting the pointer.
-        unsafe { *<*const _>::from(self).cast::<u8>() }
+        unsafe { *<*const ObjKey>::from(self).cast::<u8>() }
     }
 
     pub fn offset(&self) -> u64 {


### PR DESCRIPTION
Not because we need it so much as to exercise the new blosc release.