### PR TITLE
Import disks more reliably

### DIFF
--- a/bfffs-core/src/mirror.rs
+++ b/bfffs-core/src/mirror.rs
@@ -100,7 +100,14 @@ impl Manager {
 #[derive(Clone, Debug)]
 pub struct Status {
     /// Paths to each leaf
-    pub leaves: Vec<(PathBuf, Uuid)>
+    pub leaves: Vec<(PathBuf, Uuid)>,
+    pub uuid: Uuid
+}
+
+impl Status {
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
 }
 
 /// `Mirror`: Device mirroring, both permanent and temporary
@@ -302,6 +309,7 @@ impl Mirror {
             leaves: self.blockdevs.iter()
                 .map(|vb| (vb.path(), vb.uuid()))
                 .collect::<Vec<_>>(),
+            uuid: self.uuid()
         }
     }
 

--- a/bfffs-core/src/raid/vdev_raid/tests.rs
+++ b/bfffs-core/src/raid/vdev_raid/tests.rs
@@ -71,11 +71,11 @@ fn stripe_buffer_one_iovec() {
     {
         let sglist = sb.peek();
         assert_eq!(sglist.len(), 1);
-        assert_eq!(&sglist[0][..], &vec![0; 4096][..]);
+        assert_eq!(&sglist[0][..], &[0; 4096][..]);
     }
     let sglist = sb.pop();
     assert_eq!(sglist.len(), 1);
-    assert_eq!(&sglist[0][..], &vec![0; 4096][..]);
+    assert_eq!(&sglist[0][..], &[0; 4096][..]);
 }
 
 // Pad a StripeBuffer that is larger than the ZERO_REGION
@@ -129,13 +129,13 @@ fn stripe_buffer_two_iovecs() {
     {
         let sglist = sb.peek();
         assert_eq!(sglist.len(), 2);
-        assert_eq!(&sglist[0][..], &vec![0; 8192][..]);
-        assert_eq!(&sglist[1][..], &vec![1; 4096][..]);
+        assert_eq!(&sglist[0][..], &[0; 8192][..]);
+        assert_eq!(&sglist[1][..], &[1; 4096][..]);
     }
     let sglist = sb.pop();
     assert_eq!(sglist.len(), 2);
-    assert_eq!(&sglist[0][..], &vec![0; 8192][..]);
-    assert_eq!(&sglist[1][..], &vec![1; 4096][..]);
+    assert_eq!(&sglist[0][..], &[0; 8192][..]);
+    assert_eq!(&sglist[1][..], &[1; 4096][..]);
 }
 
 #[test]
@@ -155,13 +155,13 @@ fn stripe_buffer_two_iovecs_overflow() {
     {
         let sglist = sb.peek();
         assert_eq!(sglist.len(), 2);
-        assert_eq!(&sglist[0][..], &vec![0; 16384][..]);
-        assert_eq!(&sglist[1][..], &vec![1; 8192][..]);
+        assert_eq!(&sglist[0][..], &[0; 16384][..]);
+        assert_eq!(&sglist[1][..], &[1; 8192][..]);
     }
     let sglist = sb.pop();
     assert_eq!(sglist.len(), 2);
-    assert_eq!(&sglist[0][..], &vec![0; 16384][..]);
-    assert_eq!(&sglist[1][..], &vec![1; 8192][..]);
+    assert_eq!(&sglist[0][..], &[0; 16384][..]);
+    assert_eq!(&sglist[1][..], &[1; 8192][..]);
 }
 
 // pet kcov

--- a/bfffs-core/src/util.rs
+++ b/bfffs-core/src/util.rs
@@ -196,7 +196,7 @@ fn test_div_roundup() {
 macro_rules! checksum_sglist_helper {
     ( $klass:ident) => {
         let together = [0u8, 1, 2, 3, 4, 5];
-        let apart = vec![vec![0u8, 1], vec![2u8, 3], vec![4u8, 5]];
+        let apart = [[0u8, 1], [2u8, 3], [4u8, 5]];
         let mut together_hasher = $klass::new();
         let mut apart_hasher = $klass::new();
         let mut single_hasher = $klass::new();

--- a/bfffs-core/src/vdev_file.rs
+++ b/bfffs-core/src/vdev_file.rs
@@ -255,10 +255,14 @@ impl VdevFile {
         where P: AsRef<Path>
     {
         let pb = path.as_ref().to_path_buf();
+        // NB: Annoyingly, using O_EXLOCK without O_NONBLOCK means that we can
+        // block indefinitely.  However, using O_NONBLOCK is worse because it
+        // can cause spurious failures, such as when another thread fork()s.
+        // That happens frequently in the functional tests.
         let f = OpenOptions::new()
             .read(true)
             .write(true)
-            .custom_flags(libc::O_DIRECT)
+            .custom_flags(libc::O_DIRECT | libc::O_EXLOCK)
             .open(path)
             .map(File::new)?;
         let lpz = match lbas_per_zone {
@@ -369,10 +373,14 @@ impl VdevFile {
         -> Result<(Self, LabelReader)>
     {
         let pb = path.as_ref().to_path_buf();
+        // NB: Annoyingly, using O_EXLOCK without O_NONBLOCK means that we can
+        // block indefinitely.  However, using O_NONBLOCK is worse because it
+        // can cause spurious failures, such as when another thread fork()s.
+        // That happens frequently in the functional tests.
         let file = OpenOptions::new()
             .read(true)
             .write(true)
-            .custom_flags(libc::O_DIRECT)
+            .custom_flags(libc::O_DIRECT | libc::O_EXLOCK)
             .open(path)
             .map(File::new)
             .map_err(|e| Error::from_i32(e.raw_os_error().unwrap()).unwrap());

--- a/bfffs-core/tests/functional/clean_zone.rs
+++ b/bfffs-core/tests/functional/clean_zone.rs
@@ -17,7 +17,7 @@ use std::{
 type Harness = (Arc<Database>, Fs);
 
 async fn harness(devsize: u64, zone_size: u64) -> Harness {
-    let (_tempdir, _paths, pool) = crate::PoolBuilder::new()
+    let ph = crate::PoolBuilder::new()
         .fsize(devsize)
         .zone_size(zone_size)
         .build();
@@ -26,7 +26,7 @@ async fn harness(devsize: u64, zone_size: u64) -> Harness {
             Cache::with_capacity(32_000_000)
         )
     );
-    let ddml = Arc::new(DDML::new(pool, cache.clone()));
+    let ddml = Arc::new(DDML::new(ph.pool, cache.clone()));
     let idml = IDML::create(ddml, cache);
     let db = Arc::new(Database::create(Arc::new(idml)));
     let tree_id = db.create_fs(None, "").await.unwrap();

--- a/bfffs-core/tests/functional/cluster.rs
+++ b/bfffs-core/tests/functional/cluster.rs
@@ -95,6 +95,7 @@ mod persistence {
             f.write_all(&GOLDEN_LABEL).unwrap();
             f.seek(SeekFrom::Start(32768)).unwrap();
             f.write_all(&GOLDEN_SPACEMAP).unwrap();
+            drop(objects.0);
         }
         let mut manager = Manager::default();
         manager.taste(objects.2).await.unwrap();

--- a/bfffs-core/tests/functional/controller.rs
+++ b/bfffs-core/tests/functional/controller.rs
@@ -23,16 +23,16 @@ type Harness = (Controller,);
 #[fixture]
 fn harness() -> Harness {
     let len = 1 << 26;  // 64 MB
-    let (tempdir, _, pool) = crate::PoolBuilder::new()
+    let ph = crate::PoolBuilder::new()
         .name(POOLNAME)
         .build();
-    let filename = tempdir.path().join("vdev");
+    let filename = ph.tempdir.path().join("vdev");
     {
         let file = fs::File::create(filename).unwrap();
         file.set_len(len).unwrap();
     }
     let cache = Arc::new(Mutex::new(Cache::with_capacity(1_000_000)));
-    let ddml = Arc::new(DDML::new(pool, cache.clone()));
+    let ddml = Arc::new(DDML::new(ph.pool, cache.clone()));
     let idml = IDML::create(ddml, cache);
     let db = Database::create(Arc::new(idml));
     (Controller::new(db),)

--- a/bfffs-core/tests/functional/database.rs
+++ b/bfffs-core/tests/functional/database.rs
@@ -769,9 +769,9 @@ mod manager {
         // importable_pools should still work
         let (name, uuid) = h.manager.importable_pools().pop().unwrap();
         assert_eq!(name, "functional_test_pool");
-        // But actually importing them should not
-        let e = h.manager.import_by_uuid(uuid).await.err().unwrap();
-        assert_eq!(e, Error::ENOENT);
+        // But actually importing them should not.  The precise error code
+        // depends on the test circumstances; we won't assert on it.
+        h.manager.import_by_uuid(uuid).await.err().unwrap();
     }
 
     /// Fail to import a nonexistent pool by UUID

--- a/bfffs-core/tests/functional/database.rs
+++ b/bfffs-core/tests/functional/database.rs
@@ -619,7 +619,6 @@ mod manager {
     use rstest::rstest;
     use rstest_reuse::{apply, template};
     use std::{
-        fs,
         path::PathBuf,
         sync::{Arc, Mutex}
     };

--- a/bfffs-core/tests/functional/database.rs
+++ b/bfffs-core/tests/functional/database.rs
@@ -188,7 +188,8 @@ root:
         // Sync the database, then drop and reopen it.  That's the only way to
         // clear Inner::fs_trees
         db.sync_transaction().await.unwrap();
-        drop(db);
+        db.shutdown().await;
+
         let db = open_db(&paths[0]).await;
         db.fsread(tree_id, |_| future::ok(())).await.unwrap();
     }
@@ -216,7 +217,8 @@ root:
             // Sync the database, then drop and reopen it.  That's the only way
             // to clear Inner::fs_trees
             db.sync_transaction().await.unwrap();
-            drop(db);
+            db.shutdown().await;
+
             let db = open_db(&paths[0]).await;
 
             let tree_id = db.create_fs(None, "").await.unwrap();

--- a/bfffs-core/tests/functional/ddml.rs
+++ b/bfffs-core/tests/functional/ddml.rs
@@ -19,11 +19,11 @@ mod ddml {
 
     #[fixture]
     fn ddml() -> DDML {
-        let (_tempdir, _paths, pool) = crate::PoolBuilder::new()
+        let ph = crate::PoolBuilder::new()
             .chunksize(1)
             .build();
         let cache = Cache::with_capacity(1_000_000_000);
-        DDML::new(pool, Arc::new(Mutex::new(cache)))
+        DDML::new(ph.pool, Arc::new(Mutex::new(cache)))
     }
 
     #[rstest]

--- a/bfffs-core/tests/functional/fs.rs
+++ b/bfffs-core/tests/functional/fs.rs
@@ -34,11 +34,11 @@ mod fs {
     }
 
     async fn harness(props: Vec<Property>) -> Harness {
-        let (_, _, pool) = crate::PoolBuilder::new()
+        let ph = crate::PoolBuilder::new()
             .build();
         let cache = Arc::new(Mutex::new(Cache::with_capacity(16_000_000)));
         let cache2 = cache.clone();
-        let ddml = Arc::new(DDML::new(pool, cache2.clone()));
+        let ddml = Arc::new(DDML::new(ph.pool, cache2.clone()));
         let idml = IDML::create(ddml, cache2);
         let db = Arc::new(Database::create(Arc::new(idml)));
         let tree_id = db.create_fs(None, "").await.unwrap();

--- a/bfffs-core/tests/functional/idml.rs
+++ b/bfffs-core/tests/functional/idml.rs
@@ -101,14 +101,14 @@ mod persistence {
 
     #[fixture]
     fn objects() -> (Arc<IDML>, TempDir, Vec<PathBuf>) {
-        let (tempdir, paths, pool) = crate::PoolBuilder::new()
+        let ph = crate::PoolBuilder::new()
             .chunksize(1)
             .name(POOLNAME)
             .build();
         let cache = Arc::new(Mutex::new(Cache::with_capacity(4_194_304)));
-        let ddml = Arc::new(DDML::new(pool, cache.clone()));
+        let ddml = Arc::new(DDML::new(ph.pool, cache.clone()));
         let idml = Arc::new(IDML::create(ddml, cache));
-        (idml, tempdir, paths)
+        (idml, ph.tempdir, ph.paths)
     }
 
     // Testing IDML::open with golden labels is too hard, because we need to
@@ -188,15 +188,15 @@ mod t {
 
     #[fixture]
     fn objects() -> (IDML, TempDir) {
-        let (tempdir, _paths, pool) = crate::PoolBuilder::new()
+        let ph = crate::PoolBuilder::new()
             .chunksize(1)
             .zone_size(LBA_PER_ZONE)
             .name(POOLNAME)
             .build();
         let cache = Arc::new(Mutex::new(Cache::with_capacity(4_194_304)));
-        let ddml = Arc::new(DDML::new(pool, cache.clone()));
+        let ddml = Arc::new(DDML::new(ph.pool, cache.clone()));
         let idml = IDML::create(ddml, cache);
-        (idml, tempdir)
+        (idml, ph.tempdir)
     }
 
     // When moving the last record from a zone, the allocator should not reopen

--- a/bfffs-core/tests/functional/mirror.rs
+++ b/bfffs-core/tests/functional/mirror.rs
@@ -91,6 +91,8 @@ mod persistence {
         let uuid = old_vdev.uuid();
         let label_writer = LabelWriter::new(0);
         old_vdev.write_label(label_writer).await.unwrap();
+        drop(old_vdev);
+
         let mut children = Vec::new();
         for path in paths {
             let (leaf, reader) = VdevFile::open(path).await.unwrap();

--- a/bfffs-core/tests/functional/mod.rs
+++ b/bfffs-core/tests/functional/mod.rs
@@ -28,4 +28,4 @@ mod util;
 mod vdev_block;
 mod vdev_file;
 
-use util::{Gnop, Md, PoolBuilder};
+use util::{Gnop, Md, PoolBuilder, PoolHarness};

--- a/bfffs-core/tests/functional/raid/null_raid.rs
+++ b/bfffs-core/tests/functional/raid/null_raid.rs
@@ -52,6 +52,8 @@ mod persistence {
         let uuid = old_vdev.uuid();
         let label_writer = LabelWriter::new(0);
         old_vdev.write_label(label_writer).await.unwrap();
+        drop(old_vdev);
+
         let (leaf, reader) = VdevFile::open(path).await.unwrap();
         let mirror_children = vec![(VdevBlock::new(leaf), reader)];
         let (mirror, reader) = Mirror::open(None, mirror_children);

--- a/bfffs-core/tests/functional/raid/vdev_raid.rs
+++ b/bfffs-core/tests/functional/raid/vdev_raid.rs
@@ -940,6 +940,8 @@ mod persistence {
         let uuid = old_raid.uuid();
         let label_writer = LabelWriter::new(0);
         old_raid.write_label(label_writer).await.unwrap();
+        drop(old_raid);
+
         let mut combined = Vec::new();
         for path in paths {
             let (leaf, reader) = VdevFile::open(path).await.unwrap();

--- a/bfffs-core/tests/torture/fs.rs
+++ b/bfffs-core/tests/torture/fs.rs
@@ -236,7 +236,7 @@ async fn torture_test(seed: Option<[u8; 16]>, freqs: Option<Vec<(Op, f64)>>,
             .init();
     });
 
-    let (_tempdir, _paths, pool) = crate::PoolBuilder::new()
+    let ph = crate::PoolBuilder::new()
         .zone_size(zone_size)
         .build();
     let cache = Arc::new(
@@ -244,7 +244,7 @@ async fn torture_test(seed: Option<[u8; 16]>, freqs: Option<Vec<(Op, f64)>>,
             Cache::with_capacity(32_000_000)
         )
     );
-    let ddml = Arc::new(DDML::new(pool, cache.clone()));
+    let ddml = Arc::new(DDML::new(ph.pool, cache.clone()));
     let idml = IDML::create(ddml, cache);
     let db = Arc::new(Database::create(Arc::new(idml)));
     let tree_id = db.create_fs(None, "").await.unwrap();


### PR DESCRIPTION
Don't close devices after tasting and before pool import.

Open devices with O_EXLOCK.

Fixes #233
