### PR TITLE
Dump Dying Inodes in Hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/bfffs-core/src/fs_tree.rs
+++ b/bfffs-core/src/fs_tree.rs
@@ -402,7 +402,7 @@ impl TryFrom<FSValue> for Dirent {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct DyingInode(u64);
 
 impl DyingInode {
@@ -414,6 +414,23 @@ impl DyingInode {
 impl From<u64> for DyingInode {
     fn from(ino: u64) -> Self {
         DyingInode(ino)
+    }
+}
+
+impl Serialize for DyingInode {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        if serializer.is_human_readable() {
+            // This puts annoying quotes around the number, but that's
+            // unfortunately impossible to avoid until the serde-yaml crate
+            // grows more features.
+            // https://github.com/dtolnay/serde-yaml/issues/198
+            // https://github.com/dtolnay/serde-yaml/issues/235
+            format!("{:x}", self.0).serialize(serializer)
+        } else {
+            self.0.serialize(serializer)
+        }
     }
 }
 


### PR DESCRIPTION
This makes it easier to match them up with the object numbers in FSKeys,
which are also serialized in Hex.
    
Fixes #67