### PR TITLE
Revert "In CI, use FreeBSD 13.2 instead of 14.0-CURRENT"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,12 +19,9 @@ task:
         CARGO_ARGS: --all-features
       compute_engine_instance:
         image_project: freebsd-org-cloud-dev
-        # The latest FreeBSD 14 images in google cloud are broken, so use 13.2
-        # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=272354
-        image: freebsd-13-2-release-amd64
         # Using image_family doesn't seem to work in conjunction with
         # compute_engine_instance.  So specify a 14.0 snapshot explicitly.
-        #image: freebsd-14-0-current-amd64-v20230413
+        image: freebsd-14-0-current-amd64-v20230720
         platform: freebsd
         cpu: 4
         disk: 40


### PR DESCRIPTION
This reverts commit eefdc805830d8c66401960e7bdc4e3a5dd2644e3.

The upstream issue is fixed, and 14.0-CURRENT works in GCE again.

Also, update the specific image used.