### PR TITLE
During CI, only run bfffs-fio if fio-3.35 is installed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ setup: &SETUP
     HOME: /tmp # cargo needs it
     RUST_BACKTRACE: full  # Better info for debugging test failures.
   setup_script:
-    - pkg install -y c-blosc isa-l fio llvm pkgconf
+    - pkg install -y c-blosc isa-l llvm pkgconf
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile=minimal --default-toolchain $VERSION
     # In 12.2, aio on ufs is considered unsafe
@@ -46,10 +46,14 @@ task:
     - . $HOME/.cargo/env
     - cargo test $CARGO_ARGS --all --all-targets
   fio_script:
-    # Temporarily restrict the fio job to fio-3.34.0, due to bug
-    # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271927
-    - if [ `fio --version | sed 's:fio-3.::'` -eq 34 ]; then
+    # Restrict the fio job to FreeBSD 14, because the ioengine has to be built
+    # separately for each fio version, the installed package doesn't include
+    # its header files.  It also needs to be build separately for FreeBSD 14+
+    # as for 13.
+    # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=272960
+    - if [ `uname -U` -ge 1400092 ]; then
     -   . $HOME/.cargo/env
+    -   pkg install -y fio
     -   truncate -s 1g /tmp/bfffs.img
     -   cargo run $CARGO_ARGS --bin bfffs -- pool create testpool /tmp/bfffs.img
     -   fio bfffs-fio/data/ci.fio

--- a/bfffs-fio/bindgen.sh
+++ b/bfffs-fio/bindgen.sh
@@ -1,7 +1,8 @@
 #! /bin/sh
 
 # fio doesn't install the necessary headers, so we have to reference its source
-# directory
+# directory.
+# https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=272960
 FIOPATH="/wrkdirs/usr/home/somers/src/freebsd.org/ports/benchmarks/fio/work/fio-3.35/"
 
 cat > src/ffi.rs << HERE


### PR DESCRIPTION
That's the current version in both the main and quarterly ports repos, and it's what our FFI bindings are built for.