### PR TITLE
Fix a mismerge in PR #294

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,7 @@ task:
         image_project: freebsd-org-cloud-dev
         # Using image_family doesn't seem to work in conjunction with
         # compute_engine_instance.  So specify a 14.0 snapshot explicitly.
-        image: freebsd-14-0-current-amd64-v20230720
+        image: freebsd-14-0-beta2-amd64
         platform: freebsd
         cpu: 4
         disk: 40

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static = "1.0"
 libc = "0.2.105"
 metrohash = "1.0"
 mockall_double = "0.3.0"
-nix = { version = "0.27.0", default-features = false, features = ["fs", "ioctl", "mount", "time"] }
+nix = { version = "0.27.0", default-features = false, features = ["feature", "fs", "ioctl", "mount", "time"] }
 num_enum = "0.5.1"
 num-traits = "0.2.0"
 pin-project = "1.0.11"


### PR DESCRIPTION
It accidentally removed "feature" from Nix's features in bfffs-core. But CI didn't notice, because "feature" is still required as a build-dependency, so Cargo pulls it in sometimes.