### PR TITLE
Recover from corrupted data on disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "divbuf",
  "downcast",
  "enum-primitive-derive",
+ "enum_dispatch",
  "fixedbitset",
  "function_name",
  "futures",
@@ -687,6 +688,18 @@ dependencies = [
  "num-traits",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
 ]
 
 [[package]]

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -20,6 +20,7 @@ byteorder = "1.2.3"
 cfg-if = "1.0"
 divbuf = { git = "https://github.com/asomers/divbuf.git", rev = "deb99e3"}
 downcast = "0.11.0"
+enum_dispatch = "0.3.12"
 enum-primitive-derive = "0.2.2"
 fixedbitset = "0.4.0"
 futures = "0.3.0"

--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -963,6 +963,20 @@ impl Cluster {
         self.vdev.clone().read_at(buf, lba)
     }
 
+    /// Asynchronously read a contiguous portion of the cluster.
+    ///
+    /// Returns `()` on success, or an error on failure.
+    ///
+    /// As an optimization, if only one reconstruction is possible then
+    /// immediately return EINTEGRITY, under the assumption that this method
+    /// should only be called after a normal read already returned such an
+    /// error.
+    pub fn read_long(&self, len: LbaT, lba: LbaT)
+        -> impl Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send
+    {
+        self.vdev.read_long(len, lba)
+    }
+
     /// Return approximately the usable space of the Cluster in LBAs.
     pub fn size(&self) -> LbaT {
         self.vdev.size()

--- a/bfffs-core/src/ddml/ddml.rs
+++ b/bfffs-core/src/ddml/ddml.rs
@@ -128,8 +128,8 @@ impl DDML {
     {
         let drp = *drp;
         self.pool.read()
-        .then(move |pg| Self::read(&pg, drp))
-        .map_ok(move |dbs| Box::new(T::deserialize(dbs)))
+        .then(move |pg| Self::read(pg, drp))
+        .map_ok(move |(_, dbs)| Box::new(T::deserialize(dbs)))
         .boxed()
     }
 
@@ -144,9 +144,9 @@ impl DDML {
     }
 
     /// Read a record from disk
-    #[instrument(skip(pool))]
-    fn read(pool: &RwLockReadGuard<Pool>, drp: DRP)
-        -> impl Future<Output=Result<DivBufShared>> + Send
+    #[instrument(skip(pg))]
+    fn read(pg: RwLockReadGuard<Pool>, drp: DRP)
+        -> impl Future<Output=Result<(RwLockReadGuard<Pool>, DivBufShared)>> + Send
     {
         // Outline
         // 1) Read
@@ -157,7 +157,7 @@ impl DDML {
         let dbs = DivBufShared::uninitialized(len);
         let dbm = dbs.try_mut().unwrap();
         // Read
-        pool.read(dbm, drp.pba)
+        pg.read(dbm, drp.pba)
         .and_then(move |_| {
             //Truncate
             let mut dbm = dbs.try_mut().unwrap();
@@ -172,13 +172,38 @@ impl DDML {
                 // Decompress
                 let db = dbs.try_const().unwrap();
                 if drp.is_compressed() {
-                    future::ok(Compression::decompress(&db))
+                    future::ok((pg, Compression::decompress(&db)))
                 } else {
-                    future::ok(dbs)
-                }
+                    future::ok((pg, dbs))
+                }.boxed()
             } else {
                 tracing::warn!("Checksum mismatch");
-                future::err(Error::EINTEGRITY)
+                pg.read_long(drp.asize(), drp.pba)
+                .map(move |r| {
+                    match r {
+                        Ok(reconstructions) => {
+                            for rdbs in reconstructions {
+                                let rdb = rdbs.try_const().unwrap();
+                                let mut hasher = MetroHash64::new();
+                                checksum_iovec(&rdb, &mut hasher);
+                                let checksum = hasher.finish();
+                                if checksum == drp.checksum {
+                                    // Somehow fault the stuff in bad
+                                    let dbs = if drp.is_compressed() {
+                                        Compression::decompress(&rdb)
+                                    } else {
+                                        let mut dbm = dbs.try_mut().unwrap();
+                                        dbm[..].copy_from_slice(&rdb[..]);
+                                        dbs
+                                    };
+                                    return Ok((pg, dbs));
+                                }
+                            }
+                            Err(Error::EINTEGRITY)
+                        },
+                        Err(e) => Err(e)
+                    }
+                }).boxed()
             }
         })
     }
@@ -203,8 +228,8 @@ impl DDML {
         let drp2 = *drp;
         self.pool.read()
         .then(move |pg| {
-            Self::read(&pg, drp2)
-            .and_then(move |dbs| {
+            Self::read(pg, drp2)
+            .and_then(move |(pg, dbs)| {
                 pg.free(pba, lbas)
                 .map_ok(move |_| Box::new(T::deserialize(dbs)))
             })
@@ -614,7 +639,7 @@ mod ddml {
         }
 
         #[test]
-        fn ecksum() {
+        fn nonredundant_eintegrity() {
             let pba = PBA::default();
             let drp = DRP{pba, compressed: false, lsize: 4096,
                           csize: 1, checksum: 0xdead_beef_dead_beef};
@@ -623,12 +648,129 @@ mod ddml {
             pool.expect_read()
                 .withf(|dbm, pba| dbm.len() == 4096 && *pba == PBA::default())
                 .return_once(|_, _| Box::pin(future::ok::<(), Error>(())));
+            pool.expect_read_long()
+                .withf(|len, pba| *len == 1 && *pba == PBA::default())
+                .times(1)
+                .return_once(|_, _| future::err(Error::EINTEGRITY).boxed());
 
             let ddml = DDML::new(pool, Arc::new(Mutex::new(cache)));
             let err = ddml.get::<DivBufShared, DivBuf>(&drp)
                 .now_or_never().unwrap()
                 .unwrap_err();
             assert_eq!(err, Error::EINTEGRITY);
+        }
+
+        /// A read yields a checksum error.  A subsequent read_long finds the
+        /// correct data.
+        #[test]
+        fn redundant_eintegrity() {
+            let pba = PBA::default();
+            let csize = 1usize;
+            let drp = DRP{pba, compressed: false, lsize: 4096,
+                          csize: csize as u32, checksum: 0xe7f_1596_6a3d_61f8};
+            let cache = Cache::with_capacity(1_048_576);
+            let mut pool = mock_pool();
+            pool.expect_read()
+                .withf(|dbm, pba| dbm.len() == 4096 && *pba == PBA::default())
+                .returning(|mut dbm, _| {
+                    for x in dbm.iter_mut() {
+                        *x = b'X';
+                    }
+                    Box::pin(future::ok::<(), Error>(()))
+                });
+            pool.expect_read_long()
+                .withf(|len, pba| *len == 1 && *pba == PBA::default())
+                .times(1)
+                .return_once(move |_, _| {
+                    let dbs0 = DivBufShared::from(vec![1u8; csize]);
+                    let dbs1 = DivBufShared::from(vec![0u8; csize]);
+                    let reconstructions = Box::new(vec![dbs0, dbs1].into_iter())
+                        as Box<dyn Iterator<Item=DivBufShared> + Send>;
+                    Box::new(future::ok(reconstructions)).boxed()
+                });
+
+            let ddml = DDML::new(pool, Arc::new(Mutex::new(cache)));
+            let db = ddml.get::<DivBufShared, DivBuf>(&drp)
+                .now_or_never().unwrap()
+                .unwrap();
+            assert_eq!(&db[..], &vec![0u8; csize]);
+        }
+
+        /// A read yields a checksum error.  A subsequent read_long yields other
+        /// possibilities, but they're all wrong.
+        #[test]
+        fn redundant_eintegrity_all_wrong() {
+            let pba = PBA::default();
+            let drp = DRP{pba, compressed: false, lsize: 4096,
+                          csize: 1, checksum: 0xdead_beef_dead_beef};
+            let cache = Cache::with_capacity(1_048_576);
+            let mut pool = mock_pool();
+            pool.expect_read()
+                .withf(|dbm, pba| dbm.len() == 4096 && *pba == PBA::default())
+                .return_once(|_, _| Box::pin(future::ok::<(), Error>(())));
+            pool.expect_read_long()
+                .withf(|len, pba| *len == 1 && *pba == PBA::default())
+                .times(1)
+                .return_once(|_, _| {
+                    let dbs0 = DivBufShared::from(vec![0u8; BYTES_PER_LBA]);
+                    let dbs1 = DivBufShared::from(vec![1u8; BYTES_PER_LBA]);
+                    let reconstructions = Box::new(vec![dbs0, dbs1].into_iter())
+                        as Box<dyn Iterator<Item=DivBufShared> + Send>;
+                    Box::new(future::ok(reconstructions)).boxed()
+                });
+
+            let ddml = DDML::new(pool, Arc::new(Mutex::new(cache)));
+            let err = ddml.get::<DivBufShared, DivBuf>(&drp)
+                .now_or_never().unwrap()
+                .unwrap_err();
+            assert_eq!(err, Error::EINTEGRITY);
+        }
+
+        /// A read yields a checksum error.  A subsequent read_long finds the
+        /// correct data.
+        #[test]
+        fn redundant_eintegrity_compressed() {
+            let lsize = 2 * BYTES_PER_LBA;
+            let raw = DivBufShared::from(vec![0u8; lsize]);
+            let db = raw.try_const().unwrap();
+            let (compressed, compression) = Compression::LZ4(None).compress(db);
+            assert!(compression != Compression::None);
+            let mut hasher = MetroHash64::new();
+            checksum_iovec(&compressed, &mut hasher);
+            let checksum = hasher.finish();
+
+            let pba = PBA::default();
+            let csize = compressed.len();
+            let drp = DRP{pba, compressed: true, lsize: lsize as u32,
+                          csize: csize as u32, checksum};
+            let asize = drp.asize() as usize * BYTES_PER_LBA;
+            let cache = Cache::with_capacity(1_048_576);
+            let mut pool = mock_pool();
+            pool.expect_read()
+                .withf(move |dbm, pba| dbm.len() == asize && *pba == PBA::default())
+                .return_once(|mut dbm, _| {
+                    for x in dbm.iter_mut() {
+                        *x = 0;
+                    }
+                    Box::pin(future::ok::<(), Error>(()))
+                });
+            pool.expect_read_long()
+                .withf(|len, pba| *len == 1 && *pba == PBA::default())
+                .times(1)
+                .return_once(move |_, _| {
+                    let dbs0 = DivBufShared::from(vec![1u8; csize]);
+                    let dbs1 = DivBufShared::from(Vec::from(&compressed[..]));
+                    let reconstructions = Box::new(vec![dbs0, dbs1].into_iter())
+                        as Box<dyn Iterator<Item=DivBufShared> + Send>;
+                    Box::new(future::ok(reconstructions)).boxed()
+                });
+
+            let ddml = DDML::new(pool, Arc::new(Mutex::new(cache)));
+            let db = ddml.get::<DivBufShared, DivBuf>(&drp)
+                .now_or_never().unwrap()
+                .unwrap();
+            assert_eq!(db.len(), raw.len());
+            assert_eq!(&db[..], &raw.try_const().unwrap()[..]);
         }
     }
 
@@ -736,7 +878,7 @@ mod ddml {
     }
 
     #[test]
-    fn pop_ecksum() {
+    fn pop_eintegrity() {
         let pba = PBA::default();
         let drp = DRP{pba, compressed: false, lsize: 4096,
                       csize: 1, checksum: 0xdead_beef_dead_beef};
@@ -745,6 +887,10 @@ mod ddml {
         pool.expect_read()
             .with(always(), eq(pba))
             .return_once(|_, _| Box::pin(future::ok::<(), Error>(())));
+        pool.expect_read_long()
+            .withf(|len, pba| *len == 1 && *pba == PBA::default())
+            .times(1)
+            .return_once(|_, _| future::err(Error::EINTEGRITY).boxed());
 
         let ddml = DDML::new(pool, Arc::new(Mutex::new(cache)));
         let err = ddml.pop::<DivBufShared, DivBuf>(&drp, TxgT::from(0))

--- a/bfffs-core/src/ddml/ddml.rs
+++ b/bfffs-core/src/ddml/ddml.rs
@@ -589,7 +589,6 @@ mod ddml {
 
         #[test]
         fn cold() {
-            let mut seq = Sequence::new();
             let pba = PBA::default();
             let key = Key::PBA(pba);
             let drp = DRP{pba, compressed: false, lsize: 4096,
@@ -599,7 +598,6 @@ mod ddml {
             pool.expect_read()
                 .withf(|dbm, pba| dbm.len() == 4096 && *pba == PBA::default())
                 .once()
-                .in_sequence(&mut seq)
                 .returning(|mut dbm, _pba| {
                     for x in dbm.iter_mut() {
                         *x = 0;

--- a/bfffs-core/src/mirror.rs
+++ b/bfffs-core/src/mirror.rs
@@ -21,6 +21,7 @@ use cfg_if::cfg_if;
 use divbuf::{DivBufInaccessible, DivBufMut, DivBufShared};
 use futures::{
     Future,
+    FutureExt,
     StreamExt,
     TryFutureExt,
     TryStreamExt,
@@ -28,8 +29,6 @@ use futures::{
     stream::FuturesUnordered,
     task::{Context, Poll}
 };
-#[cfg(not(test))]
-use futures::FutureExt;
 use pin_project::pin_project;
 use serde_derive::{Deserialize, Serialize};
 
@@ -751,7 +750,7 @@ mock! {
         pub fn open_zone(&self, start: LbaT) -> BoxVdevFut;
         pub fn read_at(&self, buf: IoVecMut, lba: LbaT) -> BoxVdevFut;
         pub fn read_long(&self, len: LbaT, lba: LbaT)
-            -> Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=DivBufShared>>>> + Send>>;
+            -> Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send>>;
         pub fn read_spacemap(&self, buf: IoVecMut, idx: u32) -> BoxVdevFut;
         pub fn status(&self) -> Status;
         pub fn readv_at(&self, bufs: SGListMut, lba: LbaT) -> BoxVdevFut;

--- a/bfffs-core/src/raid/declust.rs
+++ b/bfffs-core/src/raid/declust.rs
@@ -83,6 +83,7 @@ impl Chunkloc {
 /// design, but it has performance benefits as well.  Chiefly, during a rebuild
 /// no healthy disk will be saturated, so user I/O suffers less than in a
 /// traditional RAID array.
+#[enum_dispatch::enum_dispatch(LocatorImpl)]
 pub trait Locator : Send + Sync {
     /// Return the number of data chunks in a single repetition of the layout
     fn datachunks(&self) -> u64;

--- a/bfffs-core/src/raid/declust.rs
+++ b/bfffs-core/src/raid/declust.rs
@@ -84,7 +84,7 @@ impl Chunkloc {
 /// no healthy disk will be saturated, so user I/O suffers less than in a
 /// traditional RAID array.
 #[enum_dispatch::enum_dispatch(LocatorImpl)]
-pub trait Locator : Send + Sync {
+pub trait Locator : Clone + Send + Sync {
     /// Return the number of data chunks in a single repetition of the layout
     fn datachunks(&self) -> u64;
 

--- a/bfffs-core/src/raid/mod.rs
+++ b/bfffs-core/src/raid/mod.rs
@@ -80,6 +80,7 @@ impl<'a> Label {
     }
 }
 
+#[derive(Clone)]
 #[enum_dispatch::enum_dispatch]
 enum LocatorImpl {
     PrimeS(prime_s::PrimeS)

--- a/bfffs-core/src/raid/mod.rs
+++ b/bfffs-core/src/raid/mod.rs
@@ -12,8 +12,10 @@ use crate::{
     mirror,
     vdev::*,
 };
+#[cfg(test)]
+use divbuf::DivBufShared;
+use futures::Future;
 #[cfg(not(test))] use futures::{
-    Future,
     FutureExt,
     StreamExt,
     future,
@@ -29,6 +31,8 @@ use std::{
     path::Path,
     sync::Arc
 };
+#[cfg(test)]
+use std::pin::Pin;
 
 #[double]
 use crate::mirror::Mirror;
@@ -227,6 +231,8 @@ mock!{
         fn flush_zone(&self, zone: ZoneT) -> (LbaT, BoxVdevFut);
         fn open_zone(&self, zone: ZoneT) -> BoxVdevFut;
         fn read_at(self: Arc<Self>, buf: IoVecMut, lba: LbaT) -> BoxVdevFut;
+        fn read_long(&self, len: LbaT, lba: LbaT)
+            -> Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send>>;
         fn read_spacemap(&self, buf: IoVecMut, idx: u32) -> BoxVdevFut;
         fn reopen_zone(&self, zone: ZoneT, allocated: LbaT) -> BoxVdevFut;
         fn status(&self) -> Status;

--- a/bfffs-core/src/raid/mod.rs
+++ b/bfffs-core/src/raid/mod.rs
@@ -41,6 +41,8 @@ mod null_raid;
 mod vdev_raid;
 mod vdev_raid_api;
 
+use declust::{Locator, ChunkId, Chunkloc};
+
 pub use self::null_raid::NullRaid;
 pub use self::vdev_raid::VdevRaid;
 pub use self::vdev_raid_api::VdevRaidApi;
@@ -72,6 +74,11 @@ impl<'a> Label {
             Label::NullRaid(l) => l.uuid,
         }
     }
+}
+
+#[enum_dispatch::enum_dispatch]
+enum LocatorImpl {
+    PrimeS(prime_s::PrimeS)
 }
 
 /// Manage BFFFS-formatted disks that aren't yet part of an imported pool.

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -36,6 +36,7 @@ use std::{
 };
 use serde_derive::{Deserialize, Serialize};
 use super::{
+    LocatorImpl,
     Status,
     codec::*,
     declust::*,
@@ -392,7 +393,7 @@ pub struct VdevRaid {
     faulted_children: i16,
 
     /// Locator, declustering or otherwise
-    locator: Box<dyn Locator>,
+    locator: LocatorImpl,
 
     /// Underlying mirror devices.  Order is important!
     children: Box<[Child]>,
@@ -529,9 +530,9 @@ impl VdevRaid {
         let mut faulted_children = 0;
         let num_disks = children.len() as i16;
         let codec = Codec::new(disks_per_stripe as u32, redundancy as u32);
-        let locator: Box<dyn Locator> = match layout_algorithm {
-            LayoutAlgorithm::PrimeS => Box::new(
-                PrimeS::new(num_disks, disks_per_stripe, redundancy))
+        let locator: LocatorImpl = match layout_algorithm {
+            LayoutAlgorithm::PrimeS => 
+                PrimeS::new(num_disks, disks_per_stripe, redundancy).into()
         };
 
         // XXX The vdev size or child size should be recorded in the label.

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -21,7 +21,7 @@ use futures::{
     stream::{FuturesOrdered, FuturesUnordered},
     task::{Context, Poll}
 };
-use itertools::multizip;
+use itertools::{Itertools, multizip};
 use mockall_double::double;
 use pin_project::pin_project;
 use std::{
@@ -1113,6 +1113,266 @@ impl VdevRaid {
         // and request the faulty drive's zone to be rebuilt.
     }
 
+    fn read_long_multi(&self, unlbas: LbaT, ulba: LbaT)
+        -> impl Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send
+    {
+        let codec2 = self.codec.clone();
+        let f = self.codec.protection();
+        let k = self.codec.stripesize();
+        let m = self.codec.stripesize() - f;
+        let n = self.children.len();
+        let chunksize = self.chunksize;
+        // The only current Locator is small enough that it's probably cheaper
+        // to clone it than to use an Arc.
+        let locator = self.locator.clone();
+        let lbas_per_stripe = chunksize * m as LbaT;
+        let start_stripe = ulba / (chunksize * m as LbaT);
+        let col_len = chunksize as usize * BYTES_PER_LBA;
+        // end_lba is inclusive.  The highest LBA from which data will be read
+        let end_lba = ulba + unlbas - 1;
+        let end_stripe = end_lba / (chunksize as LbaT * m as LbaT);
+        let stripes = end_stripe - start_stripe + 1;
+
+        // Assemble the list of read operations.  Unlink read_at_multi, don't
+        // use scatter/gather operations.  Instead, read each disks's data into
+        // a single contiguous buffer.  We'll chop it up in the next step.
+        let mut buffers = Vec::with_capacity(self.children.len());
+        for _ in 0..self.children.len() {
+            buffers.push(None);
+        }
+        let mut args_per_disk = vec![None; self.children.len()];
+
+        let stripe_lba = ulba - ulba % lbas_per_stripe;
+        let start_lba = stripe_lba;
+        let start_chunk_addr = start_lba / chunksize;
+        let start_cid = ChunkId::Data(start_chunk_addr);
+        let end_cid = ChunkId::Data(start_chunk_addr + stripes * m as LbaT);
+        for (_cid, loc) in locator.iter(start_cid, end_cid) {
+            match args_per_disk[loc.disk as usize] {
+                None => args_per_disk[loc.disk as usize] =
+                    Some((loc.offset, loc.offset + 1)),
+                Some((_s, ref mut e)) => *e = loc.offset + 1
+            };
+        }
+        args_per_disk.iter()
+        .enumerate()
+        .filter_map(|(disk_idx, x)| x.map(|(sofs, eofs)| (disk_idx, sofs, eofs)))
+        .map(|(disk_idx, sofs, eofs)| {
+            let disk_lba = sofs * chunksize;
+            let len = ((eofs - sofs) * chunksize) as usize * BYTES_PER_LBA;
+            let dbs = DivBufShared::from(vec![0u8; len]);
+            let dbm = dbs.try_mut().unwrap();
+            buffers[disk_idx] = Some(dbs);
+            self.children[disk_idx].read_at(dbm, disk_lba)
+        }).collect::<FuturesOrdered<_>>()
+        .collect::<Vec<Result<()>>>()
+        .map(move |dv| {
+            let mut failures = FixedBitSet::with_capacity(n);
+            for (i, v) in dv.iter().enumerate() {
+                if v.is_err() {
+                    failures.set(i, true);
+                }
+            }
+            // Now iterate over all combinations of disk failures
+            let iterator = (0..n).combinations(f as usize)
+            .filter_map(move |it| {
+                let mut disk_erasures = FixedBitSet::with_capacity(n);
+                for i in it {
+                    disk_erasures.set(i, true);
+                }
+                if failures.difference(&disk_erasures).count() != 0 {
+                    return None;
+                }
+                // Allocate storage for the reconstructed stripes
+                let sdbs = DivBufShared::from(
+                    vec![0u8; stripes as usize * m as usize * col_len]
+                );
+                let sdbm = sdbs.try_mut().unwrap();
+                let mut sdbmi = sdbm.into_chunks(col_len);
+
+                // Now iterate stripe by stripe, reconstructing the result
+                // Allocate storage for the entire stripe.
+                for s in start_stripe..=end_stripe {
+                    let mut erasures = FixedBitSet::with_capacity(k as usize);
+                    let mut surviving = Vec::with_capacity(m as usize);
+                    let mut vdbm = Vec::with_capacity(f as usize);
+                    let mut vdb = Vec::with_capacity(m as usize);
+                    let mut missing = Vec::with_capacity(f as usize);
+                    let start_chunk_addr = s * m as LbaT;
+                    let past_chunk_addr = (s + 1) * m as LbaT;
+                    let start_cid = ChunkId::Data(start_chunk_addr);
+                    let end_cid = ChunkId::Data(past_chunk_addr);
+                    for (chunkpos, (cid, loc)) in locator
+                        .iter(start_cid, end_cid)
+                        .enumerate()
+                    {
+                        let disk = loc.disk as usize;
+                        let args = args_per_disk[disk].as_ref().unwrap();
+                        if disk_erasures.contains(disk) && cid.is_data() {
+                            erasures.set(chunkpos, true);
+                            let mut dbm = sdbmi.next().unwrap();
+                            missing.push(dbm.as_mut_ptr());
+                            vdbm.push(dbm);
+                        } else {
+                            let dbs = buffers[disk].as_mut().unwrap();
+                            let mut db = dbs.try_const().unwrap();
+                            db.split_to((loc.offset - args.0) as usize * col_len);
+                            db.split_off(col_len);
+                            if cid.is_data() {
+                                sdbmi.next().unwrap().copy_from_slice(&db[..]);
+                            }
+                            surviving.push(db.as_ptr());
+                            vdb.push(db);
+                        }
+                        if surviving.len() >= m as usize {
+                            break;
+                        }
+                    }
+                    // Safe because all columns are still owned by vdb and vdbm
+                    // and they all have the same length.
+                    if !missing.is_empty() {
+                        unsafe {
+                            codec2.decode(col_len, &surviving[..],
+                                          &mut missing[..], &erasures);
+                        }
+                    }
+                }
+                debug_assert!(sdbmi.next().is_none());
+                drop(sdbmi);
+                // Now copy just the part that the user wants
+                let udbs = DivBufShared::from(
+                    vec![0u8; unlbas as usize * BYTES_PER_LBA]
+                );
+                let mut udbm = udbs.try_mut().unwrap();
+                let sdb = sdbs.try_const().unwrap();
+                let uo = (ulba % lbas_per_stripe) as usize * BYTES_PER_LBA;
+                let ul = unlbas as usize * BYTES_PER_LBA;
+                udbm.copy_from_slice(&sdb[uo..uo + ul]);
+
+                Some(udbs)
+            });
+            Ok(Box::new(iterator) as Box<dyn Iterator<Item=DivBufShared> + Send>)
+        })
+    }
+
+    // NB: In a cluster that uses raid on top of mirrors, this function won't
+    // consult the mirrors' read_long methods.  Instead, it assumes that the
+    // raid layer itself contains enough redundancy to rebuild the corrupt data.
+    // This limitation could be lifted, but I don't expect it to come up very
+    // often.
+    fn read_long_one(&self, unlbas: LbaT, ulba: LbaT)
+        -> impl Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send
+    {
+        let col_len = self.chunksize as usize * BYTES_PER_LBA;
+        let k = self.codec.stripesize() as usize;
+        let f = self.codec.protection();
+        let m = (self.codec.stripesize() - f) as usize;
+        let n = self.children.len();
+        let lbas_per_stripe = self.chunksize * m as LbaT;
+        let codec2 = self.codec.clone();
+
+        let stripe_lba = ulba - ulba % lbas_per_stripe;
+        let end_of_stripe_lba = stripe_lba + lbas_per_stripe;
+        let start_lba = stripe_lba;
+        let end_lba = end_of_stripe_lba;
+
+        let mut exbufs = Vec::with_capacity(n);
+
+        let start_chunk_addr = start_lba / self.chunksize;
+        let start_cid = ChunkId::Data(start_chunk_addr);
+        let end_cid = ChunkId::Data(end_lba / self.chunksize);
+
+        let rfut = self.locator.iter(start_cid, end_cid)
+        .map(|(_cid, loc)| {
+            let disk_lba = loc.offset * self.chunksize;
+            let dbs = DivBufShared::from(vec![0u8; col_len]);
+            let dbm = dbs.try_mut().unwrap();
+            exbufs.push(dbs);
+            self.children[loc.disk as usize].read_at(dbm, disk_lba)
+        }).collect::<FuturesOrdered<_>>();
+        rfut.collect::<Vec<Result<()>>>()
+        .map(move |dv| {
+            let mut failures = FixedBitSet::with_capacity(k);
+            for (i, v) in dv.iter().enumerate() {
+                if v.is_err() {
+                    failures.set(i, true);
+                }
+            }
+            let iterator = (0..k).combinations(f as usize).filter_map(move |it| {
+                let mut erasures = FixedBitSet::with_capacity(k);
+                for i in it {
+                    erasures.set(i, true);
+                }
+                if failures.difference(&erasures).count() != 0 {
+                    None
+                } else {
+                    // Reconstruct the entire stripe.
+                    // NB: this could be more efficient if the user only wants a
+                    // few LBAs in the middle of a chunk.  In that case we don't
+                    // need to reconstruct the entire stripe, just a thin
+                    // substripe of it.  But read_long is not optimized for
+                    // performance.
+                    let dbs = DivBufShared::from(vec![0u8; m * col_len]);
+                    let dbm = dbs.try_mut().unwrap();
+                    let mut vdb = Vec::with_capacity(m);
+                    let mut surviving = Vec::with_capacity(m);
+                    let mut vdbm = Vec::with_capacity(f as usize);
+                    let mut missing = Vec::with_capacity(f as usize);
+                    for (i, mut dbm) in dbm.into_chunks(col_len).enumerate() {
+                        if erasures.contains(i) {
+                            missing.push(dbm.as_mut_ptr());
+                            vdbm.push(dbm);
+                        } else if !erasures.contains(i) {
+                            debug_assert!(dv[i].is_ok());
+                            let db = exbufs[i].try_const().unwrap();
+                            dbm[..].copy_from_slice(&db[..]);
+                            surviving.push(db.as_ptr());
+                            vdb.push(db);
+                        }
+                    }
+                    for i in m..k {
+                        if !erasures.contains(i) {
+                            debug_assert!(dv[i].is_ok());
+                            let db = exbufs[i].try_const().unwrap();
+                            surviving.push(db.as_ptr());
+                            vdb.push(db);
+                        }
+                        if surviving.len() >= m {
+                            break;
+                        }
+                    }
+                    // Safe because all columns are still owned by vdb and vdbm
+                    // and they all have the same length.
+                    if !missing.is_empty() {
+                        unsafe {
+                            codec2.decode(col_len, &surviving[..],
+                                          &mut missing[..], &erasures);
+                        }
+                    }
+                    drop(vdbm);
+                    drop(vdb);
+                    if unlbas == lbas_per_stripe {
+                        Some(dbs)
+                    } else {
+                        // Copy just the part that the user wants
+                        // NB: this could be more efficient.  The data copy
+                        // could be eliminated by using more exbufs for stuff
+                        // the user doesn't want, and reading or reconstructing
+                        // directly into udbs.  But that would be complicated,
+                        // and read_long isn't optimized for performance.
+                        let uo = (ulba % lbas_per_stripe) as usize * BYTES_PER_LBA;
+                        let ul = unlbas as usize * BYTES_PER_LBA;
+                        let udbs = DivBufShared::from(vec![0u8; ul]);
+                        let mut udbm = udbs.try_mut().unwrap();
+                        udbm.copy_from_slice(&dbs.try_const().unwrap()[uo..uo + ul]);
+                        Some(udbs)
+                    }
+                }
+            });
+            Ok(Box::new(iterator) as Box<dyn Iterator<Item=DivBufShared> + Send>)
+        })
+    }
+
     /// Reconstruct a stripe of data, given surviving columns and parity
     fn read_at_reconstruction(
         codec: &Codec,
@@ -1835,10 +2095,29 @@ impl VdevRaidApi for VdevRaid {
         }
     }
 
-    fn read_long(&self, len: LbaT, lba: LbaT)
+    fn read_long(&self, len: LbaT, ulba: LbaT)
         -> Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send>>
     {
-        todo!()
+        let f = self.codec.protection();
+        let m = self.codec.stripesize() - f;
+
+        if self.faulted_children() >= f {
+            return future::err(Error::EINTEGRITY).boxed();
+        }
+
+        // Ignore the stripe buffer.  The fact that read_long got called meant
+        // that, even if the data is available in the stripe buffer , it must be
+        // wrong.
+
+        let start_stripe = ulba / (self.chunksize * m as LbaT);
+        // end_lba is inclusive.  The highest LBA from which data will be read
+        let end_lba = ulba + len - 1;
+        let end_stripe = end_lba / (self.chunksize as LbaT * m as LbaT);
+        if start_stripe == end_stripe {
+            Box::pin(self.read_long_one(len, ulba))
+        } else {
+            Box::pin(self.read_long_multi(len, ulba))
+        }
     }
 
     fn read_spacemap(&self, buf: IoVecMut, smidx: u32) -> BoxVdevFut

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -1835,6 +1835,12 @@ impl VdevRaidApi for VdevRaid {
         }
     }
 
+    fn read_long(&self, len: LbaT, lba: LbaT)
+        -> Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send>>
+    {
+        todo!()
+    }
+
     fn read_spacemap(&self, buf: IoVecMut, smidx: u32) -> BoxVdevFut
     {
         let dbi = buf.clone_inaccessible();

--- a/bfffs-core/tests/functional/ddml.rs
+++ b/bfffs-core/tests/functional/ddml.rs
@@ -13,7 +13,7 @@ mod ddml {
     use std::{
         fs,
         io::Read,
-        path::Path,
+        path::PathBuf,
         sync::{Arc, Mutex}
     };
 
@@ -60,12 +60,9 @@ mod ddml {
     async fn compressible(ddml: DDML) {
         let txg = TxgT::from(0);
         let ddml2 = &ddml;
-        let mut file = fs::File::open(
-                Path::new("../bfffs-core/src/raid/vdev_raid.rs")
-            ).unwrap_or_else(|_|
-                fs::File::open(Path::new("bfffs-core/src/raid/vdev_raid.rs")
-            ).unwrap()
-        );
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("src/raid/vdev_raid.rs");
+        let mut file = fs::File::open(path).unwrap();
         let mut vdev_raid_contents = Vec::new();
         file.read_to_end(&mut vdev_raid_contents).unwrap();
         let dbs = DivBufShared::from(vdev_raid_contents.clone());

--- a/bfffs-core/tests/functional/ddml.rs
+++ b/bfffs-core/tests/functional/ddml.rs
@@ -3,7 +3,9 @@ use bfffs_core::{
     cache::*,
     dml::*,
     ddml::*,
-    TxgT
+    TxgT,
+    BYTES_PER_LBA,
+    LbaT
 };
 use divbuf::{DivBuf, DivBufShared};
 use futures::TryFutureExt;
@@ -12,6 +14,7 @@ use rstest::{fixture, rstest};
 use std::{
     fs,
     io::Read,
+    os::unix::fs::FileExt,
     path::PathBuf,
     sync::{Arc, Mutex}
 };
@@ -113,4 +116,157 @@ async fn short(ddml: DDML) {
         assert_eq!(&db[..], &vec![42u8; 1024][..]);
     }).await
     .unwrap();
+}
+
+mod integrity {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    use crate::{PoolBuilder, PoolHarness};
+
+    async fn do_test(ph: PoolHarness, ulbas: usize, alignment_lbas: LbaT) {
+        let cache = Arc::new(Mutex::new(Cache::with_capacity(1_000_000_000)));
+        let ddml = DDML::new(ph.pool, cache);
+        let txg = TxgT::from(0);
+        let compression = Compression::None;
+
+        // Do a small write, if necessary, to produce desired alignment
+        if alignment_lbas > 0 {
+            let l = alignment_lbas as usize * BYTES_PER_LBA;
+            let dbs = DivBufShared::from(vec![0u8; l]);
+            let db = dbs.try_const().unwrap();
+            ddml.put_direct(&db, compression, txg).await.unwrap();
+        }
+
+        let mut v = Vec::with_capacity(ulbas * BYTES_PER_LBA);
+        for lba in 0..ulbas {
+            for _ in 0..BYTES_PER_LBA {
+                v.push(lba as u8);
+            }
+        }
+        let dbs = DivBufShared::from(v);
+        let original = dbs.try_const().unwrap();
+
+        let drp = ddml.put_direct(&original, compression, txg).await.unwrap();
+        // Flush any RAID stripe buffer to disk
+        ddml.flush(0).await.unwrap();
+
+        // Repeat the experiment with corruption on every disk.
+        for bad_disk in ph.paths {
+            let mut f = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&bad_disk)
+                .unwrap();
+            let fsize = f.metadata().unwrap().len();
+            let corrupt_buf = vec![0xFFu8; fsize as usize];
+            let mut good_buf = vec![0u8; fsize as usize];
+            f.read_exact(&mut good_buf[..]).unwrap();
+
+            // Corrupt the data on one disk.
+            f.write_all_at(&corrupt_buf[..], 0).unwrap();
+
+            // Now try to read it.
+            for _ in 0..ph.disks_per_mirror {
+                let recovered = ddml.get::<DivBufShared, DivBuf>(&drp)
+                    .await
+                    .unwrap();
+                assert_eq!(original, *recovered);
+                // Evict cache and try again for every mirror member, to ensure
+                // that we read from the corrupted mirror child on one attempt.
+                ddml.evict(&drp);
+            }
+
+            // Restore the disk's original contents before trying again.
+            f.write_all_at(&good_buf[..], 0).unwrap();
+        }
+    }
+
+    /// Corrupted data can be detected.  If redundant information is available,
+    /// the correct data can be reconstructed.
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn mirror() {
+        let fsize = 131072;
+        let ph = PoolBuilder::new()
+            .mirror_size(2)
+            .disks(2)
+            .fsize(fsize)
+            .build();
+        do_test(ph, 2, 0).await;
+    }
+
+    /// How to align the corrupted record that's about to be read
+    enum Alignment {
+        /// Align it to the beginning of a stripe
+        Stripe,
+        /// Align one LBA after the beginning of a stripe
+        OneLba,
+        /// Align one LBA before the beginning of the stripe's 2nd chunk
+        AllButOneLba,
+        /// Align one Chunk after the beginning of the stripe
+        Chunk
+    }
+
+    /// How long the corrupted record should be
+    enum Length {
+        OneLba,
+        PartialChunk,
+        OneChunk,
+        OneStripe,
+        ThreeStripes
+    }
+
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn raid(
+        #[values(
+            // Simplest sensible RAID configuration
+            (3, 3, 1),
+            // Highly declustered configuratoin
+            (11, 3, 1)
+        )]
+        raid_config: (usize, i16, i16),
+        #[values(
+            Length::OneLba,
+            Length::PartialChunk,
+            Length::OneChunk,
+            Length::OneStripe,
+            Length::ThreeStripes
+        )]
+        l: Length,
+        #[values(
+            Alignment::Stripe,
+            Alignment::OneLba,
+            Alignment::AllButOneLba,
+            Alignment::Chunk
+        )]
+        a: Alignment
+    ) {
+        let (n, k, f) = raid_config;
+        let chunksize = 5;
+        let fsize = 131072;
+        let ph = PoolBuilder::new()
+            .disks(n)
+            .chunksize(chunksize)
+            .fsize(fsize)
+            .redundancy_level(f)
+            .stripe_size(k)
+            .build();
+        let ulbas = match l {
+            Length::OneLba => 1,
+            Length::PartialChunk if chunksize == 5 => 3,
+            Length::OneChunk => chunksize as usize,
+            Length::OneStripe => chunksize as usize * (k - f) as usize,
+            Length::ThreeStripes => 3 * chunksize as usize * (k - f) as usize,
+            _ => unimplemented!()
+        };
+        let alignment_lbas = match a {
+            Alignment::Stripe => 0,
+            Alignment::OneLba => 1,
+            Alignment::AllButOneLba => chunksize - 1,
+            Alignment::Chunk => chunksize,
+        };
+        do_test(ph, ulbas, alignment_lbas).await;
+    }
 }

--- a/bfffs-core/tests/functional/ddml.rs
+++ b/bfffs-core/tests/functional/ddml.rs
@@ -1,118 +1,116 @@
 // vim: tw=80
-mod ddml {
-    use bfffs_core::{
-        cache::*,
-        dml::*,
-        ddml::*,
-        TxgT
-    };
-    use divbuf::{DivBuf, DivBufShared};
-    use futures::TryFutureExt;
-    use pretty_assertions::assert_eq;
-    use rstest::{fixture, rstest};
-    use std::{
-        fs,
-        io::Read,
-        path::PathBuf,
-        sync::{Arc, Mutex}
-    };
+use bfffs_core::{
+    cache::*,
+    dml::*,
+    ddml::*,
+    TxgT
+};
+use divbuf::{DivBuf, DivBufShared};
+use futures::TryFutureExt;
+use pretty_assertions::assert_eq;
+use rstest::{fixture, rstest};
+use std::{
+    fs,
+    io::Read,
+    path::PathBuf,
+    sync::{Arc, Mutex}
+};
 
-    #[fixture]
-    fn ddml() -> DDML {
-        let ph = crate::PoolBuilder::new()
-            .chunksize(1)
-            .build();
-        let cache = Cache::with_capacity(1_000_000_000);
-        DDML::new(ph.pool, Arc::new(Mutex::new(cache)))
-    }
+#[fixture]
+fn ddml() -> DDML {
+    let ph = crate::PoolBuilder::new()
+        .chunksize(1)
+        .build();
+    let cache = Cache::with_capacity(1_000_000_000);
+    DDML::new(ph.pool, Arc::new(Mutex::new(cache)))
+}
 
-    #[rstest]
-    #[tokio::test]
-    async fn basic(ddml: DDML) {
-        let dbs = DivBufShared::from(vec![42u8; 4096]);
-        let ddml2 = &ddml;
-        ddml.put(dbs, Compression::None, TxgT::from(0))
-        .and_then(move |drp| {
-            let drp2 = &drp;
-            ddml2.get::<DivBufShared, DivBuf>(drp2)
-            .map_ok(|db: Box<DivBuf>| {
-                assert_eq!(&db[..], &vec![42u8; 4096][..]);
-            }).and_then(move |_| {
-                ddml2.pop::<DivBufShared, DivBuf>(&drp, TxgT::from(0))
-            }).map_ok(|dbs: Box<DivBufShared>| {
-                assert_eq!(&dbs.try_const().unwrap()[..],
-                           &vec![42u8; 4096][..]);
-            }).and_then(move |_| {
-                // Even though the record has been removed from cache, it
-                // should still be on disk
-                ddml2.get::<DivBufShared, DivBuf>(&drp)
-            })
-        }).map_ok(|db: Box<DivBuf>| {
+#[rstest]
+#[tokio::test]
+async fn basic(ddml: DDML) {
+    let dbs = DivBufShared::from(vec![42u8; 4096]);
+    let ddml2 = &ddml;
+    ddml.put(dbs, Compression::None, TxgT::from(0))
+    .and_then(move |drp| {
+        let drp2 = &drp;
+        ddml2.get::<DivBufShared, DivBuf>(drp2)
+        .map_ok(|db: Box<DivBuf>| {
             assert_eq!(&db[..], &vec![42u8; 4096][..]);
-        }).await
-        .unwrap();
-    }
+        }).and_then(move |_| {
+            ddml2.pop::<DivBufShared, DivBuf>(&drp, TxgT::from(0))
+        }).map_ok(|dbs: Box<DivBufShared>| {
+            assert_eq!(&dbs.try_const().unwrap()[..],
+                       &vec![42u8; 4096][..]);
+        }).and_then(move |_| {
+            // Even though the record has been removed from cache, it
+            // should still be on disk
+            ddml2.get::<DivBufShared, DivBuf>(&drp)
+        })
+    }).map_ok(|db: Box<DivBuf>| {
+        assert_eq!(&db[..], &vec![42u8; 4096][..]);
+    }).await
+    .unwrap();
+}
 
-    // Round trip some compressible data.  Use the contents of vdev_raid.rs, a
-    // moderately large and compressible file
-    #[rstest]
-    #[tokio::test]
-    async fn compressible(ddml: DDML) {
-        let txg = TxgT::from(0);
-        let ddml2 = &ddml;
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("src/raid/vdev_raid.rs");
-        let mut file = fs::File::open(path).unwrap();
-        let mut vdev_raid_contents = Vec::new();
-        file.read_to_end(&mut vdev_raid_contents).unwrap();
-        let dbs = DivBufShared::from(vdev_raid_contents.clone());
-        ddml.put(dbs, Compression::Zstd(None), txg)
-        .and_then(|drp| {
-            let drp2 = &drp;
-            ddml2.get::<DivBufShared, DivBuf>(drp2)
-            .map_ok(|db: Box<DivBuf>| {
-                assert_eq!(&db[..], &vdev_raid_contents[..]);
-            }).and_then(move |_| {
-                ddml2.pop::<DivBufShared, DivBuf>(&drp, txg)
-            }).map_ok(|dbs: Box<DivBufShared>| {
-                assert_eq!(&dbs.try_const().unwrap()[..],
-                           &vdev_raid_contents[..]);
-            }).and_then(move |_| {
-                // Even though the record has been removed from cache, it
-                // should still be on disk
-                ddml2.get::<DivBufShared, DivBuf>(&drp)
-            }).map_ok(|db: Box<DivBuf>| {
-                assert_eq!(&db[..], &vdev_raid_contents[..]);
-            })
-        }).await
-        .unwrap();
-    }
-
-    // Records of less than an LBA should be padded up.
-    #[rstest]
-    #[tokio::test]
-    async fn short(ddml: DDML) {
-        let ddml2 = &ddml;
-        let dbs = DivBufShared::from(vec![42u8; 1024]);
-        ddml.put(dbs, Compression::None, TxgT::from(0))
-        .and_then(move |drp| {
-            let drp2 = &drp;
-            ddml2.get::<DivBufShared, DivBuf>(drp2)
-            .map_ok(|db: Box<DivBuf>| {
-                assert_eq!(&db[..], &vec![42u8; 1024][..]);
-            }).and_then(move |_| {
-                ddml2.pop::<DivBufShared, DivBuf>(&drp, TxgT::from(0))
-            }).map_ok(|dbs: Box<DivBufShared>| {
-                assert_eq!(&dbs.try_const().unwrap()[..],
-                           &vec![42u8; 1024][..]);
-            }).and_then(move |_| {
-                // Even though the record has been removed from cache, it
-                // should still be on disk
-                ddml2.get::<DivBufShared, DivBuf>(&drp)
-            })
+// Round trip some compressible data.  Use the contents of vdev_raid.rs, a
+// moderately large and compressible file
+#[rstest]
+#[tokio::test]
+async fn compressible(ddml: DDML) {
+    let txg = TxgT::from(0);
+    let ddml2 = &ddml;
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/raid/vdev_raid.rs");
+    let mut file = fs::File::open(path).unwrap();
+    let mut vdev_raid_contents = Vec::new();
+    file.read_to_end(&mut vdev_raid_contents).unwrap();
+    let dbs = DivBufShared::from(vdev_raid_contents.clone());
+    ddml.put(dbs, Compression::Zstd(None), txg)
+    .and_then(|drp| {
+        let drp2 = &drp;
+        ddml2.get::<DivBufShared, DivBuf>(drp2)
+        .map_ok(|db: Box<DivBuf>| {
+            assert_eq!(&db[..], &vdev_raid_contents[..]);
+        }).and_then(move |_| {
+            ddml2.pop::<DivBufShared, DivBuf>(&drp, txg)
+        }).map_ok(|dbs: Box<DivBufShared>| {
+            assert_eq!(&dbs.try_const().unwrap()[..],
+                       &vdev_raid_contents[..]);
+        }).and_then(move |_| {
+            // Even though the record has been removed from cache, it
+            // should still be on disk
+            ddml2.get::<DivBufShared, DivBuf>(&drp)
         }).map_ok(|db: Box<DivBuf>| {
+            assert_eq!(&db[..], &vdev_raid_contents[..]);
+        })
+    }).await
+    .unwrap();
+}
+
+// Records of less than an LBA should be padded up.
+#[rstest]
+#[tokio::test]
+async fn short(ddml: DDML) {
+    let ddml2 = &ddml;
+    let dbs = DivBufShared::from(vec![42u8; 1024]);
+    ddml.put(dbs, Compression::None, TxgT::from(0))
+    .and_then(move |drp| {
+        let drp2 = &drp;
+        ddml2.get::<DivBufShared, DivBuf>(drp2)
+        .map_ok(|db: Box<DivBuf>| {
             assert_eq!(&db[..], &vec![42u8; 1024][..]);
-        }).await
-        .unwrap();
-    }
+        }).and_then(move |_| {
+            ddml2.pop::<DivBufShared, DivBuf>(&drp, TxgT::from(0))
+        }).map_ok(|dbs: Box<DivBufShared>| {
+            assert_eq!(&dbs.try_const().unwrap()[..],
+                       &vec![42u8; 1024][..]);
+        }).and_then(move |_| {
+            // Even though the record has been removed from cache, it
+            // should still be on disk
+            ddml2.get::<DivBufShared, DivBuf>(&drp)
+        })
+    }).map_ok(|db: Box<DivBuf>| {
+        assert_eq!(&db[..], &vec![42u8; 1024][..]);
+    }).await
+    .unwrap();
 }

--- a/bfffs-core/tests/functional/util.rs
+++ b/bfffs-core/tests/functional/util.rs
@@ -162,6 +162,7 @@ pub struct PoolBuilder {
 
 pub struct PoolHarness {
     pub tempdir: TempDir,
+    pub disks_per_mirror: usize,
     pub paths: Vec<PathBuf>,
     pub pool: Pool,
     pub gnops: Vec<Gnop>
@@ -209,7 +210,7 @@ impl PoolBuilder {
                 Cluster::create(raid)
             }).collect::<Vec<_>>();
         let pool = Pool::create(String::from(self.name), clusters);
-        PoolHarness{tempdir, paths, pool, gnops}
+        PoolHarness{tempdir, disks_per_mirror: self.m, paths, pool, gnops}
     }
 
     pub fn chunksize(&mut self, cs: u64) -> &mut Self {


### PR DESCRIPTION
If the DDML detects data corruption, it will now attempt to reconstruct the correct data.  It will read the record from every disk (on a mirrored cluster) or reconstruct it from every combination of disks (on a raid cluster) looking for a reconstruction with the correct checksum.  It won't correct it on-disk though; that is for the future.

Fixes #224 