### PR TITLE
Fix invoking bfffs-bench as "cargo bench" without a subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,9 +2708,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.4"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
  "serde",

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -44,7 +44,7 @@ tokio = { version = "1.24.2", features = ["rt", "sync", "time"] }
 tokio-file = "0.9.0"
 tracing = "0.1.5"
 tracing-futures = "0.2.4"
-uuid = { version = "1.3.4", features = ["serde", "v4"]}
+uuid = { version = "1.6.1", features = ["serde", "v4"]}
 
 [dev-dependencies.clap]
 version = "4.0"

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -896,7 +896,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
     /// Flush all in-memory Nodes to disk.
     pub async fn flush(self: Arc<Self>, txg: TxgT) -> Result<()>
     {
-        while let true = Tree::flush_once(self.clone(), txg).await? {
+        while Tree::flush_once(self.clone(), txg).await? {
         }
         Ok(())
     }

--- a/bfffs-core/tests/functional/fs.rs
+++ b/bfffs-core/tests/functional/fs.rs
@@ -3011,7 +3011,6 @@ root:
         assert_ts_changed(&h.fs, &fdh, false, false, false, false).await;
     }
 
-    #[allow(clippy::blocks_in_if_conditions)]
     #[rstest(h, case(harness4k()))]
     #[tokio::test]
     #[awt]


### PR DESCRIPTION
    There were two problems:
    
    * Cargo will always add a --bench argument, even when the standard
      benchmark argument is not in use.  We must detect and ignore it.  We
      already did that when a subcommand was present, but not otherwise.
    
    * When running all benchmarks serially, we weren't using the right
      default options for each.