### PR TITLE
Remove some unused features from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2225,15 +2225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd8aef454c9a9c91a10f17aa6947f60949da6a8f0353b70a5775ad0d1023b92"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,7 +2465,6 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",
@@ -2553,17 +2543,17 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.7"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 1.9.2",
+ "indexmap 2.1.0",
  "toml_datetime",
  "winnow",
 ]
@@ -2735,7 +2725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
- "serde",
 ]
 
 [[package]]
@@ -3018,9 +3007,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.3.6"
+version = "0.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
 ]

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -44,7 +44,7 @@ tokio = { version = "1.24.2", features = ["rt", "sync", "time"] }
 tokio-file = "0.9.0"
 tracing = "0.1.5"
 tracing-futures = "0.2.4"
-uuid = { version = "1.6.1", features = ["serde", "v4"]}
+uuid = { version = "1.6.1", features = ["v4", "std"], default-features = false }
 
 [dev-dependencies.clap]
 version = "4.0"

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -18,8 +18,8 @@ bincode = "1.0.1"
 bfffs-core = { path = "../bfffs-core" }
 bytes = "1.0"
 cfg-if = "1.0"
-console-subscriber = "0.2.0"
-fuse3 = { version = "0.7.0", optional = true, features = ["tokio-runtime"] }
+console-subscriber = { default-features = false, version = "0.2.0" }
+fuse3 = { version = "0.7.0", optional = true, features = ["tokio-runtime"], default-features = false }
 futures = "0.3.0"
 lalrpop-util = { version = "0.19.9", features = ["lexer", "std"] }
 libc = "0.2.44"
@@ -27,10 +27,10 @@ nix = { version = "0.27.0", default-features = false, features = ["user"] }
 prettytable = { version = "0.10.0", default-features = false }
 si-scale = "0.1.5"
 tabular = "0.2.0"
-time = { version = "0.3.0", features = [ "formatting" ] }
-tokio = { version = "1.24.2", features = ["macros", "rt", "rt-multi-thread", "signal", "sync", "time"] }
+time = { version = "0.3.0", default-features = false }
+tokio = { version = "1.24.2", features = ["rt-multi-thread"], default-features = false }
 tokio-seqpacket = "0.5.4"
-tracing = "0.1.5"
+tracing = { default-features = false, version = "0.1.5" }
 
 [dependencies.clap]
 version = "4.0"


### PR DESCRIPTION
The main removed features are:
* signal from tokio.  It was once used, but no longer.
* serde from uuid.  It sort-of looks like it's used, but actually isn't.

Also, set default-features = false on a few other crates, with uncertain benefits.