### PR TITLE
Suppress the clippy::duplicated_attributes lint

### DIFF
--- a/bfffs-core/tests/torture/fs.rs
+++ b/bfffs-core/tests/torture/fs.rs
@@ -1,3 +1,7 @@
+// Suppress this lint, triggered by rstest
+// https://github.com/la10736/rstest/issues/238
+#![allow(clippy::duplicated_attributes)]
+
 use bfffs_core::{
     *,
     cache::*,

--- a/bfffs-core/tests/torture/vdev_raid.rs
+++ b/bfffs-core/tests/torture/vdev_raid.rs
@@ -1,5 +1,8 @@
 //! Write and read data to a raid device using a random pattern, and verify
 //! integrity.
+// Suppress this lint, triggered by rstest
+// https://github.com/la10736/rstest/issues/238
+#![allow(clippy::duplicated_attributes)]
 
 use std::{
     env,


### PR DESCRIPTION
The latest nightly toolchains report this lint for rstest's generated code.

https://github.com/la10736/rstest/issues/238