### PR TITLE
Revert "Suppress the clippy::duplicated_attributes lint"

### DIFF
--- a/bfffs-core/tests/torture/fs.rs
+++ b/bfffs-core/tests/torture/fs.rs
@@ -1,7 +1,3 @@
-// Suppress this lint, triggered by rstest
-// https://github.com/la10736/rstest/issues/238
-#![allow(clippy::duplicated_attributes)]
-
 use bfffs_core::{
     *,
     cache::*,

--- a/bfffs-core/tests/torture/vdev_raid.rs
+++ b/bfffs-core/tests/torture/vdev_raid.rs
@@ -1,8 +1,5 @@
 //! Write and read data to a raid device using a random pattern, and verify
 //! integrity.
-// Suppress this lint, triggered by rstest
-// https://github.com/la10736/rstest/issues/238
-#![allow(clippy::duplicated_attributes)]
 
 use std::{
     env,


### PR DESCRIPTION
This reverts commit 8c01118e6746b26cecf005f85e9c9c1ef4cfeb80.

Because Clippy fixed the lint