### PR TITLE
Fix a warning on the latest nightly

### DIFF
--- a/bfffs-core/build.rs
+++ b/bfffs-core/build.rs
@@ -3,6 +3,7 @@ use nix::sys::utsname::uname;
 fn main() {
     // Avoid unnecessary re-building.
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo::rustc-check-cfg=cfg(have_fspacectl)");
 
     let utsname = uname().unwrap();
     // XXX: this only checks kernel version, so it doesn't work properly in a

--- a/bfffs/build.rs
+++ b/bfffs/build.rs
@@ -3,5 +3,9 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/pool_create_parser.lalrpop");
 
+    // Workaround a lalrpop bug
+    // https://github.com/lalrpop/lalrpop/issues/892
+    println!("cargo::rustc-check-cfg=cfg(rustfmt)");
+
     lalrpop::process_root().unwrap();
 }


### PR DESCRIPTION
The latest nightly tries to check whether any #[cfg()] expressions reference unknown config variables.  But in order to do that it needs to know about custom config variables.