### PR TITLE
VdevFile::erase_method: don't require mutable access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -146,7 +146,17 @@ checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "atomic_enum"
+version = "0.2.0"
+source = "git+https://github.com/asomers/atomic_enum.git?rev=969354b#969354b78c72ca1c489e13668c51beb61b1b00a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -255,6 +265,7 @@ name = "bfffs-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "atomic_enum",
  "bincode",
  "bitfield",
  "blosc",
@@ -531,7 +542,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -834,7 +845,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1532,7 +1543,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1544,7 +1555,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1898,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -1925,7 +1936,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1939,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2177,7 +2188,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2287,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.12"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2393,7 +2404,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ resolver = "2"
 
 [patch.crates-io]
 fuse3 = { git = "https://github.com/Sherlock-Holo/fuse3.git", rev = "59d9c6e" }
+atomic_enum = { git = "https://github.com/asomers/atomic_enum.git", rev = "969354b" }

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -13,6 +13,7 @@ nightly = [ "mockall/nightly" ]
 
 [dependencies]
 async-trait = "0.1.40"
+atomic_enum = "0.2.0"
 bincode = { version = "1.0.1", features = ["i128"] }
 bitfield = "0.13.1"
 blosc = "0.2.0"

--- a/bfffs-core/tests/functional/vdev_file.rs
+++ b/bfffs-core/tests/functional/vdev_file.rs
@@ -58,7 +58,7 @@ mod basic {
     #[rstest]
     #[tokio::test]
     async fn erase_zone(harness: Harness) {
-        let (mut vd, pb, _tempdir) = harness;
+        let (vd, pb, _tempdir) = harness;
         let mut f = fs::File::open(pb).unwrap();
         let mut rbuf = vec![0u8; 4096];
 
@@ -91,7 +91,7 @@ mod basic {
     #[rstest]
     #[tokio::test]
     async fn erase_zone_twice(harness: Harness) {
-        let (mut vd, pb, _tempdir) = harness;
+        let (vd, pb, _tempdir) = harness;
         let mut f = fs::File::open(pb).unwrap();
         let mut rbuf = vec![0u8; 4096];
 
@@ -318,7 +318,7 @@ mod dev {
     async fn erase_zone() {
         require_root!();
 
-        let (mut vd, md) = harness().unwrap();
+        let (vd, md) = harness().unwrap();
         let mut rbuf = vec![0u8; 4096];
         let mut f = t!(fs::File::open(&md.0));
 


### PR DESCRIPTION
Use atomic_num to eliminate the need for a mutable referene.