### PR TITLE
Switch from serde_yaml to serde_yaml_ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,12 +768,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1488,9 +1488,9 @@ checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -1790,15 +1790,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2149,6 +2149,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.4.0",
 ]
 
 [[package]]
@@ -3085,15 +3094,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3108,21 +3108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3158,12 +3143,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
@@ -3176,12 +3155,6 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
@@ -3191,12 +3164,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3218,12 +3185,6 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
@@ -3233,12 +3194,6 @@ name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3254,12 +3209,6 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
@@ -3269,12 +3218,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
  "rstest_reuse",
  "serde",
  "serde_derive",
- "serde_yaml",
+ "serde_yaml_ng",
  "tempfile",
  "test-log",
  "time",
@@ -1196,7 +1196,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -1359,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1479,12 +1479,6 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2358,15 +2352,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.8.26"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap 1.9.2",
+ "indexmap 2.2.6",
+ "itoa",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2752,7 +2747,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow",
 ]
@@ -2920,6 +2915,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
@@ -3294,15 +3295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -53,7 +53,7 @@ default-features = true
 features=  [ "derive", "wrap_help" ]
 
 [dev-dependencies]
-dashmap = "5"
+dashmap = "5.5"
 criterion = "0.5"
 function_name = "0.3.0"
 futures-test = "0.3.30"

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -39,7 +39,7 @@ num-traits = "0.2.0"
 pin-project = "1.1.0"
 serde = "1.0.60"
 serde_derive = "1.0"
-serde_yaml = "0.8.16"
+serde_yaml_ng = "0.10.0"
 time = { version = "0.3.0", features = [ "formatting" ] }
 tokio = { version = "1.27.0", features = ["rt", "sync", "time"] }
 tokio-file = "0.10.0"

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -752,7 +752,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
         //   extend its parent's representation.
         // * Last of all, print the root's representation.
         let bf = Box::new(f) as Box<dyn io::Write>;
-        let ser = serde_yaml::Serializer::new(bf);
+        let ser = serde_yaml_ng::Serializer::new(bf);
         let rrf = Rc::new(RefCell::new(ser));
         let rrf2 = rrf.clone();
         let rrf3 = rrf.clone();
@@ -779,7 +779,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
     fn dump_r<'a>(
         dml: Arc<D>,
         node: TreeReadGuard<A, K, V>,
-        ser: Rc<RefCell<serde_yaml::Serializer<Box<dyn io::Write + 'a>>>>
+        ser: Rc<RefCell<serde_yaml_ng::Serializer<Box<dyn io::Write + 'a>>>>
     ) -> Pin<Box<dyn Future<
             Output=Result<TreeReadGuard<A, K, V>>> + 'a
         >>
@@ -1089,7 +1089,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
 
     #[cfg(test)]
     pub fn from_str(dml: Arc<D>, seq: bool, s: &str) -> Self {
-        let il: InnerLiteral<A, K, V> = serde_yaml::from_str(s).unwrap();
+        let il: InnerLiteral<A, K, V> = serde_yaml_ng::from_str(s).unwrap();
         Tree::new(dml, il.limits, seq, Some(il.root))
     }
 
@@ -2301,7 +2301,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
 #[cfg(test)]
 impl<A: Addr, D: DML<Addr=A>, K: Key, V: Value> Display for Tree<A, D, K, V> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.write_str(&serde_yaml::to_string(&self).unwrap())
+        f.write_str(&serde_yaml_ng::to_string(&self).unwrap())
     }
 }
 

--- a/bfffs-core/src/tree/tree/tests/clean_zone.rs
+++ b/bfffs-core/src/tree/tree/tests/clean_zone.rs
@@ -97,7 +97,6 @@ fn basic() {
         .returning(mem::forget);
     let ddml = Arc::new(mock);
     let tree = Arc::new(Tree::<DRP, DDML, u32, f32>::from_str(ddml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -111,94 +110,86 @@ root:
     txgs:
       start: 8
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 8
-                end: 9
-              ptr:
-                Addr:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 8
+            end: 9
+          ptr: !Addr
+            pba:
+              cluster: 0
+              lba: 2
+            compressed: false
+            lsize: 0
+            csize: 0
+            checksum: 0
+        - key: 4
+          txgs:
+            start: 20
+            end: 32
+          ptr: !Addr
+            pba:
+              cluster: 0
+              lba: 4
+            compressed: false
+            lsize: 0
+            csize: 0
+            checksum: 0
+        - key: 8
+          txgs:
+            start: 8
+            end: 24
+          ptr: !Addr
+            pba:
+              cluster: 0
+              lba: 101
+            compressed: false
+            lsize: 0
+            csize: 0
+            checksum: 0
+        - key: 12
+          txgs:
+            start: 21
+            end: 42
+          ptr: !Mem
+            Int: # In-memory Int node with a child in the target zone
+              children:
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      6: 6.0
+                      7: 7.0
+              - key: 16
+                txgs:
+                  start: 21
+                  end: 22
+                ptr: !Addr
                   pba:
                     cluster: 0
-                    lba: 2
+                    lba: 102
                   compressed: false
                   lsize: 0
                   csize: 0
                   checksum: 0
-            - key: 4
-              txgs:
-                start: 20
-                end: 32
-              ptr:
-                Addr:
+              - key: 20   # Leaf node in TXG range but not in PBA range
+                txgs:
+                  start: 29
+                  end: 30
+                ptr: !Addr
                   pba:
                     cluster: 0
-                    lba: 4
+                    lba: 200
                   compressed: false
                   lsize: 0
                   csize: 0
                   checksum: 0
-            - key: 8
-              txgs:
-                start: 8
-                end: 24
-              ptr:
-                Addr:
-                  pba:
-                    cluster: 0
-                    lba: 101
-                  compressed: false
-                  lsize: 0
-                  csize: 0
-                  checksum: 0
-            - key: 12
-              txgs:
-                start: 21
-                end: 42
-              ptr:
-                Mem:  # In-memory Int node with a child in the target zone
-                  Int:
-                    children:
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                6: 6.0
-                                7: 7.0
-                      - key: 16
-                        txgs:
-                          start: 21
-                          end: 22
-                        ptr:
-                          Addr:
-                            pba:
-                              cluster: 0
-                              lba: 102
-                            compressed: false
-                            lsize: 0
-                            csize: 0
-                            checksum: 0
-                      - key: 20   # Leaf node in TXG range but not in PBA range
-                        txgs:
-                          start: 29
-                          end: 30
-                        ptr:
-                          Addr:
-                            pba:
-                              cluster: 0
-                              lba: 200
-                            compressed: false
-                            lsize: 0
-                            csize: 0
-                            checksum: 0
 "#));
 
     let start = PBA::new(0, 100);
@@ -209,8 +200,7 @@ root:
     .unwrap();
     let clean_tree = format!("{tree}");
     assert_eq!(clean_tree,
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -223,115 +213,105 @@ root:
     txgs:
       start: 8
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 8
-                end: 9
-              ptr:
-                Addr:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 8
+            end: 9
+          ptr: !Addr
+            pba:
+              cluster: 0
+              lba: 2
+            compressed: false
+            lsize: 0
+            csize: 0
+            checksum: 0
+        - key: 4
+          txgs:
+            start: 20
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4
+                txgs:
+                  start: 31
+                  end: 32
+                ptr: !Addr
                   pba:
                     cluster: 0
-                    lba: 2
+                    lba: 3
                   compressed: false
                   lsize: 0
                   csize: 0
                   checksum: 0
-            - key: 4
-              txgs:
-                start: 20
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4
-                        txgs:
-                          start: 31
-                          end: 32
-                        ptr:
-                          Addr:
-                            pba:
-                              cluster: 0
-                              lba: 3
-                            compressed: false
-                            lsize: 0
-                            csize: 0
-                            checksum: 0
-                      - key: 6
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Addr:
-                            pba:
-                              cluster: 1
-                              lba: 0
-                            compressed: false
-                            lsize: 0
-                            csize: 0
-                            checksum: 0
-            - key: 8
-              txgs:
-                start: 8
-                end: 43
-              ptr:
-                Addr:
+              - key: 6
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Addr
                   pba:
                     cluster: 1
-                    lba: 2
+                    lba: 0
                   compressed: false
                   lsize: 0
                   csize: 0
                   checksum: 0
-            - key: 12
-              txgs:
-                start: 21
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                6: 6.0
-                                7: 7.0
-                      - key: 16
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Addr:
-                            pba:
-                              cluster: 1
-                              lba: 1
-                            compressed: false
-                            lsize: 0
-                            csize: 0
-                            checksum: 0
-                      - key: 20
-                        txgs:
-                          start: 29
-                          end: 30
-                        ptr:
-                          Addr:
-                            pba:
-                              cluster: 0
-                              lba: 200
-                            compressed: false
-                            lsize: 0
-                            csize: 0
-                            checksum: 0
+        - key: 8
+          txgs:
+            start: 8
+            end: 43
+          ptr: !Addr
+            pba:
+              cluster: 1
+              lba: 2
+            compressed: false
+            lsize: 0
+            csize: 0
+            checksum: 0
+        - key: 12
+          txgs:
+            start: 21
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      6: 6.0
+                      7: 7.0
+              - key: 16
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Addr
+                  pba:
+                    cluster: 1
+                    lba: 1
+                  compressed: false
+                  lsize: 0
+                  csize: 0
+                  checksum: 0
+              - key: 20
+                txgs:
+                  start: 29
+                  end: 30
+                ptr: !Addr
+                  pba:
+                    cluster: 0
+                    lba: 200
+                  compressed: false
+                  lsize: 0
+                  csize: 0
+                  checksum: 0
 "#);
 }
 
@@ -379,7 +359,6 @@ fn dirty_root() {
         });
     let ddml = Arc::new(mock);
     let tree = Arc::new(Tree::<DRP, DDML, u32, f32>::from_str(ddml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -393,15 +372,14 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Addr:
-        pba:
-          cluster: 0
-          lba: 100
-        compressed: false
-        lsize: 0
-        csize: 0
-        checksum: 0
+    ptr: !Addr
+      pba:
+        cluster: 0
+        lba: 100
+      compressed: false
+      lsize: 0
+      csize: 0
+      checksum: 0
   "#));
 
     let start = PBA::new(0, 100);

--- a/bfffs-core/src/tree/tree/tests/in_mem.rs
+++ b/bfffs-core/src/tree/tree/tests/in_mem.rs
@@ -17,8 +17,7 @@ fn insert() {
         .now_or_never().unwrap();
     assert_eq!(r, Ok(None));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -31,12 +30,11 @@ root:
     txgs:
       start: 42
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 0.0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 0.0
 "#);
 }
 
@@ -47,7 +45,6 @@ fn insert_lower_than_parents_key() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -61,43 +58,39 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 67
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      67: 67.0
-                      68: 68.0
-                      69: 69.0
-            - key: 70
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      70: 70.0
-                      71: 71.0
-                      72: 72.0
-                      73: 73.0
-                      74: 74.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 67
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                67: 67.0
+                68: 68.0
+                69: 69.0
+        - key: 70
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                70: 70.0
+                71: 71.0
+                72: 72.0
+                73: 73.0
+                74: 74.0
 "#));
     assert!(tree.clone().insert(36, 36.0, TxgT::from(42), Credit::forge(8))
             .now_or_never().unwrap()
             .is_ok());
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -110,37 +103,34 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 36
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      36: 36.0
-                      67: 67.0
-                      68: 68.0
-                      69: 69.0
-            - key: 70
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      70: 70.0
-                      71: 71.0
-                      72: 72.0
-                      73: 73.0
-                      74: 74.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 36
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                36: 36.0
+                67: 67.0
+                68: 68.0
+                69: 69.0
+        - key: 70
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                70: 70.0
+                71: 71.0
+                72: 72.0
+                73: 73.0
+                74: 74.0
 "#);
 }
 
@@ -149,7 +139,6 @@ fn insert_dup() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -163,19 +152,17 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 0.0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 0.0
 "#));
     let r = tree.clone().insert(0, 100.0, TxgT::from(42), Credit::forge(8))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(0.0)));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -188,12 +175,11 @@ root:
     txgs:
       start: 42
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 100.0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 100.0
 "#);
 }
 
@@ -211,7 +197,6 @@ fn insert_dup_dclone() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, NeedsDcloneV>::from_str(
         dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -225,19 +210,17 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 0
 "#));
     let r = tree.clone().insert(0, NeedsDcloneV(100), txg, Credit::forge(8))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(NeedsDcloneV(0))));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -250,12 +233,11 @@ root:
     txgs:
       start: 42
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 100
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 100
 "#);
 }
 
@@ -273,7 +255,6 @@ fn insert_dup_dclone_enoent() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, NeedsDcloneV>::from_str(
         dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -287,12 +268,11 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 0
 "#));
     let r = tree.insert(0, NeedsDcloneV(100), txg, Credit::forge(8))
         .now_or_never().unwrap();
@@ -306,7 +286,6 @@ fn insert_dup_no_split() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -320,23 +299,21 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 80
-          items:
-            0: 0.0
-            1: 1.0
-            2: 2.0
-            3: 3.0
-            4: 4.0
+    ptr: !Mem
+      Leaf:
+        credit: 80
+        items:
+          0: 0.0
+          1: 1.0
+          2: 2.0
+          3: 3.0
+          4: 4.0
   "#));
     let r = tree.clone().insert(0, 100.0, TxgT::from(42), Credit::forge(8))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(0.0)));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -349,16 +326,15 @@ root:
     txgs:
       start: 42
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 80
-          items:
-            0: 100.0
-            1: 1.0
-            2: 2.0
-            3: 3.0
-            4: 4.0
+    ptr: !Mem
+      Leaf:
+        credit: 80
+        items:
+          0: 100.0
+          1: 1.0
+          2: 2.0
+          3: 3.0
+          4: 4.0
 "#);
 }
 
@@ -375,8 +351,7 @@ fn insert_excess_credit() {
         .now_or_never().unwrap();
     assert_eq!(r, Ok(None));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -389,12 +364,11 @@ root:
     txgs:
       start: 42
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 0.0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 0.0
 "#);
 }
 
@@ -412,8 +386,7 @@ fn insert_insufficient_credit() {
         .now_or_never().unwrap();
     assert_eq!(r, Ok(None));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -426,12 +399,11 @@ root:
     txgs:
       start: 42
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 0.0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 0.0
 "#);
 }
 
@@ -441,7 +413,6 @@ fn insert_split_int() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -455,129 +426,117 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                0: 0.0
-                                1: 1.0
-                                2: 2.0
-                      - key: 3
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3: 3.0
-                                4: 4.0
-                                5: 5.0
-                      - key: 6
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                6: 6.0
-                                7: 7.0
-                                8: 8.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                9: 9.0
-                                10: 10.0
-                                11: 11.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                12: 12.0
-                                13: 13.0
-                                14: 14.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                15: 15.0
-                                16: 16.0
-                                17: 17.0
-                      - key: 18
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                18: 18.0
-                                19: 19.0
-                                20: 20.0
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                21: 21.0
-                                22: 22.0
-                                23: 23.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+              - key: 3
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+              - key: 6
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      9: 9.0
+                      10: 10.0
+                      11: 11.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      12: 12.0
+                      13: 13.0
+                      14: 14.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      15: 15.0
+                      16: 16.0
+                      17: 17.0
+              - key: 18
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      18: 18.0
+                      19: 19.0
+                      20: 20.0
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      21: 21.0
+                      22: 22.0
+                      23: 23.0
 "#));
     let r2 = tree.clone().insert(24, 24.0, TxgT::from(42), Credit::forge(8))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -590,131 +549,119 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                0: 0.0
-                                1: 1.0
-                                2: 2.0
-                      - key: 3
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3: 3.0
-                                4: 4.0
-                                5: 5.0
-                      - key: 6
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                6: 6.0
-                                7: 7.0
-                                8: 8.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                9: 9.0
-                                10: 10.0
-                                11: 11.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                12: 12.0
-                                13: 13.0
-                                14: 14.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                15: 15.0
-                                16: 16.0
-                                17: 17.0
-            - key: 18
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 18
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                18: 18.0
-                                19: 19.0
-                                20: 20.0
-                      - key: 21
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                21: 21.0
-                                22: 22.0
-                                23: 23.0
-                                24: 24.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+              - key: 3
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+              - key: 6
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      9: 9.0
+                      10: 10.0
+                      11: 11.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      12: 12.0
+                      13: 13.0
+                      14: 14.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      15: 15.0
+                      16: 16.0
+                      17: 17.0
+        - key: 18
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 18
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      18: 18.0
+                      19: 19.0
+                      20: 20.0
+              - key: 21
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      21: 21.0
+                      22: 22.0
+                      23: 23.0
+                      24: 24.0
 "#);
 }
 
@@ -724,7 +671,6 @@ fn insert_split_int_sequential() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, true, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 8
@@ -738,143 +684,129 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 3
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                3: 3.0
-                                4: 4.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-                      - key: 18
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                18: 18.0
-                                19: 19.0
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                21: 21.0
-                                22: 22.0
-                      - key: 24
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                24: 24.0
-                                25: 25.0
-                      - key: 27
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                27: 27.0
-                                28: 28.0
-                      - key: 30
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                30: 30.0
-                                31: 31.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 3
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      3: 3.0
+                      4: 4.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+              - key: 18
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      18: 18.0
+                      19: 19.0
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      21: 21.0
+                      22: 22.0
+              - key: 24
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      24: 24.0
+                      25: 25.0
+              - key: 27
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      27: 27.0
+                      28: 28.0
+              - key: 30
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      30: 30.0
+                      31: 31.0
 "#));
     let r2 = tree.clone().insert(33, 33.0, TxgT::from(42), Credit::forge(8))
     .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 8
   min_leaf_fanout: 2
@@ -887,145 +819,131 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 3
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                3: 3.0
-                                4: 4.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-                      - key: 18
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                18: 18.0
-                                19: 19.0
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                21: 21.0
-                                22: 22.0
-                      - key: 24
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                24: 24.0
-                                25: 25.0
-            - key: 27
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 27
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                27: 27.0
-                                28: 28.0
-                      - key: 30
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                30: 30.0
-                                31: 31.0
-                                33: 33.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 3
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      3: 3.0
+                      4: 4.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+              - key: 18
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      18: 18.0
+                      19: 19.0
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      21: 21.0
+                      22: 22.0
+              - key: 24
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      24: 24.0
+                      25: 25.0
+        - key: 27
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 27
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      27: 27.0
+                      28: 28.0
+              - key: 30
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      30: 30.0
+                      31: 31.0
+                      33: 33.0
 "#);
 }
 
@@ -1035,7 +953,6 @@ fn insert_split_leaf() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1049,43 +966,39 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
-            - key: 3
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      3: 3.0
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
+        - key: 3
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                3: 3.0
+                4: 4.0
+                5: 5.0
+                6: 6.0
+                7: 7.0
   "#));
     let r2 = tree.clone().insert(8, 8.0, TxgT::from(42), Credit::forge(8))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -1098,46 +1011,42 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
-            - key: 3
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      3: 3.0
-                      4: 4.0
-                      5: 5.0
-            - key: 6
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
+        - key: 3
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                3: 3.0
+                4: 4.0
+                5: 5.0
+        - key: 6
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                6: 6.0
+                7: 7.0
+                8: 8.0
 "#);
 }
 
@@ -1147,7 +1056,6 @@ fn insert_split_leaf_sequential() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, true, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 8
@@ -1161,47 +1069,43 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
-                      3: 3.0
-            - key: 4
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 128
-                    items:
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
-                      9: 9.0
-                      10: 10.0
-                      11: 11.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
+                3: 3.0
+        - key: 4
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 128
+              items:
+                4: 4.0
+                5: 5.0
+                6: 6.0
+                7: 7.0
+                8: 8.0
+                9: 9.0
+                10: 10.0
+                11: 11.0
   "#));
     let r2 = tree.clone().insert(12, 12.0, TxgT::from(42), Credit::forge(8))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 8
   min_leaf_fanout: 2
@@ -1214,50 +1118,46 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
-                      3: 3.0
-            - key: 4
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 96
-                    items:
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
-                      9: 9.0
-            - key: 10
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      10: 10.0
-                      11: 11.0
-                      12: 12.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
+                3: 3.0
+        - key: 4
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 96
+              items:
+                4: 4.0
+                5: 5.0
+                6: 6.0
+                7: 7.0
+                8: 8.0
+                9: 9.0
+        - key: 10
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                10: 10.0
+                11: 11.0
+                12: 12.0
 "#);
 }
 
@@ -1267,7 +1167,6 @@ fn insert_split_root_int() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1281,77 +1180,70 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
-            - key: 3
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      3: 3.0
-                      4: 4.0
-                      5: 5.0
-            - key: 6
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      9: 9.0
-                      10: 10.0
-                      11: 11.0
-            - key: 12
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      12: 12.0
-                      13: 13.0
-                      14: 14.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
+        - key: 3
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                3: 3.0
+                4: 4.0
+                5: 5.0
+        - key: 6
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                6: 6.0
+                7: 7.0
+                8: 8.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                9: 9.0
+                10: 10.0
+                11: 11.0
+        - key: 12
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                12: 12.0
+                13: 13.0
+                14: 14.0
   "#));
     let r2 = tree.clone().insert(15, 15.0, TxgT::from(42), Credit::forge(8))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -1364,87 +1256,79 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                0: 0.0
-                                1: 1.0
-                                2: 2.0
-                      - key: 3
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3: 3.0
-                                4: 4.0
-                                5: 5.0
-                      - key: 6
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                6: 6.0
-                                7: 7.0
-                                8: 8.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                9: 9.0
-                                10: 10.0
-                                11: 11.0
-                      - key: 12
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                12: 12.0
-                                13: 13.0
-                                14: 14.0
-                                15: 15.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+              - key: 3
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+              - key: 6
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      9: 9.0
+                      10: 10.0
+                      11: 11.0
+              - key: 12
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      12: 12.0
+                      13: 13.0
+                      14: 14.0
+                      15: 15.0
 "#);
 }
 
@@ -1454,7 +1338,6 @@ fn insert_split_root_leaf() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1468,23 +1351,21 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 80
-          items:
-            0: 0.0
-            1: 1.0
-            2: 2.0
-            3: 3.0
-            4: 4.0
+    ptr: !Mem
+      Leaf:
+        credit: 80
+        items:
+          0: 0.0
+          1: 1.0
+          2: 2.0
+          3: 3.0
+          4: 4.0
   "#));
     let r2 = tree.clone().insert(5, 5.0, TxgT::from(42), Credit::forge(8))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -1497,34 +1378,31 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
-            - key: 3
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      3: 3.0
-                      4: 4.0
-                      5: 5.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
+        - key: 3
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                3: 3.0
+                4: 4.0
+                5: 5.0
 "#);
 }
 
@@ -1546,7 +1424,6 @@ fn get() {
 fn get_deep() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1560,32 +1437,29 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
   "#));
     let r = tree.get(3).now_or_never().unwrap();
     assert_eq!(r, Ok(Some(3.0)))
@@ -1614,7 +1488,6 @@ fn last_key_empty() {
 fn last_key() {
     let dml = Arc::new(mock_dml());
     let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1628,32 +1501,29 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
   "#);
     let r = tree.last_key().now_or_never().unwrap();
     assert_eq!(r, Ok(Some(4)))
@@ -1674,7 +1544,6 @@ fn range_delete() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1688,120 +1557,108 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1: 1.0
-                                2: 2.0
-                      - key: 5
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                5: 5.0
-                                6: 6.0
-                                7: 7.0
-                      - key: 10
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                10: 10.0
-                                11: 11.0
-            - key: 15
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-                      - key: 20
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                20: 20.0
-                                25: 25.0
-            - key: 30
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 31
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                31: 31.0
-                                32: 32.0
-                      - key: 37
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                37: 37.0
-                                40: 40.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1: 1.0
+                      2: 2.0
+              - key: 5
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+              - key: 10
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      10: 10.0
+                      11: 11.0
+        - key: 15
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+              - key: 20
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      20: 20.0
+                      25: 25.0
+        - key: 30
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 31
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      31: 31.0
+                      32: 32.0
+              - key: 37
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      37: 37.0
+                      40: 40.0
   "#));
     let r = tree.clone()
         .range_delete(11..=31, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -1814,46 +1671,42 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      1: 1.0
-                      2: 2.0
-            - key: 5
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
-                      10: 10.0
-            - key: 31
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      32: 32.0
-                      37: 37.0
-                      40: 40.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                1: 1.0
+                2: 2.0
+        - key: 5
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                5: 5.0
+                6: 6.0
+                7: 7.0
+                10: 10.0
+        - key: 31
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                32: 32.0
+                37: 37.0
+                40: 40.0
 "#);
 }
 
@@ -1864,7 +1717,6 @@ fn range_delete_danger() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1878,117 +1730,105 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1: 1.0
-                                2: 2.0
-                      - key: 5
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 80
-                              items:
-                                5: 5.0
-                                6: 6.0
-                                7: 7.0
-                                8: 8.0
-                                9: 9.0
-                      - key: 10
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Addr: 110
-            - key: 15
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-                      - key: 20
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                20: 20.0
-                                25: 25.0
-            - key: 30
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 31
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                31: 31.0
-                                32: 32.0
-                      - key: 37
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                37: 37.0
-                                40: 40.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1: 1.0
+                      2: 2.0
+              - key: 5
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 80
+                    items:
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+                      9: 9.0
+              - key: 10
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Addr 110
+        - key: 15
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+              - key: 20
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      20: 20.0
+                      25: 25.0
+        - key: 30
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 31
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      31: 31.0
+                      32: 32.0
+              - key: 37
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      37: 37.0
+                      40: 40.0
   "#));
     let r = tree.clone()
         .range_delete(5..6, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -2001,108 +1841,97 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1: 1.0
-                                2: 2.0
-                      - key: 5
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                6: 6.0
-                                7: 7.0
-                                8: 8.0
-                                9: 9.0
-                      - key: 10
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Addr: 110
-            - key: 15
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-                      - key: 20
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                20: 20.0
-                                25: 25.0
-            - key: 30
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 31
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                31: 31.0
-                                32: 32.0
-                      - key: 37
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                37: 37.0
-                                40: 40.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1: 1.0
+                      2: 2.0
+              - key: 5
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+                      9: 9.0
+              - key: 10
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Addr 110
+        - key: 15
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+              - key: 20
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      20: 20.0
+                      25: 25.0
+        - key: 30
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 31
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      31: 31.0
+                      32: 32.0
+              - key: 37
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      37: 37.0
+                      40: 40.0
 "#);
 }
 
@@ -2117,7 +1946,6 @@ fn range_delete_dclone() {
         .returning(|_, _| future::ok(()).boxed());
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, NeedsDcloneV>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2131,16 +1959,15 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 80
-          items:
-            4: 4
-            5: 5
-            6: 6
-            7: 7
-            8: 8
+    ptr: !Mem
+      Leaf:
+        credit: 80
+        items:
+          4: 4
+          5: 5
+          6: 6
+          7: 7
+          8: 8
   "#));
     let r = tree.range_delete(5..6, txg, Credit::forge(80))
         .now_or_never().unwrap();
@@ -2160,7 +1987,6 @@ fn range_delete_dclone_height2() {
     }
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, NeedsDcloneV>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2174,48 +2000,44 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      1: 1
-                      2: 2
-                      3: 3
-                      4: 4
-            - key: 11
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      11: 11
-                      12: 12
-                      13: 13
-            - key: 21
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      21: 21
-                      22: 22
-                      23: 23
-                      24: 24
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                1: 1
+                2: 2
+                3: 3
+                4: 4
+        - key: 11
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                11: 11
+                12: 12
+                13: 13
+        - key: 21
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                21: 21
+                22: 22
+                23: 23
+                24: 24
   "#));
     let r = tree.range_delete(4..22, txg, Credit::forge(240))
         .now_or_never().unwrap();
@@ -2243,7 +2065,6 @@ fn range_delete_exc_exc() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2257,60 +2078,55 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      1: 1.0
-                      2: 2.0
-            - key: 4
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      10: 10.0
-                      11: 11.0
-                      12: 12.0
-                      13: 13.0
-            - key: 20
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      20: 20.0
-                      21: 21.0
-                      22: 22.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                1: 1.0
+                2: 2.0
+        - key: 4
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                4: 4.0
+                5: 5.0
+                6: 6.0
+                7: 7.0
+                8: 8.0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                10: 10.0
+                11: 11.0
+                12: 12.0
+                13: 13.0
+        - key: 20
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                20: 20.0
+                21: 21.0
+                22: 22.0
   "#));
     let r = tree.clone()
         .range_delete(
@@ -2320,8 +2136,7 @@ root:
         ).now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -2334,47 +2149,43 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      1: 1.0
-                      2: 2.0
-            - key: 4
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      4: 4.0
-                      10: 10.0
-                      11: 11.0
-                      12: 12.0
-                      13: 13.0
-            - key: 20
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      20: 20.0
-                      21: 21.0
-                      22: 22.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                1: 1.0
+                2: 2.0
+        - key: 4
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                4: 4.0
+                10: 10.0
+                11: 11.0
+                12: 12.0
+                13: 13.0
+        - key: 20
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                20: 20.0
+                21: 21.0
+                22: 22.0
 "#);
 }
 
@@ -2384,7 +2195,6 @@ fn range_delete_exc_inc() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2398,60 +2208,55 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      1: 1.0
-                      2: 2.0
-            - key: 4
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      10: 10.0
-                      11: 11.0
-                      12: 12.0
-                      13: 13.0
-            - key: 20
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      20: 20.0
-                      21: 21.0
-                      22: 22.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                1: 1.0
+                2: 2.0
+        - key: 4
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                4: 4.0
+                5: 5.0
+                6: 6.0
+                7: 7.0
+                8: 8.0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                10: 10.0
+                11: 11.0
+                12: 12.0
+                13: 13.0
+        - key: 20
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                20: 20.0
+                21: 21.0
+                22: 22.0
   "#));
     let r = tree.clone()
         .range_delete(
@@ -2461,8 +2266,7 @@ root:
         ).now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -2475,46 +2279,42 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      1: 1.0
-                      2: 2.0
-            - key: 4
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      4: 4.0
-                      11: 11.0
-                      12: 12.0
-                      13: 13.0
-            - key: 20
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      20: 20.0
-                      21: 21.0
-                      22: 22.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                1: 1.0
+                2: 2.0
+        - key: 4
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                4: 4.0
+                11: 11.0
+                12: 12.0
+                13: 13.0
+        - key: 20
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                20: 20.0
+                21: 21.0
+                22: 22.0
 "#);
 }
 
@@ -2531,7 +2331,6 @@ fn range_delete_fix_three_times() {
 
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -2545,288 +2344,246 @@ root:
     txgs:
       start: 0
       end: 8
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 664
-              txgs:
-                start: 1
-                end: 5
-              ptr:
-                Addr: 3977
-            - key: 728
-              txgs:
-                start: 1
-                end: 8
-              ptr:
-                Addr: 100728
-            - key: 832
-              txgs:
-                start: 4
-                end: 8
-              ptr:
-                Mem:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 664
+          txgs:
+            start: 1
+            end: 5
+          ptr: !Addr 3977
+        - key: 728
+          txgs:
+            start: 1
+            end: 8
+          ptr: !Addr 100728
+        - key: 832
+          txgs:
+            start: 4
+            end: 8
+          ptr: !Mem
+            Int:
+              children:
+              - key: 832
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 832
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 832
-                                  txgs:
-                                    start: 7
-                                    end: 8
-                                  ptr:
-                                    Addr: 4627
-                                - key: 836
-                                  txgs:
-                                    start: 6
-                                    end: 7
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 48
-                                        items:
-                                          838: 646
-                                          839: 647
-                                          1027: 1814
-                                - key: 1028
-                                  txgs:
-                                    start: 7
-                                    end: 8
-                                  ptr:
-                                    Addr: 1001028
-                                - key: 1054
-                                  txgs:
-                                    start: 6
-                                    end: 7
-                                  ptr:
-                                    Addr: 8892
-                      - key: 1090
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 1090
-                                  txgs:
-                                    start: 7
-                                    end: 8
-                                  ptr:
-                                    Addr: 101090
-                                - key: 1130
-                                  txgs:
-                                    start: 6
-                                    end: 7
-                                  ptr:
-                                    Addr: 8894
-                                - key: 1170
-                                  txgs:
-                                    start: 7
-                                    end: 8
-                                  ptr:
-                                    Addr: 108894
-                                - key: 1297
-                                  txgs:
-                                    start: 6
-                                    end: 7
-                                  ptr:
-                                    Addr: 8897
-                                - key: 1314
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4054
-                      - key: 1318
-                        txgs:
-                          start: 4
-                          end: 7
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 1318
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4055
-                                - key: 1322
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4056
-                                - key: 1326
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4057
-                                - key: 1330
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4058
-                                - key: 1334
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4059
-            - key: 1466
-              txgs:
-                start: 4
-                end: 8
-              ptr:
-                Mem:
+                    - key: 832
+                      txgs:
+                        start: 7
+                        end: 8
+                      ptr: !Addr 4627
+                    - key: 836
+                      txgs:
+                        start: 6
+                        end: 7
+                      ptr: !Mem
+                        Leaf:
+                          credit: 48
+                          items:
+                            838: 646
+                            839: 647
+                            1027: 1814
+                    - key: 1028
+                      txgs:
+                        start: 7
+                        end: 8
+                      ptr: !Addr 1001028
+                    - key: 1054
+                      txgs:
+                        start: 6
+                        end: 7
+                      ptr: !Addr 8892
+              - key: 1090
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 1498
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 1498
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4100
-                                - key: 1502
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4101
-                                - key: 1506
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4102
-                                - key: 1510
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4103
-                      - key: 1514
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 1514
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4104
-                                - key: 1530
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 48
-                                        items:
-                                          1530: 2317
-                                          1535: 2322
-                                          1536: 984
-                                - key: 1537
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4109
-                      - key: 1540
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 1540
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4110
-                                - key: 1544
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4111
-                                - key: 1548
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4112
-            - key: 1552
-              txgs:
-                start: 4
-                end: 8
-              ptr:
-                Mem:
+                    - key: 1090
+                      txgs:
+                        start: 7
+                        end: 8
+                      ptr: !Addr 101090
+                    - key: 1130
+                      txgs:
+                        start: 6
+                        end: 7
+                      ptr: !Addr 8894
+                    - key: 1170
+                      txgs:
+                        start: 7
+                        end: 8
+                      ptr: !Addr 108894
+                    - key: 1297
+                      txgs:
+                        start: 6
+                        end: 7
+                      ptr: !Addr 8897
+                    - key: 1314
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4054
+              - key: 1318
+                txgs:
+                  start: 4
+                  end: 7
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 1552
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Addr: 10020
-                      - key: 1568
-                        txgs:
-                          start: 4
-                          end: 7
-                        ptr:
-                          Addr: 9592
-                      - key: 1624
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Addr: 10022
-                      - key: 1640
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Addr: 10024
-                      - key: 1656
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Addr: 10025
+                    - key: 1318
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4055
+                    - key: 1322
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4056
+                    - key: 1326
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4057
+                    - key: 1330
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4058
+                    - key: 1334
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4059
+        - key: 1466
+          txgs:
+            start: 4
+            end: 8
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1498
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Mem
+                  Int:
+                    children:
+                    - key: 1498
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4100
+                    - key: 1502
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4101
+                    - key: 1506
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4102
+                    - key: 1510
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4103
+              - key: 1514
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Mem
+                  Int:
+                    children:
+                    - key: 1514
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4104
+                    - key: 1530
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Mem
+                        Leaf:
+                          credit: 48
+                          items:
+                            1530: 2317
+                            1535: 2322
+                            1536: 984
+                    - key: 1537
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4109
+              - key: 1540
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Mem
+                  Int:
+                    children:
+                    - key: 1540
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4110
+                    - key: 1544
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4111
+                    - key: 1548
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4112
+        - key: 1552
+          txgs:
+            start: 4
+            end: 8
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1552
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Addr 10020
+              - key: 1568
+                txgs:
+                  start: 4
+                  end: 7
+                ptr: !Addr 9592
+              - key: 1624
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Addr 10022
+              - key: 1640
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Addr 10024
+              - key: 1656
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Addr 10025
   "#));
   let r = tree.clone()
       .range_delete(1024..1536, TxgT::from(42), Credit::forge(80))
       .now_or_never().unwrap();
   assert!(r.is_ok());
   assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 3
   max_int_fanout: 7
   min_leaf_fanout: 3
@@ -2839,118 +2596,101 @@ root:
     txgs:
       start: 0
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 664
-              txgs:
-                start: 1
-                end: 5
-              ptr:
-                Addr: 3977
-            - key: 728
-              txgs:
-                start: 1
-                end: 8
-              ptr:
-                Addr: 100728
-            - key: 832
-              txgs:
-                start: 4
-                end: 43
-              ptr:
-                Mem:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 664
+          txgs:
+            start: 1
+            end: 5
+          ptr: !Addr 3977
+        - key: 728
+          txgs:
+            start: 1
+            end: 8
+          ptr: !Addr 100728
+        - key: 832
+          txgs:
+            start: 4
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 832
+                txgs:
+                  start: 4
+                  end: 43
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 832
-                        txgs:
-                          start: 4
-                          end: 43
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 832
-                                  txgs:
-                                    start: 7
-                                    end: 8
-                                  ptr:
-                                    Addr: 4627
-                                - key: 836
-                                  txgs:
-                                    start: 42
-                                    end: 43
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 48
-                                        items:
-                                          838: 646
-                                          839: 647
-                                          1536: 984
-                                - key: 1537
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4109
-                                - key: 1540
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4110
-                                - key: 1544
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4111
-                                - key: 1548
-                                  txgs:
-                                    start: 4
-                                    end: 5
-                                  ptr:
-                                    Addr: 4112
-                      - key: 1552
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Addr: 10020
-                      - key: 1568
-                        txgs:
-                          start: 4
-                          end: 7
-                        ptr:
-                          Addr: 9592
-            - key: 1624
-              txgs:
-                start: 4
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1624
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Addr: 10022
-                      - key: 1640
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Addr: 10024
-                      - key: 1656
-                        txgs:
-                          start: 4
-                          end: 8
-                        ptr:
-                          Addr: 10025
+                    - key: 832
+                      txgs:
+                        start: 7
+                        end: 8
+                      ptr: !Addr 4627
+                    - key: 836
+                      txgs:
+                        start: 42
+                        end: 43
+                      ptr: !Mem
+                        Leaf:
+                          credit: 48
+                          items:
+                            838: 646
+                            839: 647
+                            1536: 984
+                    - key: 1537
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4109
+                    - key: 1540
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4110
+                    - key: 1544
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4111
+                    - key: 1548
+                      txgs:
+                        start: 4
+                        end: 5
+                      ptr: !Addr 4112
+              - key: 1552
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Addr 10020
+              - key: 1568
+                txgs:
+                  start: 4
+                  end: 7
+                ptr: !Addr 9592
+        - key: 1624
+          txgs:
+            start: 4
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1624
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Addr 10022
+              - key: 1640
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Addr 10024
+              - key: 1656
+                txgs:
+                  start: 4
+                  end: 8
+                ptr: !Addr 10025
 "#);
 }
 
@@ -2961,7 +2701,6 @@ fn range_delete_merge_and_underflow() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -2975,70 +2714,64 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      1: 1.0
-                      2: 2.0
-                      3: 3.0
-            - key: 4
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-            - key: 7
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      7: 7.0
-                      8: 8.0
-                      9: 9.0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      10: 10.0
-                      11: 11.0
-                      12: 12.0
-            - key: 13
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      13: 13.0
-                      14: 14.0
-                      15: 15.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                1: 1.0
+                2: 2.0
+                3: 3.0
+        - key: 4
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                4: 4.0
+                5: 5.0
+                6: 6.0
+        - key: 7
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                7: 7.0
+                8: 8.0
+                9: 9.0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                10: 10.0
+                11: 11.0
+                12: 12.0
+        - key: 13
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                13: 13.0
+                14: 14.0
+                15: 15.0
   "#));
     let r = tree.clone()
         .range_delete(2..6, TxgT::from(42), Credit::forge(80))
@@ -3046,8 +2779,7 @@ root:
     assert!(r.is_ok());
     assert!(tree.clone().check().now_or_never().unwrap().unwrap());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 3
   max_int_fanout: 7
   min_leaf_fanout: 3
@@ -3060,48 +2792,44 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      1: 1.0
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
-                      9: 9.0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      10: 10.0
-                      11: 11.0
-                      12: 12.0
-            - key: 13
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      13: 13.0
-                      14: 14.0
-                      15: 15.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                1: 1.0
+                6: 6.0
+                7: 7.0
+                8: 8.0
+                9: 9.0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                10: 10.0
+                11: 11.0
+                12: 12.0
+        - key: 13
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                13: 13.0
+                14: 14.0
+                15: 15.0
 "#);
 }
 
@@ -3112,7 +2840,6 @@ fn range_delete_merge_and_parent_underflow() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -3126,112 +2853,99 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                1: 1.0
-                                2: 2.0
-                                3: 3.0
-                      - key: 4
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                4: 4.0
-                                5: 5.0
-                                6: 6.0
-                      - key: 7
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                7: 7.0
-                                8: 8.0
-                                9: 9.0
-                      - key: 10
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 10010
-            - key: 20
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 20
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                20: 20.0
-                                21: 21.0
-                                22: 22.0
-                      - key: 23
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 10023
-                      - key: 26
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 10026
-            - key: 30
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 300
-            - key: 40
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 10040
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      1: 1.0
+                      2: 2.0
+                      3: 3.0
+              - key: 4
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+              - key: 7
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      7: 7.0
+                      8: 8.0
+                      9: 9.0
+              - key: 10
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 10010
+        - key: 20
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Mem
+            Int:
+              children:
+              - key: 20
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+              - key: 23
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 10023
+              - key: 26
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 10026
+        - key: 30
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Addr 300
+        - key: 40
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Addr 10040
   "#));
     let r = tree.clone()
         .range_delete(2..6, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 3
   max_int_fanout: 7
   min_leaf_fanout: 3
@@ -3244,74 +2958,65 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 80
-                              items:
-                                1: 1.0
-                                6: 6.0
-                                7: 7.0
-                                8: 8.0
-                                9: 9.0
-                      - key: 10
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 10010
-                      - key: 20
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                20: 20.0
-                                21: 21.0
-                                22: 22.0
-                      - key: 23
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 10023
-                      - key: 26
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 10026
-            - key: 30
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 300
-            - key: 40
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 10040
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 80
+                    items:
+                      1: 1.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+                      9: 9.0
+              - key: 10
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 10010
+              - key: 20
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+              - key: 23
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 10023
+              - key: 26
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 10026
+        - key: 30
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Addr 300
+        - key: 40
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Addr 10040
 "#);
 }
 
@@ -3323,7 +3028,6 @@ fn range_delete_merge_descending_and_ascending() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -3337,130 +3041,117 @@ root:
     txgs:
       start: 0
       end: 3
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 452
-              txgs:
-                start: 2
-                end: 3
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 452
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                462: 458
-                                494: 490
-                      - key: 1021
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1025: 835
-                                1027: 837
-            - key: 1245
-              txgs:
-                start: 2
-                end: 3
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1309
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1313: 1123
-                                1316: 1126
-                      - key: 1341
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1368: 1178
-                                1662: 518
-            - key: 1663
-              txgs:
-                start: 2
-                end: 3
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1663
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1663: 523
-                                1666: 547
-                      - key: 1687
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1687: 776
-                                1690: 779
-            - key: 1727
-              txgs:
-                start: 2
-                end: 3
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1727
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1727: 828
-                                1730: 832
-                      - key: 1759
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1759: 861
-                                1762: 864
+    ptr: !Mem
+      Int:
+        children:
+        - key: 452
+          txgs:
+            start: 2
+            end: 3
+          ptr: !Mem
+            Int:
+              children:
+              - key: 452
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      462: 458
+                      494: 490
+              - key: 1021
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1025: 835
+                      1027: 837
+        - key: 1245
+          txgs:
+            start: 2
+            end: 3
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1309
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1313: 1123
+                      1316: 1126
+              - key: 1341
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1368: 1178
+                      1662: 518
+        - key: 1663
+          txgs:
+            start: 2
+            end: 3
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1663
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1663: 523
+                      1666: 547
+              - key: 1687
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1687: 776
+                      1690: 779
+        - key: 1727
+          txgs:
+            start: 2
+            end: 3
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1727
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1727: 828
+                      1730: 832
+              - key: 1759
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1759: 861
+                      1762: 864
   "#));
     assert!(tree.clone().check().now_or_never().unwrap().unwrap());
     let r = tree.clone()
@@ -3477,7 +3168,6 @@ fn range_delete_merge_left_child_twice() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 5
   max_int_fanout: 12
@@ -3491,88 +3181,81 @@ root:
     txgs:
       start: 2
       end: 15
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
-                      3: 3.0
-                      4: 4.0
-            - key: 10
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      10: 10.0
-                      11: 11.0
-                      12: 12.0
-                      13: 13.0
-                      14: 14.0
-            - key: 20
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      20: 20.0
-                      21: 21.0
-                      22: 22.0
-                      23: 23.0
-                      24: 24.0
-            - key: 30
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      30: 30.0
-                      31: 31.0
-                      32: 32.0
-                      33: 33.0
-                      34: 34.0
-            - key: 40
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      40: 40.0
-                      41: 41.0
-                      42: 42.0
-                      43: 43.0
-                      44: 44.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
+                3: 3.0
+                4: 4.0
+        - key: 10
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                10: 10.0
+                11: 11.0
+                12: 12.0
+                13: 13.0
+                14: 14.0
+        - key: 20
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                20: 20.0
+                21: 21.0
+                22: 22.0
+                23: 23.0
+                24: 24.0
+        - key: 30
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                30: 30.0
+                31: 31.0
+                32: 32.0
+                33: 33.0
+                34: 34.0
+        - key: 40
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                40: 40.0
+                41: 41.0
+                42: 42.0
+                43: 43.0
+                44: 44.0
   "#));
     let r = tree.clone()
         .range_delete(12..23, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 5
   max_int_fanout: 12
   min_leaf_fanout: 5
@@ -3585,56 +3268,52 @@ root:
     txgs:
       start: 2
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
-                      3: 3.0
-                      4: 4.0
-            - key: 10
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 144
-                    items:
-                      10: 10.0
-                      11: 11.0
-                      23: 23.0
-                      24: 24.0
-                      30: 30.0
-                      31: 31.0
-                      32: 32.0
-                      33: 33.0
-                      34: 34.0
-            - key: 40
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      40: 40.0
-                      41: 41.0
-                      42: 42.0
-                      43: 43.0
-                      44: 44.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
+                3: 3.0
+                4: 4.0
+        - key: 10
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 144
+              items:
+                10: 10.0
+                11: 11.0
+                23: 23.0
+                24: 24.0
+                30: 30.0
+                31: 31.0
+                32: 32.0
+                33: 33.0
+                34: 34.0
+        - key: 40
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                40: 40.0
+                41: 41.0
+                42: 42.0
+                43: 43.0
+                44: 44.0
 "#);
 }
 
@@ -3646,7 +3325,6 @@ fn range_delete_merge_to_lca_twice() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -3660,202 +3338,176 @@ root:
     txgs:
       start: 0
       end: 10
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 10422
-              txgs:
-                start: 7
-                end: 10
-              ptr:
-                Addr: 1010422
-            - key: 10694
-              txgs:
-                start: 7
-                end: 9
-              ptr:
-                Mem:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 10422
+          txgs:
+            start: 7
+            end: 10
+          ptr: !Addr 1010422
+        - key: 10694
+          txgs:
+            start: 7
+            end: 9
+          ptr: !Mem
+            Int:
+              children:
+              - key: 10694
+                txgs:
+                  start: 7
+                  end: 8
+                ptr: !Addr 11632
+              - key: 10710
+                txgs:
+                  start: 7
+                  end: 9
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 10694
-                        txgs:
-                          start: 7
-                          end: 8
-                        ptr:
-                          Addr: 11632
-                      - key: 10710
-                        txgs:
-                          start: 7
-                          end: 9
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 10711
-                                  txgs:
-                                    start: 7
-                                    end: 8
-                                  ptr:
-                                    Addr: 11432
-                                - key: 10714
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 48
-                                        items:
-                                          10714: 5916
-                                          11722: 3874
-                                          11725: 3877
-                                - key: 11730
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 48
-                                        items:
-                                          10726: 5916
-                                          11727: 3874
-                                          11729: 3877
-                      - key: 11734
-                        txgs:
-                          start: 8
-                          end: 9
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 11734
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 48
-                                        items:
-                                          10738: 5916
-                                          11739: 3874
-                                          11741: 3877
-                                - key: 11742
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 48
-                                        items:
-                                          11742: 3927
-                                          11744: 3938
-                                          11781: 4342
-                                - key: 11782
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 48
-                                        items:
-                                          11782: 4343
-                                          11784: 4345
-                                          11785: 4346
-                      - key: 11786
-                        txgs:
-                          start: 8
-                          end: 9
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 11786
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Addr: 7170
-                                - key: 11790
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Addr: 7171
-                                - key: 11794
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Addr: 7172
-                                - key: 11798
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Addr: 7173
-            - key: 11802
-              txgs:
-                start: 8
-                end: 10
-              ptr:
-                Mem:
+                    - key: 10711
+                      txgs:
+                        start: 7
+                        end: 8
+                      ptr: !Addr 11432
+                    - key: 10714
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Mem
+                        Leaf:
+                          credit: 48
+                          items:
+                            10714: 5916
+                            11722: 3874
+                            11725: 3877
+                    - key: 11730
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Mem
+                        Leaf:
+                          credit: 48
+                          items:
+                            10726: 5916
+                            11727: 3874
+                            11729: 3877
+              - key: 11734
+                txgs:
+                  start: 8
+                  end: 9
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 11802
-                        txgs:
-                          start: 8
-                          end: 10
-                        ptr:
-                          Addr: 111802
-                      - key: 11865
-                        txgs:
-                          start: 8
-                          end: 9
-                        ptr:
-                          Addr: 7605
-                      - key: 11881
-                        txgs:
-                          start: 8
-                          end: 9
-                        ptr:
-                          Addr: 7606
-                      - key: 11897
-                        txgs:
-                          start: 8
-                          end: 9
-                        ptr:
-                          Addr: 7607
-                      - key: 12018
-                        txgs:
-                          start: 8
-                          end: 10
-                        ptr:
-                          Addr: 112018
-            - key: 12050
-              txgs:
-                start: 8
-                end: 9
-              ptr:
-                Addr: 7713
-            - key: 12114
-              txgs:
-                start: 8
-                end: 10
-              ptr:
-                Addr: 112144
+                    - key: 11734
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Mem
+                        Leaf:
+                          credit: 48
+                          items:
+                            10738: 5916
+                            11739: 3874
+                            11741: 3877
+                    - key: 11742
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Mem
+                        Leaf:
+                          credit: 48
+                          items:
+                            11742: 3927
+                            11744: 3938
+                            11781: 4342
+                    - key: 11782
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Mem
+                        Leaf:
+                          credit: 48
+                          items:
+                            11782: 4343
+                            11784: 4345
+                            11785: 4346
+              - key: 11786
+                txgs:
+                  start: 8
+                  end: 9
+                ptr: !Mem
+                  Int:
+                    children:
+                    - key: 11786
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Addr 7170
+                    - key: 11790
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Addr 7171
+                    - key: 11794
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Addr 7172
+                    - key: 11798
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Addr 7173
+        - key: 11802
+          txgs:
+            start: 8
+            end: 10
+          ptr: !Mem
+            Int:
+              children:
+              - key: 11802
+                txgs:
+                  start: 8
+                  end: 10
+                ptr: !Addr 111802
+              - key: 11865
+                txgs:
+                  start: 8
+                  end: 9
+                ptr: !Addr 7605
+              - key: 11881
+                txgs:
+                  start: 8
+                  end: 9
+                ptr: !Addr 7606
+              - key: 11897
+                txgs:
+                  start: 8
+                  end: 9
+                ptr: !Addr 7607
+              - key: 12018
+                txgs:
+                  start: 8
+                  end: 10
+                ptr: !Addr 112018
+        - key: 12050
+          txgs:
+            start: 8
+            end: 9
+          ptr: !Addr 7713
+        - key: 12114
+          txgs:
+            start: 8
+            end: 10
+          ptr: !Addr 112144
   "#));
     let r = tree.clone()
         .range_delete(11264..11776, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 3
   max_int_fanout: 7
   min_leaf_fanout: 3
@@ -3868,140 +3520,120 @@ root:
     txgs:
       start: 0
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 10422
-              txgs:
-                start: 7
-                end: 10
-              ptr:
-                Addr: 1010422
-            - key: 10694
-              txgs:
-                start: 7
-                end: 43
-              ptr:
-                Mem:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 10422
+          txgs:
+            start: 7
+            end: 10
+          ptr: !Addr 1010422
+        - key: 10694
+          txgs:
+            start: 7
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 10694
+                txgs:
+                  start: 7
+                  end: 8
+                ptr: !Addr 11632
+              - key: 10710
+                txgs:
+                  start: 7
+                  end: 43
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 10694
-                        txgs:
-                          start: 7
-                          end: 8
-                        ptr:
-                          Addr: 11632
-                      - key: 10710
-                        txgs:
-                          start: 7
-                          end: 43
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 10711
-                                  txgs:
-                                    start: 7
-                                    end: 8
-                                  ptr:
-                                    Addr: 11432
-                                - key: 10714
-                                  txgs:
-                                    start: 42
-                                    end: 43
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 80
-                                        items:
-                                          10714: 5916
-                                          11781: 4342
-                                          11782: 4343
-                                          11784: 4345
-                                          11785: 4346
-                                - key: 11786
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Addr: 7170
-                      - key: 11790
-                        txgs:
-                          start: 8
-                          end: 43
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 11790
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Addr: 7171
-                                - key: 11794
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Addr: 7172
-                                - key: 11798
-                                  txgs:
-                                    start: 8
-                                    end: 9
-                                  ptr:
-                                    Addr: 7173
-                      - key: 11802
-                        txgs:
-                          start: 8
-                          end: 10
-                        ptr:
-                          Addr: 111802
-            - key: 11865
-              txgs:
-                start: 8
-                end: 43
-              ptr:
-                Mem:
+                    - key: 10711
+                      txgs:
+                        start: 7
+                        end: 8
+                      ptr: !Addr 11432
+                    - key: 10714
+                      txgs:
+                        start: 42
+                        end: 43
+                      ptr: !Mem
+                        Leaf:
+                          credit: 80
+                          items:
+                            10714: 5916
+                            11781: 4342
+                            11782: 4343
+                            11784: 4345
+                            11785: 4346
+                    - key: 11786
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Addr 7170
+              - key: 11790
+                txgs:
+                  start: 8
+                  end: 43
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 11865
-                        txgs:
-                          start: 8
-                          end: 9
-                        ptr:
-                          Addr: 7605
-                      - key: 11881
-                        txgs:
-                          start: 8
-                          end: 9
-                        ptr:
-                          Addr: 7606
-                      - key: 11897
-                        txgs:
-                          start: 8
-                          end: 9
-                        ptr:
-                          Addr: 7607
-                      - key: 12018
-                        txgs:
-                          start: 8
-                          end: 10
-                        ptr:
-                          Addr: 112018
-            - key: 12050
-              txgs:
-                start: 8
-                end: 9
-              ptr:
-                Addr: 7713
-            - key: 12114
-              txgs:
-                start: 8
-                end: 10
-              ptr:
-                Addr: 112144
+                    - key: 11790
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Addr 7171
+                    - key: 11794
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Addr 7172
+                    - key: 11798
+                      txgs:
+                        start: 8
+                        end: 9
+                      ptr: !Addr 7173
+              - key: 11802
+                txgs:
+                  start: 8
+                  end: 10
+                ptr: !Addr 111802
+        - key: 11865
+          txgs:
+            start: 8
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 11865
+                txgs:
+                  start: 8
+                  end: 9
+                ptr: !Addr 7605
+              - key: 11881
+                txgs:
+                  start: 8
+                  end: 9
+                ptr: !Addr 7606
+              - key: 11897
+                txgs:
+                  start: 8
+                  end: 9
+                ptr: !Addr 7607
+              - key: 12018
+                txgs:
+                  start: 8
+                  end: 10
+                ptr: !Addr 112018
+        - key: 12050
+          txgs:
+            start: 8
+            end: 9
+          ptr: !Addr 7713
+        - key: 12114
+          txgs:
+            start: 8
+            end: 10
+          ptr: !Addr 112144
 "#);
 }
 
@@ -4014,7 +3646,6 @@ fn range_delete_merge_right_child_descending() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 4
   max_int_fanout: 10
@@ -4028,70 +3659,64 @@ root:
     txgs:
       start: 2
       end: 15
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 4898
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      4903: 3431
-                      4993: 3521
-                      5045: 3573
-                      5583: 2277
-            - key: 5618
-              txgs:
-                start: 13
-                end: 14
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      5618: 5459
-                      5623: 5464
-                      5624: 5465
-                      5625: 5466
-            - key: 5626
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      5629: 5470
-                      5630: 5471
-                      5631: 5472
-                      5632: 7554
-            - key: 5634
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      5635: 7557
-                      5637: 7559
-                      5638: 7560
-                      5642: 7564
+    ptr: !Mem
+      Int:
+        children:
+        - key: 4898
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                4903: 3431
+                4993: 3521
+                5045: 3573
+                5583: 2277
+        - key: 5618
+          txgs:
+            start: 13
+            end: 14
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                5618: 5459
+                5623: 5464
+                5624: 5465
+                5625: 5466
+        - key: 5626
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                5629: 5470
+                5630: 5471
+                5631: 5472
+                5632: 7554
+        - key: 5634
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                5635: 7557
+                5637: 7559
+                5638: 7560
+                5642: 7564
   "#));
     let r = tree.clone()
         .range_delete(5120..5632, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 4
   max_int_fanout: 10
   min_leaf_fanout: 4
@@ -4104,36 +3729,33 @@ root:
     txgs:
       start: 2
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 4898
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      4903: 3431
-                      4993: 3521
-                      5045: 3573
-                      5632: 7554
-            - key: 5634
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      5635: 7557
-                      5637: 7559
-                      5638: 7560
-                      5642: 7564
+    ptr: !Mem
+      Int:
+        children:
+        - key: 4898
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                4903: 3431
+                4993: 3521
+                5045: 3573
+                5632: 7554
+        - key: 5634
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                5635: 7557
+                5637: 7559
+                5638: 7560
+                5642: 7564
 "#);
 }
 
@@ -4147,7 +3769,6 @@ fn range_delete_merge_right_child_first() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 4
   max_int_fanout: 10
@@ -4161,128 +3782,114 @@ root:
     txgs:
       start: 4
       end: 15
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 7148
-              txgs:
-                start: 13
-                end: 15
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 7148
-                        txgs:
-                          start: 14
-                          end: 15
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                7153: 6699
-                                7156: 6702
-                                7164: 6710
-                                7173: 6719
-                      - key: 7252
-                        txgs:
-                          start: 13
-                          end: 1
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                7252: 6798
-                                7253: 6799
-                                7254: 6800
-                                7255: 6801
-                      - key: 7260
-                        txgs:
-                          start: 13
-                          end: 14
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                7260: 6806
-                                7265: 6811
-                                7266: 6812
-                                7267: 6813
-                      - key: 7268
-                        txgs:
-                          start: 14
-                          end: 15
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                7281: 6827
-                                7282: 6828
-                                7287: 6833
-                                7735: 5525
-            - key: 7736
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 7736
-                        txgs:
-                          start: 14
-                          end: 15
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                7736: 5527
-                                7737: 5538
-                                7738: 5540
-                                7739: 5543
-                      - key: 7744
-                        txgs:
-                          start: 14
-                          end: 15
-                        ptr:
-                          Addr: 1007744
-                      - key: 7752
-                        txgs:
-                          start: 14
-                          end: 15
-                        ptr:
-                          Addr: 1007752
-                      - key: 7760
-                        txgs:
-                          start: 14
-                          end: 15
-                        ptr:
-                          Addr: 1007760
-            - key: 7840
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Addr: 7693
-            - key: 8000
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Addr: 7692
+    ptr: !Mem
+      Int:
+        children:
+        - key: 7148
+          txgs:
+            start: 13
+            end: 15
+          ptr: !Mem
+            Int:
+              children:
+              - key: 7148
+                txgs:
+                  start: 14
+                  end: 15
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      7153: 6699
+                      7156: 6702
+                      7164: 6710
+                      7173: 6719
+              - key: 7252
+                txgs:
+                  start: 13
+                  end: 1
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      7252: 6798
+                      7253: 6799
+                      7254: 6800
+                      7255: 6801
+              - key: 7260
+                txgs:
+                  start: 13
+                  end: 14
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      7260: 6806
+                      7265: 6811
+                      7266: 6812
+                      7267: 6813
+              - key: 7268
+                txgs:
+                  start: 14
+                  end: 15
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      7281: 6827
+                      7282: 6828
+                      7287: 6833
+                      7735: 5525
+        - key: 7736
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Mem
+            Int:
+              children:
+              - key: 7736
+                txgs:
+                  start: 14
+                  end: 15
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      7736: 5527
+                      7737: 5538
+                      7738: 5540
+                      7739: 5543
+              - key: 7744
+                txgs:
+                  start: 14
+                  end: 15
+                ptr: !Addr 1007744
+              - key: 7752
+                txgs:
+                  start: 14
+                  end: 15
+                ptr: !Addr 1007752
+              - key: 7760
+                txgs:
+                  start: 14
+                  end: 15
+                ptr: !Addr 1007760
+        - key: 7840
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Addr 7693
+        - key: 8000
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Addr 7692
   "#));
     tree.clone()
         .range_delete(7168..7680, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap().unwrap();
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 4
   max_int_fanout: 10
   min_leaf_fanout: 4
@@ -4295,74 +3902,65 @@ root:
     txgs:
       start: 4
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 7148
-              txgs:
-                start: 14
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 7148
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                7153: 6699
-                                7156: 6702
-                                7164: 6710
-                                7735: 5525
-                      - key: 7736
-                        txgs:
-                          start: 14
-                          end: 15
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                7736: 5527
-                                7737: 5538
-                                7738: 5540
-                                7739: 5543
-                      - key: 7744
-                        txgs:
-                          start: 14
-                          end: 15
-                        ptr:
-                          Addr: 1007744
-                      - key: 7752
-                        txgs:
-                          start: 14
-                          end: 15
-                        ptr:
-                          Addr: 1007752
-                      - key: 7760
-                        txgs:
-                          start: 14
-                          end: 15
-                        ptr:
-                          Addr: 1007760
-            - key: 7840
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Addr: 7693
-            - key: 8000
-              txgs:
-                start: 14
-                end: 15
-              ptr:
-                Addr: 7692
+    ptr: !Mem
+      Int:
+        children:
+        - key: 7148
+          txgs:
+            start: 14
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 7148
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      7153: 6699
+                      7156: 6702
+                      7164: 6710
+                      7735: 5525
+              - key: 7736
+                txgs:
+                  start: 14
+                  end: 15
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      7736: 5527
+                      7737: 5538
+                      7738: 5540
+                      7739: 5543
+              - key: 7744
+                txgs:
+                  start: 14
+                  end: 15
+                ptr: !Addr 1007744
+              - key: 7752
+                txgs:
+                  start: 14
+                  end: 15
+                ptr: !Addr 1007752
+              - key: 7760
+                txgs:
+                  start: 14
+                  end: 15
+                ptr: !Addr 1007760
+        - key: 7840
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Addr 7693
+        - key: 8000
+          txgs:
+            start: 14
+            end: 15
+          ptr: !Addr 7692
 "#);
 }
 
@@ -4372,7 +3970,6 @@ fn range_delete_merge_root() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -4386,44 +3983,40 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      1: 1.0
-                      2: 2.0
-                      3: 3.0
-            - key: 4
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                1: 1.0
+                2: 2.0
+                3: 3.0
+        - key: 4
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                4: 4.0
+                5: 5.0
+                6: 6.0
+                7: 7.0
+                8: 8.0
   "#));
     let r = tree.clone()
         .range_delete(0..4, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -4436,16 +4029,15 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 80
-          items:
-            4: 4.0
-            5: 5.0
-            6: 6.0
-            7: 7.0
-            8: 8.0
+    ptr: !Mem
+      Leaf:
+        credit: 80
+        items:
+          4: 4.0
+          5: 5.0
+          6: 6.0
+          7: 7.0
+          8: 8.0
 "#);
 }
 
@@ -4458,7 +4050,6 @@ fn range_delete_merge_root_during_ascent() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -4472,150 +4063,136 @@ root:
     txgs:
       start: 2
       end: 14
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 2762
-              txgs:
-                start: 12
-                end: 14
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 2778
-                        txgs:
-                          start: 12
-                          end: 13
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                2778: 2859
-                                2781: 2868
-                                2782: 2869
-                      - key: 2788
-                        txgs:
-                          start: 13
-                          end: 14
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                2965: 4758
-                                3027: 4820
-                                3074: 6186
-                      - key: 3077
-                        txgs:
-                          start: 13
-                          end: 14
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3081: 6193
-                                3085: 6197
-                                3088: 6200
-            - key: 3109
-              txgs:
-                start: 12
-                end: 14
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 3109
-                        txgs:
-                          start: 13
-                          end: 14
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3112: 6224
-                                3113: 6225
-                                3122: 6234
-                      - key: 3149
-                        txgs:
-                          start: 13
-                          end: 14
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3149: 6261
-                                3153: 6265
-                                3154: 6266
-                      - key: 3157
-                        txgs:
-                          start: 13
-                          end: 14
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3157: 6269
-                                3166: 6278
-                                3167: 6279
-            - key: 3365
-              txgs:
-                start: 13
-                end: 14
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 3509
-                        txgs:
-                          start: 13
-                          end: 14
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3509: 6621
-                                3531: 6643
-                                3532: 6644
-                      - key: 3541
-                        txgs:
-                          start: 13
-                          end: 14
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3546: 6658
-                                3547: 6659
-                                3572: 6684
-                      - key: 3573
-                        txgs:
-                          start: 13
-                          end: 14
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3581: 6693
-                                3584: 3091
-                                3585: 3092
+    ptr: !Mem
+      Int:
+        children:
+        - key: 2762
+          txgs:
+            start: 12
+            end: 14
+          ptr: !Mem
+            Int:
+              children:
+              - key: 2778
+                txgs:
+                  start: 12
+                  end: 13
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      2778: 2859
+                      2781: 2868
+                      2782: 2869
+              - key: 2788
+                txgs:
+                  start: 13
+                  end: 14
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      2965: 4758
+                      3027: 4820
+                      3074: 6186
+              - key: 3077
+                txgs:
+                  start: 13
+                  end: 14
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3081: 6193
+                      3085: 6197
+                      3088: 6200
+        - key: 3109
+          txgs:
+            start: 12
+            end: 14
+          ptr: !Mem
+            Int:
+              children:
+              - key: 3109
+                txgs:
+                  start: 13
+                  end: 14
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3112: 6224
+                      3113: 6225
+                      3122: 6234
+              - key: 3149
+                txgs:
+                  start: 13
+                  end: 14
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3149: 6261
+                      3153: 6265
+                      3154: 6266
+              - key: 3157
+                txgs:
+                  start: 13
+                  end: 14
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3157: 6269
+                      3166: 6278
+                      3167: 6279
+        - key: 3365
+          txgs:
+            start: 13
+            end: 14
+          ptr: !Mem
+            Int:
+              children:
+              - key: 3509
+                txgs:
+                  start: 13
+                  end: 14
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3509: 6621
+                      3531: 6643
+                      3532: 6644
+              - key: 3541
+                txgs:
+                  start: 13
+                  end: 14
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3546: 6658
+                      3547: 6659
+                      3572: 6684
+              - key: 3573
+                txgs:
+                  start: 13
+                  end: 14
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3581: 6693
+                      3584: 3091
+                      3585: 3092
   "#));
     let r = tree.clone()
         .range_delete(3072..3584, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 3
   max_int_fanout: 7
   min_leaf_fanout: 3
@@ -4628,35 +4205,32 @@ root:
     txgs:
       start: 12
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 2778
-              txgs:
-                start: 12
-                end: 13
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      2778: 2859
-                      2781: 2868
-                      2782: 2869
-            - key: 2788
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      2965: 4758
-                      3027: 4820
-                      3584: 3091
-                      3585: 3092
+    ptr: !Mem
+      Int:
+        children:
+        - key: 2778
+          txgs:
+            start: 12
+            end: 13
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                2778: 2859
+                2781: 2868
+                2782: 2869
+        - key: 2788
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                2965: 4758
+                3027: 4820
+                3584: 3091
+                3585: 3092
 "#);
 }
 
@@ -4666,7 +4240,6 @@ fn range_delete_merge_root_twice() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -4680,86 +4253,78 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                1: 1.0
-                                2: 2.0
-                                3: 3.0
-                      - key: 4
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 80
-                              items:
-                                4: 4.0
-                                5: 5.0
-                                6: 6.0
-                                7: 7.0
-                                8: 8.0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 10
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                10: 10.0
-                                11: 11.0
-                                12: 12.0
-                      - key: 13
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 80
-                              items:
-                                13: 13.0
-                                14: 14.0
-                                15: 15.0
-                                16: 16.0
-                                17: 17.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      1: 1.0
+                      2: 2.0
+                      3: 3.0
+              - key: 4
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 80
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+                      7: 7.0
+                      8: 8.0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 10
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+              - key: 13
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 80
+                    items:
+                      13: 13.0
+                      14: 14.0
+                      15: 15.0
+                      16: 16.0
+                      17: 17.0
   "#));
     let r = tree.clone()
         .range_delete(0..13, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -4772,16 +4337,15 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 80
-          items:
-            13: 13.0
-            14: 14.0
-            15: 15.0
-            16: 16.0
-            17: 17.0
+    ptr: !Mem
+      Leaf:
+        credit: 80
+        items:
+          13: 13.0
+          14: 14.0
+          15: 15.0
+          16: 16.0
+          17: 17.0
 "#);
 }
 
@@ -4793,7 +4357,6 @@ fn range_delete_parent_and_child_underflow_after_descent() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 4
   max_int_fanout: 17
@@ -4807,217 +4370,193 @@ root:
     txgs:
       start: 0
       end: 11
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 11
-              ptr:
-                Addr: 1000000
-            - key: 2218
-              txgs:
-                start: 5
-                end: 11
-              ptr:
-                Addr: 1002218
-            - key: 3563
-              txgs:
-                start: 8
-                end: 11
-              ptr:
-                Mem:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 11
+          ptr: !Addr 1000000
+        - key: 2218
+          txgs:
+            start: 5
+            end: 11
+          ptr: !Addr 1002218
+        - key: 3563
+          txgs:
+            start: 8
+            end: 11
+          ptr: !Mem
+            Int:
+              children:
+              - key: 3563
+                txgs:
+                  start: 9
+                  end: 11
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 3563
-                        txgs:
-                          start: 9
-                          end: 11
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 3563
-                                  txgs:
-                                    start: 9
-                                    end: 10
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          3563: 2604
-                                          3564: 2605
-                                          3565: 2606
-                                          3566: 2607
-                                - key: 3611
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          3613: 3005
-                                          3621: 3013
-                                          3624: 3016
-                                          3625: 3017
-                                - key: 3627
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          3627: 3019
-                                          3640: 3032
-                                          3641: 3033
-                                          3642: 3034
-                                - key: 3643
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          3643: 3035
-                                          3664: 3056
-                                          3665: 3057
-                                          3666: 3058
-                      - key: 4051
-                        txgs:
-                          start: 8
-                          end: 11
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 4075
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          4075: 3467
-                                          4076: 3468
-                                          4077: 3469
-                                          4078: 3470
-                                - key: 4083
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          4083: 3475
-                                          4084: 3476
-                                          4085: 3477
-                                          4086: 3478
-                                - key: 4091
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 80
-                                        items:
-                                          4091: 3483
-                                          4092: 3484
-                                          4093: 3485
-                                          4094: 3486
-                                          4095: 3487
-                                - key: 4604
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          4609: 3745
-                                          4610: 3746
-                                          4614: 3750
-                                          4615: 3751
-            - key: 4620
-              txgs:
-                start: 9
-                end: 11
-              ptr:
-                Mem:
+                    - key: 3563
+                      txgs:
+                        start: 9
+                        end: 10
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            3563: 2604
+                            3564: 2605
+                            3565: 2606
+                            3566: 2607
+                    - key: 3611
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            3613: 3005
+                            3621: 3013
+                            3624: 3016
+                            3625: 3017
+                    - key: 3627
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            3627: 3019
+                            3640: 3032
+                            3641: 3033
+                            3642: 3034
+                    - key: 3643
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            3643: 3035
+                            3664: 3056
+                            3665: 3057
+                            3666: 3058
+              - key: 4051
+                txgs:
+                  start: 8
+                  end: 11
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 4620
-                        txgs:
-                          start: 9
-                          end: 11
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 4620
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Addr: 1004620
-                                - key: 4628
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Addr: 1004628
-                                - key: 4636
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Addr: 1004636
-                                - key: 4644
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Addr: 1004644
-                      - key: 4684
-                        txgs:
-                          start: 9
-                          end: 11
-                        ptr:
-                          Addr: 1004684
-                      - key: 4748
-                        txgs:
-                          start: 9
-                          end: 11
-                        ptr:
-                          Addr: 1004748
-                      - key: 5119
-                        txgs:
-                          start: 9
-                          end: 11
-                        ptr:
-                          Addr: 1005119
+                    - key: 4075
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            4075: 3467
+                            4076: 3468
+                            4077: 3469
+                            4078: 3470
+                    - key: 4083
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            4083: 3475
+                            4084: 3476
+                            4085: 3477
+                            4086: 3478
+                    - key: 4091
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Mem
+                        Leaf:
+                          credit: 80
+                          items:
+                            4091: 3483
+                            4092: 3484
+                            4093: 3485
+                            4094: 3486
+                            4095: 3487
+                    - key: 4604
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            4609: 3745
+                            4610: 3746
+                            4614: 3750
+                            4615: 3751
+        - key: 4620
+          txgs:
+            start: 9
+            end: 11
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4620
+                txgs:
+                  start: 9
+                  end: 11
+                ptr: !Mem
+                  Int:
+                    children:
+                    - key: 4620
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Addr 1004620
+                    - key: 4628
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Addr 1004628
+                    - key: 4636
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Addr 1004636
+                    - key: 4644
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Addr 1004644
+              - key: 4684
+                txgs:
+                  start: 9
+                  end: 11
+                ptr: !Addr 1004684
+              - key: 4748
+                txgs:
+                  start: 9
+                  end: 11
+                ptr: !Addr 1004748
+              - key: 5119
+                txgs:
+                  start: 9
+                  end: 11
+                ptr: !Addr 1005119
   "#));
     let r = tree.clone()
         .range_delete(3584..4096, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 4
   max_int_fanout: 17
   min_leaf_fanout: 4
@@ -5030,106 +4569,92 @@ root:
     txgs:
       start: 0
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 11
-              ptr:
-                Addr: 1000000
-            - key: 2218
-              txgs:
-                start: 5
-                end: 11
-              ptr:
-                Addr: 1002218
-            - key: 3563
-              txgs:
-                start: 8
-                end: 43
-              ptr:
-                Mem:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 11
+          ptr: !Addr 1000000
+        - key: 2218
+          txgs:
+            start: 5
+            end: 11
+          ptr: !Addr 1002218
+        - key: 3563
+          txgs:
+            start: 8
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 3563
+                txgs:
+                  start: 10
+                  end: 43
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 3563
-                        txgs:
-                          start: 10
-                          end: 43
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 3563
-                                  txgs:
-                                    start: 42
-                                    end: 43
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          3563: 2604
-                                          3564: 2605
-                                          3565: 2606
-                                          3566: 2607
-                                - key: 4604
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          4609: 3745
-                                          4610: 3746
-                                          4614: 3750
-                                          4615: 3751
-                                - key: 4620
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Addr: 1004620
-                                - key: 4628
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Addr: 1004628
-                                - key: 4636
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Addr: 1004636
-                                - key: 4644
-                                  txgs:
-                                    start: 10
-                                    end: 11
-                                  ptr:
-                                    Addr: 1004644
-                      - key: 4684
-                        txgs:
-                          start: 9
-                          end: 11
-                        ptr:
-                          Addr: 1004684
-                      - key: 4748
-                        txgs:
-                          start: 9
-                          end: 11
-                        ptr:
-                          Addr: 1004748
-                      - key: 5119
-                        txgs:
-                          start: 9
-                          end: 11
-                        ptr:
-                          Addr: 1005119
+                    - key: 3563
+                      txgs:
+                        start: 42
+                        end: 43
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            3563: 2604
+                            3564: 2605
+                            3565: 2606
+                            3566: 2607
+                    - key: 4604
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            4609: 3745
+                            4610: 3746
+                            4614: 3750
+                            4615: 3751
+                    - key: 4620
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Addr 1004620
+                    - key: 4628
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Addr 1004628
+                    - key: 4636
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Addr 1004636
+                    - key: 4644
+                      txgs:
+                        start: 10
+                        end: 11
+                      ptr: !Addr 1004644
+              - key: 4684
+                txgs:
+                  start: 9
+                  end: 11
+                ptr: !Addr 1004684
+              - key: 4748
+                txgs:
+                  start: 9
+                  end: 11
+                ptr: !Addr 1004748
+              - key: 5119
+                txgs:
+                  start: 9
+                  end: 11
+                ptr: !Addr 1005119
 "#);
 }
 
@@ -5141,7 +4666,6 @@ fn range_delete_cant_fix_for_minfanout_plus_two() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5155,97 +4679,85 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003623
-            - key: 3889
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003889
-            - key: 4145
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4160
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004160
-                      - key: 4194
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4193: 4193.0
-                                4195: 4195.0
-            - key: 4599
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4600
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4601: 4601.0
-                                4608: 4608.0
-                      - key: 4609
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4610: 4610.0
-                                4612: 4612.0
-                      - key: 4617
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004617
-                      - key: 4627
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004627
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003623
+        - key: 3889
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003889
+        - key: 4145
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4160
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004160
+              - key: 4194
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4193: 4193.0
+                      4195: 4195.0
+        - key: 4599
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4600
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4601: 4601.0
+                      4608: 4608.0
+              - key: 4609
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4610: 4610.0
+                      4612: 4612.0
+              - key: 4617
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004617
+              - key: 4627
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004627
   "#));
     let r = tree.clone()
         .range_delete(4480..4600, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -5258,89 +4770,78 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003623
-            - key: 3889
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003889
-            - key: 4145
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4160
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004160
-                      - key: 4194
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4193: 4193.0
-                                4195: 4195.0
-            - key: 4599
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4600
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4601: 4601.0
-                                4608: 4608.0
-                      - key: 4609
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4610: 4610.0
-                                4612: 4612.0
-                      - key: 4617
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004617
-                      - key: 4627
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004627
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003623
+        - key: 3889
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003889
+        - key: 4145
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4160
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004160
+              - key: 4194
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4193: 4193.0
+                      4195: 4195.0
+        - key: 4599
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4600
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4601: 4601.0
+                      4608: 4608.0
+              - key: 4609
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4610: 4610.0
+                      4612: 4612.0
+              - key: 4617
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004617
+              - key: 4627
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004627
 "#);
 }
 
@@ -5349,7 +4850,6 @@ fn range_delete_cant_steal_to_fix_lca() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -5363,106 +4863,94 @@ root:
     txgs:
       start: 1
       end: 2
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 1
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 1000001
-                      - key: 10
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                10: 10.0
-                                11: 11.0
-                                12: 12.0
-                      - key: 20
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                20: 20.0
-                                21: 21.0
-                                22: 22.0
-                      - key: 30
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                30: 30.0
-                                31: 31.0
-                                32: 32.0
-            - key: 40
-              txgs:
-                start: 1
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 40
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                40: 40.0
-                                41: 41.0
-                                42: 42.0
-                      - key: 50
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 1000050
-                      - key: 60
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 1000060
-                      - key: 70
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 1000070
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 1
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 1000001
+              - key: 10
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+              - key: 20
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+              - key: 30
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      30: 30.0
+                      31: 31.0
+                      32: 32.0
+        - key: 40
+          txgs:
+            start: 1
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 40
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      40: 40.0
+                      41: 41.0
+                      42: 42.0
+              - key: 50
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 1000050
+              - key: 60
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 1000060
+              - key: 70
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 1000070
   "#));
     let r = tree.clone()
         .range_delete(21..32, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 3
   max_int_fanout: 7
   min_leaf_fanout: 3
@@ -5475,76 +4963,67 @@ root:
     txgs:
       start: 1
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 1
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 1000001
-                      - key: 10
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                10: 10.0
-                                11: 11.0
-                                12: 12.0
-                      - key: 20
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 80
-                              items:
-                                20: 20.0
-                                32: 32.0
-                                40: 40.0
-                                41: 41.0
-                                42: 42.0
-            - key: 50
-              txgs:
-                start: 1
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 50
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 1000050
-                      - key: 60
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 1000060
-                      - key: 70
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 1000070
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 1
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 1000001
+              - key: 10
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      10: 10.0
+                      11: 11.0
+                      12: 12.0
+              - key: 20
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 80
+                    items:
+                      20: 20.0
+                      32: 32.0
+                      40: 40.0
+                      41: 41.0
+                      42: 42.0
+        - key: 50
+          txgs:
+            start: 1
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 50
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 1000050
+              - key: 60
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 1000060
+              - key: 70
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 1000070
 "#);
 }
 
@@ -5554,7 +5033,6 @@ fn range_delete_single_node() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5568,55 +5046,50 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      1: 1.0
-                      2: 2.0
-            - key: 4
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      10: 10.0
-                      11: 11.0
-                      12: 12.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                1: 1.0
+                2: 2.0
+        - key: 4
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                4: 4.0
+                5: 5.0
+                6: 6.0
+                7: 7.0
+                8: 8.0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                10: 10.0
+                11: 11.0
+                12: 12.0
   "#));
     let r = tree.clone()
         .range_delete(5..7, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -5629,45 +5102,41 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      1: 1.0
-                      2: 2.0
-            - key: 4
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      4: 4.0
-                      7: 7.0
-                      8: 8.0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      10: 10.0
-                      11: 11.0
-                      12: 12.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                1: 1.0
+                2: 2.0
+        - key: 4
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                4: 4.0
+                7: 7.0
+                8: 8.0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                10: 10.0
+                11: 11.0
+                12: 12.0
 "#);
 }
 
@@ -5679,7 +5148,6 @@ fn range_delete_underflow_and_steal_left() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5693,111 +5161,98 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003623
-            - key: 3889
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003889
-            - key: 4145
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4193
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4193: 4193.0
-                                4195: 4195.0
-                      - key: 4457
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4565: 4565.0
-                                4567: 4567.0
-            - key: 4599
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4600
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 80
-                              items:
-                                4601: 4601.0
-                                4605: 4605.0
-                                4606: 4606.0
-                                4607: 4607.0
-                                4608: 4608.0
-                      - key: 4609
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4610: 4610.0
-                                4612: 4612.0
-                      - key: 4617
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004617
-                      - key: 4627
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004627
-                      - key: 4637
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004637
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003623
+        - key: 3889
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003889
+        - key: 4145
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4193
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4193: 4193.0
+                      4195: 4195.0
+              - key: 4457
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4565: 4565.0
+                      4567: 4567.0
+        - key: 4599
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4600
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 80
+                    items:
+                      4601: 4601.0
+                      4605: 4605.0
+                      4606: 4606.0
+                      4607: 4607.0
+                      4608: 4608.0
+              - key: 4609
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4610: 4610.0
+                      4612: 4612.0
+              - key: 4617
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004617
+              - key: 4627
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004627
+              - key: 4637
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004637
   "#));
     let r = tree.clone()
         .range_delete(4480..4605, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -5810,91 +5265,80 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003623
-            - key: 3889
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003889
-            - key: 4145
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4193
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4193: 4193.0
-                                4195: 4195.0
-                      - key: 4600
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                4605: 4605.0
-                                4606: 4606.0
-                                4607: 4607.0
-                                4608: 4608.0
-                      - key: 4609
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4610: 4610.0
-                                4612: 4612.0
-                      - key: 4617
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004617
-            - key: 4627
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4627
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004627
-                      - key: 4637
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004637
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003623
+        - key: 3889
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003889
+        - key: 4145
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4193
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4193: 4193.0
+                      4195: 4195.0
+              - key: 4600
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      4605: 4605.0
+                      4606: 4606.0
+                      4607: 4607.0
+                      4608: 4608.0
+              - key: 4609
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4610: 4610.0
+                      4612: 4612.0
+              - key: 4617
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004617
+        - key: 4627
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4627
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004627
+              - key: 4637
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004637
 "#);
 }
 
@@ -5904,7 +5348,6 @@ fn range_delete_to_end() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -5918,53 +5361,48 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      1: 1.0
-                      2: 2.0
-            - key: 4
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      10: 10.0
-                      11: 11.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                1: 1.0
+                2: 2.0
+        - key: 4
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                4: 4.0
+                5: 5.0
+                6: 6.0
+                7: 7.0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                10: 10.0
+                11: 11.0
   "#));
     let r = tree.clone()
         .range_delete(7..20, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -5977,33 +5415,30 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      1: 1.0
-                      2: 2.0
-            - key: 4
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                1: 1.0
+                2: 2.0
+        - key: 4
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                4: 4.0
+                5: 5.0
+                6: 6.0
 "#);
 }
 
@@ -6014,7 +5449,6 @@ fn range_delete_to_end_of_int_node() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -6028,124 +5462,112 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1: 1.0
-                                2: 2.0
-                      - key: 4
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                4: 4.0
-                                5: 5.0
-                                6: 6.0
-                      - key: 7
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                7: 7.0
-                                8: 8.0
-                      - key: 10
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                10: 10.0
-                                11: 11.0
-            - key: 15
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 20
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                20: 20.0
-                                21: 21.0
-                                22: 22.0
-                      - key: 24
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                24: 24.0
-                                26: 26.0
-            - key: 30
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 30
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                30: 30.0
-                                31: 31.0
-                      - key: 40
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                40: 40.0
-                                41: 41.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1: 1.0
+                      2: 2.0
+              - key: 4
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+              - key: 7
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      7: 7.0
+                      8: 8.0
+              - key: 10
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      10: 10.0
+                      11: 11.0
+        - key: 15
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 20
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+              - key: 24
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      24: 24.0
+                      26: 26.0
+        - key: 30
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 30
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      30: 30.0
+                      31: 31.0
+              - key: 40
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      40: 40.0
+                      41: 41.0
   "#));
     let r = tree.clone()
         .range_delete(10..16, TxgT::from(42), Credit::forge(80))
@@ -6155,8 +5577,7 @@ root:
     // However, range_delete is a 2-pass operation, and by the time that the 1st
     // pass is done, the 2nd pass can't tell that that node wasn't modified.
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -6169,113 +5590,102 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1: 1.0
-                                2: 2.0
-                      - key: 4
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                4: 4.0
-                                5: 5.0
-                                6: 6.0
-                      - key: 7
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                7: 7.0
-                                8: 8.0
-            - key: 15
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 20
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                20: 20.0
-                                21: 21.0
-                                22: 22.0
-                      - key: 24
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                24: 24.0
-                                26: 26.0
-            - key: 30
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 30
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                30: 30.0
-                                31: 31.0
-                      - key: 40
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                40: 40.0
-                                41: 41.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1: 1.0
+                      2: 2.0
+              - key: 4
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+              - key: 7
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      7: 7.0
+                      8: 8.0
+        - key: 15
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 20
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+              - key: 24
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      24: 24.0
+                      26: 26.0
+        - key: 30
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 30
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      30: 30.0
+                      31: 31.0
+              - key: 40
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      40: 40.0
+                      41: 41.0
 "#);
 }
 
@@ -6285,7 +5695,6 @@ fn range_delete_whole_nodes() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -6299,57 +5708,52 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      1: 1.0
-                      2: 2.0
-                      3: 3.0
-            - key: 4
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      10: 10.0
-                      11: 11.0
-            - key: 20
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      20: 20.0
-                      21: 21.0
-                      22: 22.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                1: 1.0
+                2: 2.0
+                3: 3.0
+        - key: 4
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                4: 4.0
+                5: 5.0
+                6: 6.0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                10: 10.0
+                11: 11.0
+        - key: 20
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                20: 20.0
+                21: 21.0
+                22: 22.0
   "#));
     let r = tree.clone()
         .range_delete(4..20, TxgT::from(42), Credit::forge(80))
@@ -6359,8 +5763,7 @@ root:
     // range_delete is a 2-pass operation, and by the time that the 1st pass is
     // done, the 2nd pass can't tell that that node wasn't modified.
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -6373,34 +5776,31 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      1: 1.0
-                      2: 2.0
-                      3: 3.0
-            - key: 20
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      20: 20.0
-                      21: 21.0
-                      22: 22.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                1: 1.0
+                2: 2.0
+                3: 3.0
+        - key: 20
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                20: 20.0
+                21: 21.0
+                22: 22.0
 "#);
 }
 
@@ -6410,7 +5810,6 @@ fn range_delete_whole_node_denormalized() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -6424,81 +5823,70 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003623
-            - key: 3889
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003889
-            - key: 4145
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4193
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004193
-                      - key: 4457
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004457
-            - key: 4599
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4600
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004600
-                      - key: 4609
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                4610: 4610.0
-                                4612: 4612.0
-                      - key: 4617
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004617
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003623
+        - key: 3889
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003889
+        - key: 4145
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4193
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004193
+              - key: 4457
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004457
+        - key: 4599
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4600
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004600
+              - key: 4609
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      4610: 4610.0
+                      4612: 4612.0
+              - key: 4617
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004617
   "#));
     let r = tree.clone()
         .range_delete(4610..4613, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -6511,54 +5899,46 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003623
-            - key: 3889
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1003889
-            - key: 4145
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 4193
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004193
-                      - key: 4457
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004457
-                      - key: 4600
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004600
-                      - key: 4617
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1004617
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003623
+        - key: 3889
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1003889
+        - key: 4145
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 4193
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004193
+              - key: 4457
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004457
+              - key: 4600
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004600
+              - key: 4617
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1004617
 "#);
 }
 
@@ -6571,7 +5951,6 @@ fn range_delete_pass2_steal_creates_an_lca() {
 
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -6585,400 +5964,352 @@ root:
     txgs:
       start: 1
       end: 6
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 2599
-              txgs:
-                start: 2
-                end: 6
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 3634
-                        txgs:
-                          start: 3
-                          end: 6
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 3634
-                                  txgs:
-                                    start: 3
-                                    end: 6
-                                  ptr:
-                                    Addr: 103634
+    ptr: !Mem
+      Int:
+        children:
+          - key: 2599
+            txgs:
+              start: 2
+              end: 6
+            ptr: !Mem
+              Int:
+                children:
+                  - key: 3634
+                    txgs:
+                      start: 3
+                      end: 6
+                    ptr: !Mem
+                      Int:
+                        children:
+                          - key: 3634
+                            txgs:
+                              start: 3
+                              end: 6
+                            ptr: !Addr 103634
+                          - key: 3682
+                            txgs:
+                              start: 3
+                              end: 6
+                            ptr: !Mem
+                              Int:
+                                children:
                                 - key: 3682
                                   txgs:
                                     start: 3
-                                    end: 6
-                                  ptr:
-                                    Mem:
-                                      Int:
-                                        children:
-                                          - key: 3682
-                                            txgs:
-                                              start: 3
-                                              end: 4
-                                            ptr:
-                                              Addr: 4494
-                                          - key: 3686
-                                            txgs:
-                                              start: 3
-                                              end: 4
-                                            ptr:
-                                              Addr: 4495
-                                          - key: 3690
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 7382
-                                          - key: 3698
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 7384
-                                - key: 3706
+                                    end: 4
+                                  ptr: !Addr 4494
+                                - key: 3686
                                   txgs:
-                                    start: 4
+                                    start: 3
+                                    end: 4
+                                  ptr: !Addr 4495
+                                - key: 3690
+                                  txgs:
+                                    start: 5
                                     end: 6
-                                  ptr:
-                                    Mem:
-                                      Int:
-                                        children:
-                                          - key: 3706
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 48
-                                                  items:
-                                                    3706: 3060
-                                                    3704: 3061
-                                                    3711: 3065
-                                          - key: 4774
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 48
-                                                  items:
-                                                    4774: 3069
-                                                    4775: 3070
-                                                    4776: 3071
-                                          - key: 4778
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 96
-                                                  items:
-                                                    4778: 3073
-                                                    4780: 3075
-                                                    4781: 3076
-                                                    4785: 3080
-                                                    4786: 3081
-                                                    4789: 3084
+                                  ptr: !Addr 7382
+                                - key: 3698
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr: !Addr 7384
+                          - key: 3706
+                            txgs:
+                              start: 4
+                              end: 6
+                            ptr: !Mem
+                              Int:
+                                children:
+                                  - key: 3706
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Mem
+                                      Leaf:
+                                        credit: 48
+                                        items:
+                                          3706: 3060
+                                          3704: 3061
+                                          3711: 3065
+                                  - key: 4774
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Mem
+                                      Leaf:
+                                        credit: 48
+                                        items:
+                                          4774: 3069
+                                          4775: 3070
+                                          4776: 3071
+                                  - key: 4778
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Mem
+                                      Leaf:
+                                        credit: 96
+                                        items:
+                                          4778: 3073
+                                          4780: 3075
+                                          4781: 3076
+                                          4785: 3080
+                                          4786: 3081
+                                          4789: 3084
+                          - key: 4790
+                            txgs:
+                              start: 5
+                              end: 6
+                            ptr: !Mem
+                              Int:
+                                children:
                                 - key: 4790
                                   txgs:
                                     start: 5
                                     end: 6
-                                  ptr:
-                                    Mem:
-                                      Int:
-                                        children:
-                                          - key: 4790
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 48
-                                                  items:
-                                                    4791: 3086
-                                                    4792: 3087
-                                                    4793: 3088
-                                          - key: 4794
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 64
-                                                  items:
-                                                    4794: 3089
-                                                    4795: 3090
-                                                    4796: 3091
-                                                    4801: 3096
-                                          - key: 4802
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 48
-                                                  items:
-                                                    4802: 3097
-                                                    4804: 3099
-                                                    4805: 3100
-                                          - key: 4806
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 64
-                                                  items:
-                                                    4806: 3101
-                                                    4808: 3103
-                                                    4812: 3107
-                                                    4815: 3110
-                                          - key: 4818
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 96
-                                                  items:
-                                                    4818: 3113
-                                                    4820: 3115
-                                                    4832: 3127
-                                                    4834: 3129
-                                                    4835: 3130
-                                                    4836: 3131
-                                          - key: 4838
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 80
-                                                  items:
-                                                    4838: 3133
-                                                    4839: 3134
-                                                    4845: 3140
-                                                    4846: 3141
-                                                    4847: 3142
-                      - key: 4850
-                        txgs:
-                          start: 4
-                          end: 6
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
+                                  ptr: !Mem
+                                    Leaf:
+                                      credit: 48
+                                      items:
+                                        4791: 3086
+                                        4792: 3087
+                                        4793: 3088
+                                - key: 4794
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr: !Mem
+                                    Leaf:
+                                      credit: 64
+                                      items:
+                                        4794: 3089
+                                        4795: 3090
+                                        4796: 3091
+                                        4801: 3096
+                                - key: 4802
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr: !Mem
+                                    Leaf:
+                                      credit: 48
+                                      items:
+                                        4802: 3097
+                                        4804: 3099
+                                        4805: 3100
+                                - key: 4806
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr: !Mem
+                                    Leaf:
+                                      credit: 64
+                                      items:
+                                        4806: 3101
+                                        4808: 3103
+                                        4812: 3107
+                                        4815: 3110
+                                - key: 4818
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr: !Mem
+                                    Leaf:
+                                      credit: 96
+                                      items:
+                                        4818: 3113
+                                        4820: 3115
+                                        4832: 3127
+                                        4834: 3129
+                                        4835: 3130
+                                        4836: 3131
+                                - key: 4838
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr: !Mem
+                                    Leaf:
+                                      credit: 80
+                                      items:
+                                        4838: 3133
+                                        4839: 3134
+                                        4845: 3140
+                                        4846: 3141
+                                        4847: 3142
+                  - key: 4850
+                    txgs:
+                      start: 4
+                      end: 6
+                    ptr: !Mem
+                      Int:
+                        children:
+                          - key: 4850
+                            txgs:
+                              start: 4
+                              end: 6
+                            ptr: !Mem
+                              Int:
+                                children:
                                 - key: 4850
                                   txgs:
-                                    start: 4
+                                    start: 5
                                     end: 6
-                                  ptr:
-                                    Mem:
-                                      Int:
-                                        children:
-                                          - key: 4850
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 104850
-                                          - key: 4865
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 104865
-                                          - key: 4878
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 104878
+                                  ptr: !Addr 104850
+                                - key: 4865
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr: !Addr 104865
+                                - key: 4878
+                                  txgs:
+                                    start: 5
+                                    end: 6
+                                  ptr: !Addr 104878
+                          - key: 5035
+                            txgs:
+                              start: 5
+                              end: 6
+                            ptr: !Mem
+                              Int:
+                                children:
                                 - key: 5035
                                   txgs:
                                     start: 5
                                     end: 6
-                                  ptr:
-                                    Mem:
-                                      Int:
-                                        children:
-                                          - key: 5035
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 105035
-                                          - key: 5058
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 105058
-                                          - key: 5062
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 105062
-                                - key: 5070
+                                  ptr: !Addr 105035
+                                - key: 5058
                                   txgs:
                                     start: 5
                                     end: 6
-                                  ptr:
-                                    Mem:
-                                      Int:
-                                        children:
-                                          - key: 5070
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 105070
-                                          - key: 5090
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 105090
-                                          - key: 5100
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 105100
-                      - key: 5106
-                        txgs:
-                          start: 4
-                          end: 6
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 5106
-                                  txgs:
-                                    start: 4
-                                    end: 6
-                                  ptr:
-                                    Mem:
-                                      Int:
-                                        children:
-                                          - key: 5106
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 48
-                                                  items:
-                                                    5107: 3402
-                                                    5112: 3407
-                                                    5113: 3408
-                                          - key: 5114
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 48
-                                                  items:
-                                                    5115: 3410
-                                                    5119: 3414
-                                                    5120: 3415
-                                          - key: 5122
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Mem:
-                                                Leaf:
-                                                  credit: 48
-                                                  items:
-                                                    5122: 3417
-                                                    5123: 3418
-                                                    5137: 3432
-                                - key: 5138
-                                  txgs:
-                                    start: 4
-                                    end: 6
-                                  ptr:
-                                    Mem:
-                                      Int:
-                                        children:
-                                          - key: 5138
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 1005138
-                                          - key: 5146
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 1005146
-                                          - key: 5162
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 1005162
-                                          - key: 5166
-                                            txgs:
-                                              start: 5
-                                              end: 6
-                                            ptr:
-                                              Addr: 1005166
-                                - key: 5182
-                                  txgs:
-                                    start: 4
-                                    end: 6
-                                  ptr:
-                                    Addr: 105182
-                                - key: 5202
+                                  ptr: !Addr 105058
+                                - key: 5062
                                   txgs:
                                     start: 5
                                     end: 6
-                                  ptr:
-                                    Addr: 105202
-                                - key: 5298
-                                  txgs:
-                                    start: 4
-                                    end: 6
-                                  ptr:
-                                    Addr: 105298
-                                - key: 5330
-                                  txgs:
-                                    start: 4
-                                    end: 6
-                                  ptr:
-                                    Addr: 105330
+                                  ptr: !Addr 105062
+                          - key: 5070
+                            txgs:
+                              start: 5
+                              end: 6
+                            ptr: !Mem
+                              Int:
+                                children:
+                                  - key: 5070
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Addr 105070
+                                  - key: 5090
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Addr 105090
+                                  - key: 5100
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Addr 105100
+                  - key: 5106
+                    txgs:
+                      start: 4
+                      end: 6
+                    ptr: !Mem
+                      Int:
+                        children:
+                          - key: 5106
+                            txgs:
+                              start: 4
+                              end: 6
+                            ptr: !Mem
+                              Int:
+                                children:
+                                  - key: 5106
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Mem
+                                      Leaf:
+                                        credit: 48
+                                        items:
+                                          5107: 3402
+                                          5112: 3407
+                                          5113: 3408
+                                  - key: 5114
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Mem
+                                      Leaf:
+                                        credit: 48
+                                        items:
+                                          5115: 3410
+                                          5119: 3414
+                                          5120: 3415
+                                  - key: 5122
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Mem
+                                      Leaf:
+                                        credit: 48
+                                        items:
+                                          5122: 3417
+                                          5123: 3418
+                                          5137: 3432
+                          - key: 5138
+                            txgs:
+                              start: 4
+                              end: 6
+                            ptr: !Mem
+                              Int:
+                                children:
+                                  - key: 5138
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Addr 1005138
+                                  - key: 5146
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Addr 1005146
+                                  - key: 5162
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Addr 1005162
+                                  - key: 5166
+                                    txgs:
+                                      start: 5
+                                      end: 6
+                                    ptr: !Addr 1005166
+                          - key: 5182
+                            txgs:
+                              start: 4
+                              end: 6
+                            ptr: !Addr 105182
+                          - key: 5202
+                            txgs:
+                              start: 5
+                              end: 6
+                            ptr: !Addr 105202
+                          - key: 5298
+                            txgs:
+                              start: 4
+                              end: 6
+                            ptr: !Addr 105298
+                          - key: 5330
+                            txgs:
+                              start: 4
+                              end: 6
+                            ptr: !Addr 105330
   "#));
     let r = tree.clone()
         .range_delete(4608..5120, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 3
   max_int_fanout: 7
   min_leaf_fanout: 3
@@ -6991,145 +6322,125 @@ root:
     txgs:
       start: 2
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 3634
-              txgs:
-                start: 3
-                end: 43
-              ptr:
-                Mem:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 3634
+          txgs:
+            start: 3
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 3634
+                txgs:
+                  start: 3
+                  end: 6
+                ptr: !Addr 103634
+              - key: 3682
+                txgs:
+                  start: 3
+                  end: 6
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 3634
-                        txgs:
-                          start: 3
-                          end: 6
-                        ptr:
-                          Addr: 103634
-                      - key: 3682
-                        txgs:
-                          start: 3
-                          end: 6
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 3682
-                                  txgs:
-                                    start: 3
-                                    end: 4
-                                  ptr:
-                                    Addr: 4494
-                                - key: 3686
-                                  txgs:
-                                    start: 3
-                                    end: 4
-                                  ptr:
-                                    Addr: 4495
-                                - key: 3690
-                                  txgs:
-                                    start: 5
-                                    end: 6
-                                  ptr:
-                                    Addr: 7382
-                                - key: 3698
-                                  txgs:
-                                    start: 5
-                                    end: 6
-                                  ptr:
-                                    Addr: 7384
-                      - key: 3706
-                        txgs:
-                          start: 5
-                          end: 43
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 3706
-                                  txgs:
-                                    start: 42
-                                    end: 43
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 48
-                                        items:
-                                          3704: 3061
-                                          3706: 3060
-                                          3711: 3065
-                                - key: 5114
-                                  txgs:
-                                    start: 42
-                                    end: 43
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          5120: 3415
-                                          5122: 3417
-                                          5123: 3418
-                                          5137: 3432
-                                - key: 5138
-                                  txgs:
-                                    start: 5
-                                    end: 6
-                                  ptr:
-                                    Addr: 1005138
-                                - key: 5146
-                                  txgs:
-                                    start: 5
-                                    end: 6
-                                  ptr:
-                                    Addr: 1005146
-                                - key: 5162
-                                  txgs:
-                                    start: 5
-                                    end: 6
-                                  ptr:
-                                    Addr: 1005162
-                                - key: 5166
-                                  txgs:
-                                    start: 5
-                                    end: 6
-                                  ptr:
-                                    Addr: 1005166
-            - key: 5182
-              txgs:
-                start: 4
-                end: 43
-              ptr:
-                Mem:
+                    - key: 3682
+                      txgs:
+                        start: 3
+                        end: 4
+                      ptr: !Addr 4494
+                    - key: 3686
+                      txgs:
+                        start: 3
+                        end: 4
+                      ptr: !Addr 4495
+                    - key: 3690
+                      txgs:
+                        start: 5
+                        end: 6
+                      ptr: !Addr 7382
+                    - key: 3698
+                      txgs:
+                        start: 5
+                        end: 6
+                      ptr: !Addr 7384
+              - key: 3706
+                txgs:
+                  start: 5
+                  end: 43
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 5182
-                        txgs:
-                          start: 4
-                          end: 6
-                        ptr:
-                          Addr: 105182
-                      - key: 5202
-                        txgs:
-                          start: 5
-                          end: 6
-                        ptr:
-                          Addr: 105202
-                      - key: 5298
-                        txgs:
-                          start: 4
-                          end: 6
-                        ptr:
-                          Addr: 105298
-                      - key: 5330
-                        txgs:
-                          start: 4
-                          end: 6
-                        ptr:
-                          Addr: 105330
+                    - key: 3706
+                      txgs:
+                        start: 42
+                        end: 43
+                      ptr: !Mem
+                        Leaf:
+                          credit: 48
+                          items:
+                            3704: 3061
+                            3706: 3060
+                            3711: 3065
+                    - key: 5114
+                      txgs:
+                        start: 42
+                        end: 43
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            5120: 3415
+                            5122: 3417
+                            5123: 3418
+                            5137: 3432
+                    - key: 5138
+                      txgs:
+                        start: 5
+                        end: 6
+                      ptr: !Addr 1005138
+                    - key: 5146
+                      txgs:
+                        start: 5
+                        end: 6
+                      ptr: !Addr 1005146
+                    - key: 5162
+                      txgs:
+                        start: 5
+                        end: 6
+                      ptr: !Addr 1005162
+                    - key: 5166
+                      txgs:
+                        start: 5
+                        end: 6
+                      ptr: !Addr 1005166
+        - key: 5182
+          txgs:
+            start: 4
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 5182
+                txgs:
+                  start: 4
+                  end: 6
+                ptr: !Addr 105182
+              - key: 5202
+                txgs:
+                  start: 5
+                  end: 6
+                ptr: !Addr 105202
+              - key: 5298
+                txgs:
+                  start: 4
+                  end: 6
+                ptr: !Addr 105298
+              - key: 5330
+                txgs:
+                  start: 4
+                  end: 6
+                ptr: !Addr 105330
 "#);
 }
 
@@ -7139,7 +6450,6 @@ fn range_delete_pass2_steal_left() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7153,88 +6463,77 @@ root:
     txgs:
       start: 0
       end: 2
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 11
-                      - key: 3
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3: 3.0
-                                4: 4.0
-                                5: 5.0
-            - key: 20
-              txgs:
-                start: 0
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 20
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                20: 20.0
-                                21: 21.0
-                                22: 22.0
-                      - key: 26
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 126
-                      - key: 29
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 32
-                      - key: 30
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 33
-                      - key: 40
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 34
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 11
+              - key: 3
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+        - key: 20
+          txgs:
+            start: 0
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 20
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+              - key: 26
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 126
+              - key: 29
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 32
+              - key: 30
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 33
+              - key: 40
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 34
   "#));
     let r = tree.clone()
         .range_delete(3..21, TxgT::from(2), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -7247,67 +6546,58 @@ root:
     txgs:
       start: 0
       end: 3
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 3
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 11
-                      - key: 20
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                21: 21.0
-                                22: 22.0
-                      - key: 26
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 126
-                      - key: 29
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 32
-            - key: 30
-              txgs:
-                start: 0
-                end: 3
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 30
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 33
-                      - key: 40
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 34
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 3
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 11
+              - key: 20
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      21: 21.0
+                      22: 22.0
+              - key: 26
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 126
+              - key: 29
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 32
+        - key: 30
+          txgs:
+            start: 0
+            end: 3
+          ptr: !Mem
+            Int:
+              children:
+              - key: 30
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 33
+              - key: 40
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 34
 "#);
 }
 
@@ -7317,7 +6607,6 @@ fn range_delete_pass2_steal_right() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7331,190 +6620,169 @@ root:
     txgs:
       start: 0
       end: 23
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 5409
-              txgs:
-                start: 14
-                end: 23
-              ptr:
-                Mem:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 5409
+          txgs:
+            start: 14
+            end: 23
+          ptr: !Mem
+            Int:
+              children:
+                - key: 5729
+                  txgs:
+                    start: 14
+                    end: 23
+                  ptr: !Addr 1005729
+                - key: 6809
+                  txgs:
+                    start: 16
+                    end: 23
+                  ptr: !Addr 1006809
+                - key: 9437
+                  txgs:
+                    start: 17
+                    end: 23
+                  ptr: !Addr 1009437
+        - key: 10049
+          txgs:
+            start: 18
+            end: 23
+          ptr: !Mem
+            Int:
+              children:
+              - key: 10113
+                txgs:
+                  start: 22
+                  end: 23
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 5729
-                        txgs:
-                          start: 14
-                          end: 23
-                        ptr:
-                          Addr: 1005729
-                      - key: 6809
-                        txgs:
-                          start: 16
-                          end: 23
-                        ptr:
-                          Addr: 1006809
-                      - key: 9437
-                        txgs:
-                          start: 17
-                          end: 23
-                        ptr:
-                          Addr: 1009437
-            - key: 10049
-              txgs:
-                start: 18
-                end: 23
-              ptr:
-                Mem:
+                    - key: 10113
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            11264: 9282
+                            11269: 9287
+                            11270: 9288
+                            11271: 9289
+                    - key: 11279
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            11281: 9299
+                            11283: 9301
+                            11284: 9302
+                            11285: 9303
+                    - key: 11287
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            11288: 9306
+                            11292: 9310
+                            11293: 9311
+                            11294: 9312
+                    - key: 11295
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Mem
+                        Leaf:
+                          credit: 64
+                          items:
+                            11295: 9313
+                            11298: 9316
+                            11300: 9318
+                            11301: 9319
+              - key: 11495
+                txgs:
+                  start: 21
+                  end: 23
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 10113
-                        txgs:
-                          start: 22
-                          end: 23
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 10113
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          11264: 9282
-                                          11269: 9287
-                                          11270: 9288
-                                          11271: 9289
-                                - key: 11279
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          11281: 9299
-                                          11283: 9301
-                                          11284: 9302
-                                          11285: 9303
-                                - key: 11287
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          11288: 9306
-                                          11292: 9310
-                                          11293: 9311
-                                          11294: 9312
-                                - key: 11295
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 64
-                                        items:
-                                          11295: 9313
-                                          11298: 9316
-                                          11300: 9318
-                                          11301: 9319
-                      - key: 11495
-                        txgs:
-                          start: 21
-                          end: 23
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 11511
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 32
-                                        items:
-                                          11511: 9529
-                                          11514: 9532
-                                - key: 11519
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 32
-                                        items:
-                                          11616: 9634
-                                          11994: 6844
-                                - key: 11995
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 32
-                                        items:
-                                          11995: 6871
-                                          12002: 7037
-                                - key: 12003
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 32
-                                        items:
-                                          12003: 7053
-                                          12010: 7164
-                      - key: 12037
-                        txgs:
-                          start: 22
-                          end: 23
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 12037
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Addr: 1012037
-                                - key: 12095
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Addr: 1012095
-                      - key: 12155
-                        txgs:
-                          start: 22
-                          end: 23
-                        ptr:
-                          Addr: 1012155
+                    - key: 11511
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Mem
+                        Leaf:
+                          credit: 32
+                          items:
+                            11511: 9529
+                            11514: 9532
+                    - key: 11519
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Mem
+                        Leaf:
+                          credit: 32
+                          items:
+                            11616: 9634
+                            11994: 6844
+                    - key: 11995
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Mem
+                        Leaf:
+                          credit: 32
+                          items:
+                            11995: 6871
+                            12002: 7037
+                    - key: 12003
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Mem
+                        Leaf:
+                          credit: 32
+                          items:
+                            12003: 7053
+                            12010: 7164
+              - key: 12037
+                txgs:
+                  start: 22
+                  end: 23
+                ptr: !Mem
+                  Int:
+                    children:
+                    - key: 12037
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Addr 1012037
+                    - key: 12095
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Addr 1012095
+              - key: 12155
+                txgs:
+                  start: 22
+                  end: 23
+                ptr: !Addr 1012155
   "#));
     let r = tree.clone()
         .range_delete(11264..11776, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -7527,93 +6795,81 @@ root:
     txgs:
       start: 0
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 5409
-              txgs:
-                start: 14
-                end: 43
-              ptr:
-                Mem:
+    ptr: !Mem
+      Int:
+        children:
+        - key: 5409
+          txgs:
+            start: 14
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 5729
+                txgs:
+                  start: 14
+                  end: 23
+                ptr: !Addr 1005729
+              - key: 6809
+                txgs:
+                  start: 16
+                  end: 23
+                ptr: !Addr 1006809
+        - key: 9437
+          txgs:
+            start: 17
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9437
+                txgs:
+                  start: 17
+                  end: 23
+                ptr: !Addr 1009437
+              - key: 11495
+                txgs:
+                  start: 22
+                  end: 43
+                ptr: !Mem
                   Int:
                     children:
-                      - key: 5729
-                        txgs:
-                          start: 14
-                          end: 23
-                        ptr:
-                          Addr: 1005729
-                      - key: 6809
-                        txgs:
-                          start: 16
-                          end: 23
-                        ptr:
-                          Addr: 1006809
-            - key: 9437
-              txgs:
-                start: 17
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9437
-                        txgs:
-                          start: 17
-                          end: 23
-                        ptr:
-                          Addr: 1009437
-                      - key: 11495
-                        txgs:
-                          start: 22
-                          end: 43
-                        ptr:
-                          Mem:
-                            Int:
-                              children:
-                                - key: 11519
-                                  txgs:
-                                    start: 42
-                                    end: 43
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 48
-                                        items:
-                                          11994: 6844
-                                          11995: 6871
-                                          12002: 7037
-                                - key: 12003
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Mem:
-                                      Leaf:
-                                        credit: 32
-                                        items:
-                                          12003: 7053
-                                          12010: 7164
-                                - key: 12037
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Addr: 1012037
-                                - key: 12095
-                                  txgs:
-                                    start: 22
-                                    end: 23
-                                  ptr:
-                                    Addr: 1012095
-                      - key: 12155
-                        txgs:
-                          start: 22
-                          end: 23
-                        ptr:
-                          Addr: 1012155
+                    - key: 11519
+                      txgs:
+                        start: 42
+                        end: 43
+                      ptr: !Mem
+                        Leaf:
+                          credit: 48
+                          items:
+                            11994: 6844
+                            11995: 6871
+                            12002: 7037
+                    - key: 12003
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Mem
+                        Leaf:
+                          credit: 32
+                          items:
+                            12003: 7053
+                            12010: 7164
+                    - key: 12037
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Addr 1012037
+                    - key: 12095
+                      txgs:
+                        start: 22
+                        end: 23
+                      ptr: !Addr 1012095
+              - key: 12155
+                txgs:
+                  start: 22
+                  end: 23
+                ptr: !Addr 1012155
 "#);
 }
 
@@ -7643,7 +6899,6 @@ fn range_delete_range_from() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7657,74 +6912,66 @@ root:
     txgs:
       start: 0
       end: 2
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 10010
-                      - key: 3
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3: 3.0
-                                4: 4.0
-                                5: 5.0
-            - key: 20
-              txgs:
-                start: 0
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 20
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                20: 20.0
-                                21: 21.0
-                      - key: 26
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                26: 26.0
-                                27: 27.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 10010
+              - key: 3
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+        - key: 20
+          txgs:
+            start: 0
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 20
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      20: 20.0
+                      21: 21.0
+              - key: 26
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      26: 26.0
+                      27: 27.0
   "#));
     let r = tree.clone()
         .range_delete(5.., TxgT::from(2), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -7737,27 +6984,24 @@ root:
     txgs:
       start: 0
       end: 3
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 10010
-            - key: 3
-              txgs:
-                start: 2
-                end: 3
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Addr 10010
+        - key: 3
+          txgs:
+            start: 2
+            end: 3
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
 "#);
 }
 
@@ -7767,7 +7011,6 @@ fn range_delete_range_full() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7781,79 +7024,71 @@ root:
     txgs:
       start: 0
       end: 2
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1: 1.0
-                                2: 2.0
-                      - key: 3
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                3: 3.0
-                                4: 4.0
-            - key: 20
-              txgs:
-                start: 0
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 20
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                20: 20.0
-                                21: 21.0
-                                22: 22.0
-                      - key: 26
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                26: 26.0
-                                27: 27.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1: 1.0
+                      2: 2.0
+              - key: 3
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      3: 3.0
+                      4: 4.0
+        - key: 20
+          txgs:
+            start: 0
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 20
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+              - key: 26
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      26: 26.0
+                      27: 27.0
   "#));
     let r = tree.clone()
         .range_delete(.., TxgT::from(2), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -7866,11 +7101,10 @@ root:
     txgs:
       start: 0
       end: 3
-    ptr:
-      Mem:
-        Leaf:
-          credit: 0
-          items: {}
+    ptr: !Mem
+      Leaf:
+        credit: 0
+        items: {}
 "#);
 }
 
@@ -7880,7 +7114,6 @@ fn range_delete_range_to() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -7894,74 +7127,66 @@ root:
     txgs:
       start: 0
       end: 2
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1: 1.0
-                                2: 2.0
-                      - key: 3
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                3: 3.0
-                                4: 4.0
-            - key: 20
-              txgs:
-                start: 0
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 20
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                20: 20.0
-                                21: 21.0
-                                22: 22.0
-                      - key: 26
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 10026
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1: 1.0
+                      2: 2.0
+              - key: 3
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      3: 3.0
+                      4: 4.0
+        - key: 20
+          txgs:
+            start: 0
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 20
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+              - key: 26
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 10026
   "#));
     let r = tree.clone()
         .range_delete(..21, TxgT::from(2), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -7974,27 +7199,24 @@ root:
     txgs:
       start: 0
       end: 3
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 20
-              txgs:
-                start: 2
-                end: 3
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      21: 21.0
-                      22: 22.0
-            - key: 26
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 10026
+    ptr: !Mem
+      Int:
+        children:
+        - key: 20
+          txgs:
+            start: 2
+            end: 3
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                21: 21.0
+                22: 22.0
+        - key: 26
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Addr 10026
 "#);
 }
 
@@ -8021,8 +7243,7 @@ fn range_delete_to_end_deep() {
     // either a single IntNode with two Leaves as shown below, or simply as a
     // single Leaf.
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -8035,33 +7256,30 @@ root:
     txgs:
       start: 2
       end: 3
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 2
-                end: 3
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
-            - key: 3
-              txgs:
-                start: 2
-                end: 3
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 2
+            end: 3
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
+        - key: 3
+          txgs:
+            start: 2
+            end: 3
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
 "#);
 
 }
@@ -8071,7 +7289,6 @@ fn range_delete_underflow_in_parent_and_child() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8085,80 +7302,72 @@ root:
     txgs:
       start: 0
       end: 2
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 1
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                1: 1.0
-                                2: 2.0
-                      - key: 3
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                3: 3.0
-                                4: 4.0
-                                5: 5.0
-            - key: 20
-              txgs:
-                start: 0
-                end: 2
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 20
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                20: 20.0
-                                21: 21.0
-                                22: 22.0
-                      - key: 26
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                26: 26.0
-                                27: 27.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 1
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      1: 1.0
+                      2: 2.0
+              - key: 3
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+        - key: 20
+          txgs:
+            start: 0
+            end: 2
+          ptr: !Mem
+            Int:
+              children:
+              - key: 20
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      20: 20.0
+                      21: 21.0
+                      22: 22.0
+              - key: 26
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      26: 26.0
+                      27: 27.0
   "#));
     let r = tree.clone()
         .range_delete(2..30, TxgT::from(2), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -8171,12 +7380,11 @@ root:
     txgs:
       start: 2
       end: 3
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            1: 1.0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          1: 1.0
 "#);
 }
 
@@ -8184,7 +7392,6 @@ root:
 fn range_empty_range() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8198,32 +7405,29 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
   "#));
     let r = tree.range(1..1)
         .try_collect()
@@ -8249,7 +7453,6 @@ fn range_empty_tree() {
 fn range_full() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8263,32 +7466,29 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
   "#));
     let r = tree.range(..)
         .try_collect()
@@ -8300,7 +7500,6 @@ root:
 fn range_exclusive_start() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8314,32 +7513,29 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
   "#));
     // A query that starts on a leaf
     let r = tree.range((Bound::Excluded(0), Bound::Excluded(4)))
@@ -8358,7 +7554,6 @@ root:
 fn range_leaf() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8372,16 +7567,15 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 80
-          items:
-            0: 0.0
-            1: 1.0
-            2: 2.0
-            3: 3.0
-            4: 4.0
+    ptr: !Mem
+      Leaf:
+        credit: 80
+        items:
+          0: 0.0
+          1: 1.0
+          2: 2.0
+          3: 3.0
+          4: 4.0
   "#));
     let r = tree.range(1..3)
         .try_collect()
@@ -8393,7 +7587,6 @@ root:
 fn range_leaf_inclusive_end() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8407,16 +7600,15 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 80
-          items:
-            0: 0.0
-            1: 1.0
-            2: 2.0
-            3: 3.0
-            4: 4.0
+    ptr: !Mem
+      Leaf:
+        credit: 80
+        items:
+          0: 0.0
+          1: 1.0
+          2: 2.0
+          3: 3.0
+          4: 4.0
   "#));
     let r = tree.range(3..=4)
         .try_collect()
@@ -8428,7 +7620,6 @@ root:
 fn range_nonexistent_between_two_leaves() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8442,32 +7633,29 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      5: 5.0
-                      6: 6.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                5: 5.0
+                6: 6.0
   "#));
     let r = tree.range(2..4)
         .try_collect()
@@ -8479,7 +7667,6 @@ root:
 fn range_two_ints() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8493,48 +7680,43 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 0
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-            - key: 9
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 0
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 0
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+        - key: 9
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 0
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
   "#));
     let r = tree.range(1..10)
         .try_collect()
@@ -8546,7 +7728,6 @@ root:
 fn range_ends_between_two_leaves() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8560,32 +7741,29 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 4
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      4: 4.0
-                      5: 5.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 4
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                4: 4.0
+                5: 5.0
   "#));
     let r = tree.range(0..3)
         .try_collect()
@@ -8597,7 +7775,6 @@ root:
 fn range_ends_before_node_but_after_parent_pointer() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8611,32 +7788,29 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 4
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      6: 6.0
-                      7: 7.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 4
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                6: 6.0
+                7: 7.0
   "#));
     let r = tree.range(0..5)
         .try_collect()
@@ -8648,7 +7822,6 @@ root:
 fn range_starts_between_two_leaves() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8662,43 +7835,39 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
-            - key: 5
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      5: 5.0
-                      6: 6.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
+        - key: 5
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                5: 5.0
+                6: 6.0
   "#));
     let r = tree.range(2..6)
         .try_collect()
@@ -8710,7 +7879,6 @@ root:
 fn range_two_leaves() {
     let dml = Arc::new(mock_dml());
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8724,32 +7892,29 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 0
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 0
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
   "#));
     let r = tree.range(1..4)
         .try_collect()
@@ -8771,7 +7936,6 @@ fn remove_dclone() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, NeedsDcloneV>::from_str(
         dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8785,21 +7949,19 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 48
-          items:
-            0: 0
-            1: 1
-            2: 2
+    ptr: !Mem
+      Leaf:
+        credit: 48
+        items:
+          0: 0
+          1: 1
+          2: 2
   "#));
     let r = tree.clone().remove(1, txg, Credit::null())
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(NeedsDcloneV(1))));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -8812,13 +7974,12 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 32
-          items:
-            0: 0
-            2: 2
+    ptr: !Mem
+      Leaf:
+        credit: 32
+        items:
+          0: 0
+          2: 2
 "#);
 }
 
@@ -8827,7 +7988,6 @@ fn remove_last_key() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8841,19 +8001,17 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 0.0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 0.0
   "#));
     let r = tree.clone().remove(0, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(0.0)));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -8866,11 +8024,10 @@ root:
     txgs:
       start: 0
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 0
-          items: {}
+    ptr: !Mem
+      Leaf:
+        credit: 0
+        items: {}
 "#);
 }
 
@@ -8879,7 +8036,6 @@ fn remove_from_leaf() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8893,21 +8049,19 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Leaf:
-          credit: 48
-          items:
-            0: 0.0
-            1: 1.0
-            2: 2.0
+    ptr: !Mem
+      Leaf:
+        credit: 48
+        items:
+          0: 0.0
+          1: 1.0
+          2: 2.0
   "#));
     let r = tree.clone().remove(1, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(1.0)));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -8920,13 +8074,12 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 32
-          items:
-            0: 0.0
-            2: 2.0
+    ptr: !Mem
+      Leaf:
+        credit: 32
+        items:
+          0: 0.0
+          2: 2.0
 "#);
 }
 
@@ -8935,7 +8088,6 @@ fn remove_and_merge_down() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -8949,29 +8101,26 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
   "#));
     let r2 = tree.clone().remove(1, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -8984,13 +8133,12 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 32
-          items:
-            0: 0.0
-            2: 2.0
+    ptr: !Mem
+      Leaf:
+        credit: 32
+        items:
+          0: 0.0
+          2: 2.0
 "#);
 }
 
@@ -8999,7 +8147,6 @@ fn remove_and_merge_int_left() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9013,130 +8160,117 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 3
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                3: 3.0
-                                4: 4.0
-                      - key: 6
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                6: 6.0
-                                7: 7.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-            - key: 18
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 18
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                18: 18.0
-                                19: 19.0
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                21: 21.0
-                                22: 22.0
-                                23: 23.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 3
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      3: 3.0
+                      4: 4.0
+              - key: 6
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      6: 6.0
+                      7: 7.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+        - key: 18
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 18
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      18: 18.0
+                      19: 19.0
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      21: 21.0
+                      22: 22.0
+                      23: 23.0
 "#));
     let r2 = tree.clone().remove(23, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -9149,114 +8283,103 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 3
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                3: 3.0
-                                4: 4.0
-                      - key: 6
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                6: 6.0
-                                7: 7.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-                      - key: 18
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                18: 18.0
-                                19: 19.0
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                21: 21.0
-                                22: 22.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 3
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      3: 3.0
+                      4: 4.0
+              - key: 6
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      6: 6.0
+                      7: 7.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+              - key: 18
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      18: 18.0
+                      19: 19.0
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      21: 21.0
+                      22: 22.0
 "#);
 }
 
@@ -9265,7 +8388,6 @@ fn remove_and_merge_int_right() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9279,119 +8401,107 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 2
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                2: 2.0
-                                3: 3.0
-                                4: 4.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-            - key: 18
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 18
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                18: 18.0
-                                19: 19.0
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                21: 21.0
-                                22: 22.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 2
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      2: 2.0
+                      3: 3.0
+                      4: 4.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+        - key: 18
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 18
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      18: 18.0
+                      19: 19.0
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      21: 21.0
+                      22: 22.0
 "#));
     let r2 = tree.clone().remove(4, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -9404,103 +8514,93 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 2
-                        txgs:
-                          start: 41
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                2: 2.0
-                                3: 3.0
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-            - key: 18
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 18
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                18: 18.0
-                                19: 19.0
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                21: 21.0
-                                22: 22.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 2
+                txgs:
+                  start: 41
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      2: 2.0
+                      3: 3.0
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+        - key: 18
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 18
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      18: 18.0
+                      19: 19.0
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      21: 21.0
+                      22: 22.0
 "#);
 }
 
@@ -9509,7 +8609,6 @@ fn remove_and_merge_leaf_left() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9523,50 +8622,45 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
-            - key: 5
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      5: 5.0
-                      7: 7.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
+        - key: 5
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                5: 5.0
+                7: 7.0
   "#));
     let r2 = tree.clone().remove(7, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -9579,33 +8673,30 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      3: 3.0
-                      4: 4.0
-                      5: 5.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                3: 3.0
+                4: 4.0
+                5: 5.0
 "#);
 }
 
@@ -9614,7 +8705,6 @@ fn remove_and_merge_leaf_right() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9628,51 +8718,46 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
-            - key: 5
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
+        - key: 5
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                5: 5.0
+                6: 6.0
+                7: 7.0
   "#));
     let r2 = tree.clone().remove(4, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -9685,34 +8770,31 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      3: 3.0
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                3: 3.0
+                5: 5.0
+                6: 6.0
+                7: 7.0
 "#);
 }
 
@@ -9721,7 +8803,6 @@ fn remove_and_steal_int_left() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -9735,141 +8816,127 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 2
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                2: 2.0
-                                3: 3.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-                      - key: 17
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                17: 17.0
-                                18: 18.0
-                      - key: 19
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                19: 19.0
-                                20: 20.0
-            - key: 21
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                21: 21.0
-                                22: 22.0
-                      - key: 24
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                24: 24.0
-                                25: 25.0
-                                26: 26.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 2
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      2: 2.0
+                      3: 3.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+              - key: 17
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      17: 17.0
+                      18: 18.0
+              - key: 19
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      19: 19.0
+                      20: 20.0
+        - key: 21
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      21: 21.0
+                      22: 22.0
+              - key: 24
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      24: 24.0
+                      25: 25.0
+                      26: 26.0
 "#));
     let r2 = tree.clone().remove(26, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -9882,133 +8949,120 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 2
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                2: 2.0
-                                3: 3.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-                      - key: 17
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                17: 17.0
-                                18: 18.0
-            - key: 19
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 19
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                19: 19.0
-                                20: 20.0
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                21: 21.0
-                                22: 22.0
-                      - key: 24
-                        txgs:
-                          start: 41
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                24: 24.0
-                                25: 25.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 2
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      2: 2.0
+                      3: 3.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+              - key: 17
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      17: 17.0
+                      18: 18.0
+        - key: 19
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 19
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      19: 19.0
+                      20: 20.0
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      21: 21.0
+                      22: 22.0
+              - key: 24
+                txgs:
+                  start: 41
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      24: 24.0
+                      25: 25.0
 "#);
 }
 
@@ -10017,7 +9071,6 @@ fn remove_and_steal_int_right() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -10031,141 +9084,127 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 2
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                2: 2.0
-                                3: 3.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                12: 12.0
-                                13: 13.0
-                                14: 14.0
-            - key: 15
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-                      - key: 17
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                17: 17.0
-                                18: 18.0
-                      - key: 19
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                19: 19.0
-                                20: 20.0
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                21: 21.0
-                                22: 22.0
-                      - key: 24
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                24: 24.0
-                                26: 26.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 2
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      2: 2.0
+                      3: 3.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      12: 12.0
+                      13: 13.0
+                      14: 14.0
+        - key: 15
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+              - key: 17
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      17: 17.0
+                      18: 18.0
+              - key: 19
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      19: 19.0
+                      20: 20.0
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      21: 21.0
+                      22: 22.0
+              - key: 24
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      24: 24.0
+                      26: 26.0
 "#));
     let r2 = tree.clone().remove(14, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -10178,133 +9217,120 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 2
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                2: 2.0
-                                3: 3.0
-            - key: 9
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-            - key: 17
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 17
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                17: 17.0
-                                18: 18.0
-                      - key: 19
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                19: 19.0
-                                20: 20.0
-                      - key: 21
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                21: 21.0
-                                22: 22.0
-                      - key: 24
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                24: 24.0
-                                26: 26.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 2
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      2: 2.0
+                      3: 3.0
+        - key: 9
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+        - key: 17
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 17
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      17: 17.0
+                      18: 18.0
+              - key: 19
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      19: 19.0
+                      20: 20.0
+              - key: 21
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      21: 21.0
+                      22: 22.0
+              - key: 24
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      24: 24.0
+                      26: 26.0
 "#);
 }
 
@@ -10313,7 +9339,6 @@ fn remove_and_steal_leaf_left() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -10327,53 +9352,48 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 2
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      2: 2.0
-                      3: 3.0
-                      4: 4.0
-                      5: 5.0
-                      6: 6.0
-            - key: 8
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      8: 8.0
-                      9: 9.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 2
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                2: 2.0
+                3: 3.0
+                4: 4.0
+                5: 5.0
+                6: 6.0
+        - key: 8
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                8: 8.0
+                9: 9.0
   "#));
     let r2 = tree.clone().remove(8, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -10386,45 +9406,41 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 2
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      2: 2.0
-                      3: 3.0
-                      4: 4.0
-                      5: 5.0
-            - key: 6
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      6: 6.0
-                      9: 9.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 2
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                2: 2.0
+                3: 3.0
+                4: 4.0
+                5: 5.0
+        - key: 6
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                6: 6.0
+                9: 9.0
 "#);
 }
 
@@ -10433,7 +9449,6 @@ fn remove_and_steal_leaf_right() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -10447,53 +9462,48 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      4: 4.0
-            - key: 5
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 80
-                    items:
-                      5: 5.0
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
-                      9: 9.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                4: 4.0
+        - key: 5
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 80
+              items:
+                5: 5.0
+                6: 6.0
+                7: 7.0
+                8: 8.0
+                9: 9.0
   "#));
     let r2 = tree.clone().remove(4, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -10506,45 +9516,41 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      1: 1.0
-            - key: 3
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      5: 5.0
-            - key: 6
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      6: 6.0
-                      7: 7.0
-                      8: 8.0
-                      9: 9.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                1: 1.0
+        - key: 3
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                5: 5.0
+        - key: 6
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                6: 6.0
+                7: 7.0
+                8: 8.0
+                9: 9.0
 "#);
 }
 

--- a/bfffs-core/src/tree/tree/tests/io.rs
+++ b/bfffs-core/src/tree/tree/tests/io.rs
@@ -64,7 +64,6 @@ async fn addresses() {
 
     let dml = Arc::new(mock);
     let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -78,49 +77,43 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 8
-                end: 9
-              ptr:
-                Addr: 3
-            - key: 10
-              txgs:
-                start: 20
-                end: 32
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 10
-                        txgs:
-                          start: 9
-                          end: 10
-                        ptr:
-                          Addr: 2
-                      - key: 15
-                        txgs:
-                          start: 9
-                          end: 10
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                15: 15.0
-                                16: 16.0
-                                17: 17.0
-            # This  Node is not returned due to its TXG range
-            - key: 20
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 4
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 8
+            end: 9
+          ptr: !Addr 3
+        - key: 10
+          txgs:
+            start: 20
+            end: 32
+          ptr: !Mem
+            Int:
+              children:
+              - key: 10
+                txgs:
+                  start: 9
+                  end: 10
+                ptr: !Addr 2
+              - key: 15
+                txgs:
+                  start: 9
+                  end: 10
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      15: 15.0
+                      16: 16.0
+                      17: 17.0
+        # This  Node is not returned due to its TXG range
+        - key: 20
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Addr 4
 "#);
     let addrs = tree.addresses(TxgT::from(5)..)
         .collect::<Vec<_>>()
@@ -135,7 +128,6 @@ async fn addresses_leaf() {
     let addrl = 0;
     let dml = Arc::new(mock);
     let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -149,8 +141,7 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Addr: 0"#);
+    ptr: !Addr 0"#);
     let addrs = tree.addresses(..)
         .collect::<Vec<_>>()
         .await;
@@ -215,7 +206,6 @@ fn dump() {
 
     let dml = Arc::new(mock);
     let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -229,52 +219,45 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 8
-                end: 9
-              ptr:
-                Addr: 3
-            - key: 10
-              txgs:
-                start: 20
-                end: 32
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 10
-                        txgs:
-                          start: 9
-                          end: 10
-                        ptr:
-                          Addr: 2
-                      - key: 15
-                        txgs:
-                          start: 9
-                          end: 10
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                15: 15.0
-                                16: 16.0
-                                17: 17.0
-            - key: 20
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 4
+    ptr: !Mem
+      Int:
+        children:
+          - key: 0
+            txgs:
+              start: 8
+              end: 9
+            ptr: !Addr 3
+          - key: 10
+            txgs:
+              start: 20
+              end: 32
+            ptr: !Mem
+              Int:
+                children:
+                  - key: 10
+                    txgs:
+                      start: 9
+                      end: 10
+                    ptr: !Addr 2
+                  - key: 15
+                    txgs:
+                      start: 9
+                      end: 10
+                    ptr: !Mem
+                      Leaf:
+                        credit: 48
+                        items:
+                          15: 15.0
+                          16: 16.0
+                          17: 17.0
+          - key: 20
+            txgs:
+              start: 0
+              end: 1
+            ptr: !Addr 4
   "#);
 let expected =
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -287,116 +270,95 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 8
-                end: 9
-              ptr:
-                Addr: 3
-            - key: 10
-              txgs:
-                start: 20
-                end: 32
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 10
-                        txgs:
-                          start: 9
-                          end: 10
-                        ptr:
-                          Addr: 2
-                      - key: 15
-                        txgs:
-                          start: 9
-                          end: 10
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                15: 15.0
-                                16: 16.0
-                                17: 17.0
-            - key: 20
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 4
-...
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 8
+            end: 9
+          ptr: !Addr 3
+        - key: 10
+          txgs:
+            start: 20
+            end: 32
+          ptr: !Mem
+            Int:
+              children:
+              - key: 10
+                txgs:
+                  start: 9
+                  end: 10
+                ptr: !Addr 2
+              - key: 15
+                txgs:
+                  start: 9
+                  end: 10
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      15: 15.0
+                      16: 16.0
+                      17: 17.0
+        - key: 20
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Addr 4
 ---
-0:
-  Leaf:
-    credit: 0
-    items:
-      0: 0.0
-      1: 1.0
-1:
-  Leaf:
-    credit: 0
-    items:
-      2: 2.0
-      3: 3.0
-...
+0: !Leaf
+  credit: 0
+  items:
+    0: 0.0
+    1: 1.0
+1: !Leaf
+  credit: 0
+  items:
+    2: 2.0
+    3: 3.0
 ---
-2:
-  Leaf:
-    credit: 0
-    items:
-      10: 10.0
-      11: 11.0
-...
+2: !Leaf
+  credit: 0
+  items:
+    10: 10.0
+    11: 11.0
 ---
-5:
-  Leaf:
-    credit: 0
-    items:
-      20: 20.0
-      21: 21.0
-6:
-  Leaf:
-    credit: 0
-    items:
-      25: 25.0
-      26: 26.0
-...
+5: !Leaf
+  credit: 0
+  items:
+    20: 20.0
+    21: 21.0
+6: !Leaf
+  credit: 0
+  items:
+    25: 25.0
+    26: 26.0
 ---
-3:
-  Int:
-    children:
-      - key: 0
-        txgs:
-          start: 8
-          end: 9
-        ptr:
-          Addr: 0
-      - key: 2
-        txgs:
-          start: 8
-          end: 9
-        ptr:
-          Addr: 1
-4:
-  Int:
-    children:
-      - key: 20
-        txgs:
-          start: 8
-          end: 9
-        ptr:
-          Addr: 5
-      - key: 25
-        txgs:
-          start: 8
-          end: 9
-        ptr:
-          Addr: 6
+3: !Int
+  children:
+  - key: 0
+    txgs:
+      start: 8
+      end: 9
+    ptr: !Addr 0
+  - key: 2
+    txgs:
+      start: 8
+      end: 9
+    ptr: !Addr 1
+4: !Int
+  children:
+  - key: 20
+    txgs:
+      start: 8
+      end: 9
+    ptr: !Addr 5
+  - key: 25
+    txgs:
+      start: 8
+      end: 9
+    ptr: !Addr 6
 "#;
     let mut out = Vec::new();
     tree.dump(&mut out).now_or_never().unwrap().unwrap();
@@ -431,7 +393,6 @@ fn dump_error() {
 
     let dml = Arc::new(mock);
     let tree: Tree<u32, MockDML, u32, f32> = Tree::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -445,32 +406,27 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 8
-                end: 9
-              ptr:
-                Addr: 3
-            - key: 10
-              txgs:
-                start: 20
-                end: 32
-              ptr:
-                Addr: 4
-            - key: 20
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 5
+    ptr: !Mem
+      Int:
+        children:
+          - key: 0
+            txgs:
+              start: 8
+              end: 9
+            ptr: !Addr 3
+          - key: 10
+            txgs:
+              start: 20
+              end: 32
+            ptr: !Addr 4
+          - key: 20
+            txgs:
+              start: 0
+              end: 1
+            ptr: !Addr 5
   "#);
 let expected =
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -483,45 +439,36 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 8
-                end: 9
-              ptr:
-                Addr: 3
-            - key: 10
-              txgs:
-                start: 20
-                end: 32
-              ptr:
-                Addr: 4
-            - key: 20
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Addr: 5
-...
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 8
+            end: 9
+          ptr: !Addr 3
+        - key: 10
+          txgs:
+            start: 20
+            end: 32
+          ptr: !Addr 4
+        - key: 20
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Addr 5
+--- 'Error reading 4: EIO'
 ---
-"Error reading 4: EIO"
-...
----
-3:
-  Leaf:
-    credit: 0
-    items:
-      0: 0.0
-      1: 1.0
-5:
-  Leaf:
-    credit: 0
-    items:
-      20: 20.0
-      21: 21.0
+3: !Leaf
+  credit: 0
+  items:
+    0: 0.0
+    1: 1.0
+5: !Leaf
+  credit: 0
+  items:
+    20: 20.0
+    21: 21.0
 "#;
     let mut out = Vec::new();
     tree.dump(&mut out).now_or_never().unwrap().unwrap();
@@ -560,7 +507,6 @@ fn insert_dclone() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, NeedsDcloneV>::from_str(
         dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -574,16 +520,14 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Addr: 0
+    ptr: !Addr 0
   "#));
 
     let r = tree.clone().insert(4, NeedsDcloneV(400), txg, Credit::forge(16))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(Some(NeedsDcloneV(4))));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -596,13 +540,12 @@ root:
     txgs:
       start: 42
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 32
-          items:
-            3: 3
-            4: 400
+    ptr: !Mem
+      Leaf:
+        credit: 32
+        items:
+          3: 3
+          4: 400
 "#);
 }
 
@@ -624,7 +567,6 @@ fn insert_below_root() {
         });
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -638,30 +580,26 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 0
-            - key: 256
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 256
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 0
+        - key: 256
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 256
   "#));
 
     let r = tree.clone().insert(0, 0, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(None));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -674,29 +612,26 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      0: 0
-                      3: 3
-                      4: 4
-                      5: 5
-            - key: 256
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 256
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                0: 0
+                3: 3
+                4: 4
+                5: 5
+        - key: 256
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 256
 "#);
 }
 
@@ -719,7 +654,6 @@ fn insert_insufficient_credit() {
         });
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -733,22 +667,19 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 0
-            - key: 256
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 256
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 0
+        - key: 256
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 256
   "#));
 
     tree.insert(0, 0, TxgT::from(42), Credit::forge(8))
@@ -770,7 +701,6 @@ fn insert_root() {
         });
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -784,16 +714,14 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Addr: 0
+    ptr: !Addr 0
   "#));
 
     let r = tree.clone().insert(0, 0, TxgT::from(42), Credit::forge(8))
         .now_or_never().unwrap();
     assert_eq!(r, Ok(None));
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -806,12 +734,11 @@ root:
     txgs:
       start: 42
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 0
 "#);
 }
 
@@ -835,7 +762,6 @@ fn insert_split_root_leaf() {
         });
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -849,15 +775,13 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Addr: 0
+    ptr: !Addr 0
   "#));
     let r2 = tree.clone().insert(5, 5.0, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -870,34 +794,31 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      0: 0.0
-                      1: 1.0
-                      2: 2.0
-            - key: 3
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      3: 3.0
-                      4: 4.0
-                      5: 5.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                0: 0.0
+                1: 1.0
+                2: 2.0
+        - key: 3
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                3: 3.0
+                4: 4.0
+                5: 5.0
 "#);
 }
 
@@ -914,7 +835,6 @@ fn is_dirty() {
         });
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -928,8 +848,7 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Addr: 0
+    ptr: !Addr 0
   "#));
 
     assert!(!tree.is_dirty());
@@ -1036,7 +955,6 @@ fn range_delete() {
 
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1050,34 +968,29 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 8
-                end: 9
-              ptr:
-                Addr: 0
-            - key: 10
-              txgs:
-                start: 20
-                end: 32
-              ptr:
-                Addr: 1
-            - key: 20
-              txgs:
-                start: 8
-                end: 24
-              ptr:
-                Addr: 2
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 8
+            end: 9
+          ptr: !Addr 0
+        - key: 10
+          txgs:
+            start: 20
+            end: 32
+          ptr: !Addr 1
+        - key: 20
+          txgs:
+            start: 8
+            end: 24
+          ptr: !Addr 2
   "#));
     tree.clone().range_delete(5..25, TxgT::from(42), Credit::forge(120))
         .now_or_never().unwrap().unwrap();
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -1090,67 +1003,58 @@ root:
     txgs:
       start: 0
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 10
-                      - key: 1
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 11
-            - key: 3
-              txgs:
-                start: 0
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 3
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                3: 3.0
-                                4: 4.0
-                      - key: 26
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 31
-                      - key: 29
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 32
-                      - key: 30
-                        txgs:
-                          start: 0
-                          end: 1
-                        ptr:
-                          Addr: 33
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 10
+              - key: 1
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 11
+        - key: 3
+          txgs:
+            start: 0
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 3
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      3: 3.0
+                      4: 4.0
+              - key: 26
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 31
+              - key: 29
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 32
+              - key: 30
+                txgs:
+                  start: 0
+                  end: 1
+                ptr: !Addr 33
 "#);
 }
 
@@ -1179,7 +1083,6 @@ fn range_delete_dclone() {
         .return_once(move |_, _| future::ok(Box::new(node1)).boxed());
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, NeedsDcloneV>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1193,28 +1096,24 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 1
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 0
-            - key: 11
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1
-            - key: 21
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 2
+    ptr: !Mem
+      Int:
+        children:
+        - key: 1
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 0
+        - key: 11
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1
+        - key: 21
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 2
   "#));
     let r = tree.range_delete(11..21, txg, Credit::forge(64))
         .now_or_never().unwrap();
@@ -1242,7 +1141,6 @@ fn range_delete_left_in_cut_full() {
 
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1256,112 +1154,99 @@ root:
     txgs:
       start: 0
       end: 3
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 3
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 81
-                      - key: 22
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Addr: 94
-                      - key: 25
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                25: 21
-                                31: 27
-                                32: 16
-                      - key: 33
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                33: 17
-                                34: 18
-                                35: 19
-                      - key: 37
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                37: 17
-                                38: 18
-                                39: 19
-            - key: 46
-              txgs:
-                start: 1
-                end: 3
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 46
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 80
-                              items:
-                                46: 20
-                                47: 21
-                                48: 27
-                                77: 33
-                                78: 34
-                      - key: 69
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 84
-                      - key: 72
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Addr: 172
-                      - key: 75
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Addr: 175
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 3
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 81
+              - key: 22
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Addr 94
+              - key: 25
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      25: 21
+                      31: 27
+                      32: 16
+              - key: 33
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      33: 17
+                      34: 18
+                      35: 19
+              - key: 37
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      37: 17
+                      38: 18
+                      39: 19
+        - key: 46
+          txgs:
+            start: 1
+            end: 3
+          ptr: !Mem
+            Int:
+              children:
+              - key: 46
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 80
+                    items:
+                      46: 20
+                      47: 21
+                      48: 27
+                      77: 33
+                      78: 34
+              - key: 69
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 84
+              - key: 72
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Addr 172
+              - key: 75
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Addr 175
   "#));
     tree.clone().range_delete(4..32, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap().unwrap();
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -1374,83 +1259,74 @@ root:
     txgs:
       start: 0
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 2
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 25
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                32: 16.0
-                                33: 17.0
-                                34: 18.0
-                                35: 19.0
-                      - key: 37
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                37: 17.0
-                                38: 18.0
-                                39: 19.0
-                      - key: 46
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 80
-                              items:
-                                46: 20.0
-                                47: 21.0
-                                48: 27.0
-                                77: 33.0
-                                78: 34.0
-            - key: 69
-              txgs:
-                start: 1
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 69
-                        txgs:
-                          start: 1
-                          end: 2
-                        ptr:
-                          Addr: 84
-                      - key: 72
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Addr: 172
-                      - key: 75
-                        txgs:
-                          start: 2
-                          end: 3
-                        ptr:
-                          Addr: 175
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 2
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 25
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      32: 16.0
+                      33: 17.0
+                      34: 18.0
+                      35: 19.0
+              - key: 37
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      37: 17.0
+                      38: 18.0
+                      39: 19.0
+              - key: 46
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Mem
+                  Leaf:
+                    credit: 80
+                    items:
+                      46: 20.0
+                      47: 21.0
+                      48: 27.0
+                      77: 33.0
+                      78: 34.0
+        - key: 69
+          txgs:
+            start: 1
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 69
+                txgs:
+                  start: 1
+                  end: 2
+                ptr: !Addr 84
+              - key: 72
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Addr 172
+              - key: 75
+                txgs:
+                  start: 2
+                  end: 3
+                ptr: !Addr 175
 "#);
 }
 
@@ -1486,7 +1362,6 @@ async fn range_leaf() {
         });
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1500,8 +1375,7 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Addr: 0
+    ptr: !Addr 0
   "#));
     let r = tree.range(1..3)
         .try_collect()
@@ -1530,7 +1404,6 @@ fn read_int() {
     let dml = Arc::new(mock);
     let tree: Tree<u32, MockDML, u32, u32> =
         Tree::from_str(dml.clone(), false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1544,8 +1417,7 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Addr: 102
+    ptr: !Addr 102
   "#);
 
     let root_guard = tree.root.try_read().unwrap();
@@ -1574,7 +1446,6 @@ fn read_leaf() {
         .return_once(move |_| future::ok(Box::new(node)).boxed());
     let dml = Arc::new(mock);
     let tree: Tree<u32, MockDML, u32, u32> = Tree::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1588,8 +1459,7 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Addr: 0
+    ptr: !Addr 0
   "#);
 
     let r = tree.get(1).now_or_never().unwrap();
@@ -1621,7 +1491,6 @@ fn remove() {
 
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1635,30 +1504,26 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1
   "#));
     let r2 = tree.clone().remove(4, TxgT::from(42), Credit::forge(48))
         .now_or_never()
         .unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -1671,27 +1536,24 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      3: 3.0
-                      5: 5.0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                3: 3.0
+                5: 5.0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1
 "#);
 }
 
@@ -1728,7 +1590,6 @@ fn remove_dclone() {
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, NeedsDcloneV>::from_str(
         dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1742,8 +1603,7 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Addr: 0
+    ptr: !Addr 0
   "#));
 
     let r = tree.clone().remove(4, txg, Credit::forge(48))
@@ -1751,8 +1611,7 @@ root:
         .unwrap();
     assert_eq!(Ok(Some(NeedsDcloneV(4))), r);
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -1765,13 +1624,12 @@ root:
     txgs:
       start: 0
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 32
-          items:
-            3: 3
-            5: 5
+    ptr: !Mem
+      Leaf:
+        credit: 32
+        items:
+          3: 3
+          5: 5
 "#);
 }
 
@@ -1803,7 +1661,6 @@ fn remove_and_merge_down() {
 
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1817,24 +1674,21 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 0
   "#));
     let r2 = tree.clone().remove(1, TxgT::from(42), Credit::forge(80))
         .now_or_never()
         .unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -1847,14 +1701,13 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Leaf:
-          credit: 48
-          items:
-            3: 3.0
-            4: 4.0
-            5: 5.0
+    ptr: !Mem
+      Leaf:
+        credit: 48
+        items:
+          3: 3.0
+          4: 4.0
+          5: 5.0
 "#);
 }
 
@@ -1901,7 +1754,6 @@ fn remove_and_steal_leaf_left() {
 
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -1915,35 +1767,30 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 0
-            - key: 2
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1
-            - key: 8
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 2
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 0
+        - key: 2
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1
+        - key: 8
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 2
   "#));
     let r2 = tree.clone().remove(8, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -1956,40 +1803,36 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 0
-            - key: 2
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      2: 2.0
-                      3: 3.0
-                      4: 4.0
-                      5: 5.0
-            - key: 6
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      6: 6.0
-                      9: 9.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 0
+        - key: 2
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                2: 2.0
+                3: 3.0
+                4: 4.0
+                5: 5.0
+        - key: 6
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                6: 6.0
+                9: 9.0
 "#);
 }
 
@@ -2022,7 +1865,6 @@ fn remove_insufficient_credit() {
 
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2036,22 +1878,19 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 0
-            - key: 10
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 1
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 0
+        - key: 10
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 1
   "#));
     tree.remove(4, TxgT::from(42), Credit::forge(15))
         .now_or_never()
@@ -2066,7 +1905,6 @@ fn serialize_alloc_t() {
     let idml = Arc::new(mock);
     let typical_tree: Tree<DRP, DDML, PBA, RID> =
         Tree::from_str(idml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2082,8 +1920,7 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Addr:
+    ptr: !Addr
         pba:
           cluster: 2
           lba: 0x0102030405060708
@@ -2104,7 +1941,6 @@ fn serialize_forest() {
     let idml = Arc::new(mock);
     let typical_tree: Tree<RID, IDML, FSKey, FSValue> =
         Tree::from_str(idml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2118,8 +1954,7 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Addr:
+    ptr: !Addr
         1
   "#);
 
@@ -2146,7 +1981,6 @@ fn serialize_inner() {
     let mock = DDML::default();
     let ddml = Arc::new(mock);
     let tree: Tree<DRP, DDML, u32, u32> = Tree::from_str(ddml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2160,8 +1994,7 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Addr:
+    ptr: !Addr
         pba:
           cluster: 2
           lba: 0x0102030405060708
@@ -2179,7 +2012,6 @@ root:
 fn write_clean() {
     let dml = Arc::new(MockDML::new());
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2193,8 +2025,7 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Addr: 0
+    ptr: !Addr 0
   "#));
 
     let r = tree.flush(TxgT::from(42)).now_or_never().unwrap();
@@ -2243,7 +2074,6 @@ fn write_height2() {
         }).return_once(move |_, _, _| future::ok(addri).boxed());
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2257,35 +2087,31 @@ root:
     txgs:
       start: 30
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 100
-                      1: 200
-            - key: 256
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Addr: 256
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 100
+                1: 200
+        - key: 256
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Addr 256
   "#));
 
     let r = tree.clone().flush(TxgT::from(42)).now_or_never().unwrap();
     assert!(r.is_ok());
 
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -2298,8 +2124,7 @@ root:
     txgs:
       start: 41
       end: 43
-    ptr:
-      Addr: 101
+    ptr: !Addr 101
 "#);
 }
 
@@ -2391,7 +2216,6 @@ fn write_height3() {
         }).return_once(move |_, _, _| future::ok(11).boxed());
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2405,85 +2229,74 @@ root:
     txgs:
       start: 0
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 5
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 10
-                        txgs:
-                          start: 9
-                          end: 10
-                        ptr:
-                          Addr: 2
-                      - key: 15
-                        txgs:
-                          start: 9
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                15: 15.0
-                                16: 16.0
-                      - key: 20
-                        txgs:
-                          start: 5
-                          end: 7
-                        ptr:
-                          Addr: 3
-            - key: 30
-              txgs:
-                start: 20
-                end: 32
-              ptr:
-                Addr: 4
-            - key: 40
-              txgs:
-                start: 7
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 40
-                        txgs:
-                          start: 9
-                          end: 10
-                        ptr:
-                          Addr: 5
-                      - key: 50
-                        txgs:
-                          start: 11
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                50: 50.0
-                                51: 51.0
-                      - key: 60
-                        txgs:
-                          start: 7
-                          end: 8
-                        ptr:
-                          Addr: 6
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 5
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 10
+                txgs:
+                  start: 9
+                  end: 10
+                ptr: !Addr 2
+              - key: 15
+                txgs:
+                  start: 9
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      15: 15.0
+                      16: 16.0
+              - key: 20
+                txgs:
+                  start: 5
+                  end: 7
+                ptr: !Addr 3
+        - key: 30
+          txgs:
+            start: 20
+            end: 32
+          ptr: !Addr 4
+        - key: 40
+          txgs:
+            start: 7
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 40
+                txgs:
+                  start: 9
+                  end: 10
+                ptr: !Addr 5
+              - key: 50
+                txgs:
+                  start: 11
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      50: 50.0
+                      51: 51.0
+              - key: 60
+                txgs:
+                  start: 7
+                  end: 8
+                ptr: !Addr 6
   "#));
 
     let r = tree.clone().flush(TxgT::from(42)).now_or_never().unwrap();
     assert!(r.is_ok());
     assert_eq!(format!("{tree}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -2496,8 +2309,7 @@ root:
     txgs:
       start: 5
       end: 43
-    ptr:
-      Addr: 11
+    ptr: !Addr 11
 "#);
 }
 
@@ -2519,7 +2331,6 @@ fn write_int() {
     let dml = Arc::new(mock);
     let mut tree = Arc::new(
         Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2533,22 +2344,19 @@ root:
     txgs:
       start: 5
       end: 25
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 5
-                end: 15
-              ptr:
-                Addr: 0
-            - key: 256
-              txgs:
-                start: 18
-                end: 25
-              ptr:
-                Addr: 256
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 5
+            end: 15
+          ptr: !Addr 0
+        - key: 256
+          txgs:
+            start: 18
+            end: 25
+          ptr: !Addr 256
   "#));
 
     let r = tree.clone().flush(TxgT::from(42)).now_or_never().unwrap();
@@ -2581,7 +2389,6 @@ fn write_leaf() {
     let dml = Arc::new(mock);
     let mut tree = Arc::new(
         Tree::<u32, MockDML, u32, u32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2595,13 +2402,12 @@ root:
     txgs:
       start: 0
       end: 1
-    ptr:
-      Mem:
-        Leaf:
-          credit: 32
-          items:
-            0: 100
-            1: 200
+    ptr: !Mem
+      Leaf:
+        credit: 32
+        items:
+          0: 100
+          1: 200
   "#));
 
     let r = tree.clone().flush(TxgT::from(42)).now_or_never().unwrap();
@@ -2689,7 +2495,6 @@ fn write_race() {
 
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -2703,85 +2508,75 @@ root:
     txgs:
       start: 30
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 5
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Addr: 0
-            - key: 10
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 10
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                10: 10.0
-                                11: 11.0
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1
-            - key: 20
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 20
-                        txgs:
-                          start: 41
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                20: 20.0
-                                21: 21.0
-                      - key: 25
-                        txgs:
-                          start: 40
-                          end: 41
-                        ptr:
-                          Addr: 2
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 5
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Addr 0
+        - key: 10
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 10
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      10: 10.0
+                      11: 11.0
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1
+        - key: 20
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 20
+                txgs:
+                  start: 41
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      20: 20.0
+                      21: 21.0
+              - key: 25
+                txgs:
+                  start: 40
+                  end: 41
+                ptr: !Addr 2
   "#));
     *otree.write().unwrap() = Some(tree);
     let guard = otree.read().unwrap();
@@ -2791,8 +2586,7 @@ root:
     assert_eq!(r, Ok(true));
 
     assert_eq!(format!("{tref}"),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -2805,76 +2599,66 @@ root:
     txgs:
       start: 30
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                0: 0.0
-                                1: 1.0
-                                2: 2.0
-                      - key: 5
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Addr: 0
-            - key: 10
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 10
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Addr: 70
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 1
-            - key: 20
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 20
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Addr: 71
-                      - key: 25
-                        txgs:
-                          start: 40
-                          end: 41
-                        ptr:
-                          Addr: 2
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      0: 0.0
+                      1: 1.0
+                      2: 2.0
+              - key: 5
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Addr 0
+        - key: 10
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 10
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Addr 70
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 1
+        - key: 20
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 20
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Addr 71
+              - key: 25
+                txgs:
+                  start: 40
+                  end: 41
+                ptr: !Addr 2
 "#);
 }
 

--- a/bfffs-core/src/tree/tree/tests/txg.rs
+++ b/bfffs-core/src/tree/tree/tests/txg.rs
@@ -10,7 +10,6 @@ fn check_bad_root_txgs() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -24,32 +23,29 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 42
-                end: 43
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 1.0
-                      1: 2.0
-            - key: 256
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      256: 256.0
-                      257: 257.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 42
+            end: 43
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 1.0
+                1: 2.0
+        - key: 256
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                256: 256.0
+                257: 257.0
   "#));
 
     assert!(!tree.check()
@@ -62,7 +58,6 @@ fn check_bad_int_txgs() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -76,70 +71,63 @@ root:
     txgs:
       start: 20
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 30
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 30
-                          end: 31
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 1.0
-                                1: 2.0
-                      - key: 2
-                        txgs:
-                          start: 31
-                          end: 32
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                2: 3.0
-                                3: 4.0
-            - key: 9
-              txgs:
-                start: 21
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                9: 9.0
-                                10: 10.0
-                      - key: 12
-                        txgs:
-                          start: 20
-                          end: 21
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 30
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 30
+                  end: 31
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 1.0
+                      1: 2.0
+              - key: 2
+                txgs:
+                  start: 31
+                  end: 32
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      2: 3.0
+                      3: 4.0
+        - key: 9
+          txgs:
+            start: 21
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      9: 9.0
+                      10: 10.0
+              - key: 12
+                txgs:
+                  start: 20
+                  end: 21
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
   "#));
 
     assert!(!tree.check()
@@ -152,7 +140,6 @@ fn check_bad_key() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -166,32 +153,29 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 11
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      10: 10.0
-                      11: 11.0
-            - key: 13
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      13: 13.0
-                      14: 14.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 11
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                10: 10.0
+                11: 11.0
+        - key: 13
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                13: 13.0
+                14: 14.0
   "#));
 
     assert!(!tree.check()
@@ -204,7 +188,6 @@ fn check_ok() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -218,73 +201,66 @@ root:
     txgs:
       start: 20
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 30
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 30
-                          end: 31
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                0: 0.0
-                                1: 1.0
-                      - key: 2
-                        txgs:
-                          start: 31
-                          end: 32
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 80
-                              items:
-                                2: 2.0
-                                3: 3.0
-                                4: 4.0
-                                5: 5.0
-                                6: 6.0
-            - key: 9
-              txgs:
-                start: 20
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                10: 10.0
-                                11: 11.0
-                      - key: 12
-                        txgs:
-                          start: 20
-                          end: 21
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                12: 12.0
-                                13: 13.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 30
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 30
+                  end: 31
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      0: 0.0
+                      1: 1.0
+              - key: 2
+                txgs:
+                  start: 31
+                  end: 32
+                ptr: !Mem
+                  Leaf:
+                    credit: 80
+                    items:
+                      2: 2.0
+                      3: 3.0
+                      4: 4.0
+                      5: 5.0
+                      6: 6.0
+        - key: 9
+          txgs:
+            start: 20
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      10: 10.0
+                      11: 11.0
+              - key: 12
+                txgs:
+                  start: 20
+                  end: 21
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      12: 12.0
+                      13: 13.0
   "#));
 
     assert!(tree.check()
@@ -310,7 +286,6 @@ fn check_leaf_underflow() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -324,31 +299,28 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 9
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 16
-                    items:
-                      10: 10.0
-            - key: 13
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      13: 13.0
-                      14: 14.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 9
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 16
+              items:
+                10: 10.0
+        - key: 13
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                13: 13.0
+                14: 14.0
   "#));
 
     assert!(!tree.check()
@@ -362,7 +334,6 @@ fn check_root_int_underflow() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 3
   max_int_fanout: 7
@@ -376,36 +347,33 @@ root:
     txgs:
       start: 41
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 9
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      10: 10.0
-                      11: 11.0
-                      12: 12.0
-                      13: 13.0
-            - key: 19
-              txgs:
-                start: 41
-                end: 42
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 64
-                    items:
-                      20: 20.0
-                      21: 21.0
-                      22: 22.0
-                      23: 23.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 9
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                10: 10.0
+                11: 11.0
+                12: 12.0
+                13: 13.0
+        - key: 19
+          txgs:
+            start: 41
+            end: 42
+          ptr: !Mem
+            Leaf:
+              credit: 64
+              items:
+                20: 20.0
+                21: 21.0
+                22: 22.0
+                23: 23.0
   "#));
 
     assert!(tree.check()
@@ -419,7 +387,6 @@ fn check_root_leaf_ok() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -433,12 +400,11 @@ root:
     txgs:
       start: 0
       end: 1
-    ptr:
-      Mem:
-        Leaf:
-          credit: 16
-          items:
-            0: 0.0
+    ptr: !Mem
+      Leaf:
+        credit: 16
+        items:
+          0: 0.0
   "#));
 
     assert!(tree.check()
@@ -451,7 +417,6 @@ fn check_root_leaf_overflow() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -465,17 +430,16 @@ root:
     txgs:
       start: 0
       end: 1
-    ptr:
-      Mem:
-        Leaf:
-          credit: 96
-          items:
-            0: 0.0
-            1: 1.0
-            2: 2.0
-            3: 3.0
-            4: 4.0
-            5: 5.0
+    ptr: !Mem
+      Leaf:
+        credit: 96
+        items:
+          0: 0.0
+          1: 1.0
+          2: 2.0
+          3: 3.0
+          4: 4.0
+          5: 5.0
   "#));
 
     assert!(!tree.check()
@@ -489,7 +453,6 @@ fn check_unsorted() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -503,33 +466,30 @@ root:
     txgs:
       start: 0
       end: 1
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 32
-                    items:
-                      0: 0.0
-                      10: 10.0
-            - key: 5
-              txgs:
-                start: 0
-                end: 1
-              ptr:
-                Mem:
-                  Leaf:
-                    credit: 48
-                    items:
-                      5: 5.0
-                      6: 6.0
-                      11: 11.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Mem
+            Leaf:
+              credit: 32
+              items:
+                0: 0.0
+                10: 10.0
+        - key: 5
+          txgs:
+            start: 0
+            end: 1
+          ptr: !Mem
+            Leaf:
+              credit: 48
+              items:
+                5: 5.0
+                6: 6.0
+                11: 11.0
   "#));
 
     assert!(!tree.check()
@@ -553,7 +513,6 @@ fn merge() {
         .return_once(move |_, _| Box::pin(future::ok(Box::new(ln1))));
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -567,69 +526,59 @@ root:
     txgs:
       start: 20
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 30
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 30
-                          end: 31
-                        ptr:
-                          Addr: 1
-                      - key: 2
-                        txgs:
-                          start: 31
-                          end: 32
-                        ptr:
-                          Addr: 2
-            - key: 9
-              txgs:
-                start: 20
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 3
-                      - key: 12
-                        txgs:
-                          start: 20
-                          end: 21
-                        ptr:
-                          Addr: 4
-                      - key: 15
-                        txgs:
-                          start: 24
-                          end: 25
-                        ptr:
-                          Addr: 5
-            - key: 18
-              txgs:
-                start: 15
-                end: 16
-              ptr:
-                Addr: 6
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 30
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 30
+                  end: 31
+                ptr: !Addr 1
+              - key: 2
+                txgs:
+                  start: 31
+                  end: 32
+                ptr: !Addr 2
+        - key: 9
+          txgs:
+            start: 20
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 3
+              - key: 12
+                txgs:
+                  start: 20
+                  end: 21
+                ptr: !Addr 4
+              - key: 15
+                txgs:
+                  start: 24
+                  end: 25
+                ptr: !Addr 5
+        - key: 18
+          txgs:
+            start: 15
+            end: 16
+          ptr: !Addr 6
 "#));
     let r2 = tree.clone().remove(4, TxgT::from(42), Credit::forge(40))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -642,59 +591,51 @@ root:
     txgs:
       start: 20
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 20
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 30
-                          end: 31
-                        ptr:
-                          Addr: 1
-                      - key: 2
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                2: 2.0
-                                3: 3.0
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 3
-                      - key: 12
-                        txgs:
-                          start: 20
-                          end: 21
-                        ptr:
-                          Addr: 4
-                      - key: 15
-                        txgs:
-                          start: 24
-                          end: 25
-                        ptr:
-                          Addr: 5
-            - key: 18
-              txgs:
-                start: 15
-                end: 16
-              ptr:
-                Addr: 6
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 20
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 30
+                  end: 31
+                ptr: !Addr 1
+              - key: 2
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      2: 2.0
+                      3: 3.0
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 3
+              - key: 12
+                txgs:
+                  start: 20
+                  end: 21
+                ptr: !Addr 4
+              - key: 15
+                txgs:
+                  start: 24
+                  end: 25
+                ptr: !Addr 5
+        - key: 18
+          txgs:
+            start: 15
+            end: 16
+          ptr: !Addr 6
 "#);
 }
 
@@ -714,7 +655,6 @@ fn split() {
         .return_once(move |_, _| Box::pin(future::ok(Box::new(node))));
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -728,47 +668,40 @@ root:
     txgs:
       start: 3
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 4
-                end: 10
-              ptr:
-                Addr: 256
-            - key: 3
-              txgs:
-                start: 5
-                end: 11
-              ptr:
-                Addr: 512
-            - key: 6
-              txgs:
-                start: 3
-                end: 12
-              ptr:
-                Addr: 768
-            - key: 9
-              txgs:
-                start: 6
-                end: 22
-              ptr:
-                Addr: 1024
-            - key: 12
-              txgs:
-                start: 7
-                end: 34
-              ptr:
-                Addr: 1280
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 4
+            end: 10
+          ptr: !Addr 256
+        - key: 3
+          txgs:
+            start: 5
+            end: 11
+          ptr: !Addr 512
+        - key: 6
+          txgs:
+            start: 3
+            end: 12
+          ptr: !Addr 768
+        - key: 9
+          txgs:
+            start: 6
+            end: 22
+          ptr: !Addr 1024
+        - key: 12
+          txgs:
+            start: 7
+            end: 34
+          ptr: !Addr 1280
   "#));
     let r2 = tree.clone().insert(15, 15.0, TxgT::from(42), Credit::forge(80))
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -781,63 +714,55 @@ root:
     txgs:
       start: 3
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 3
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 0
-                        txgs:
-                          start: 4
-                          end: 10
-                        ptr:
-                          Addr: 256
-                      - key: 3
-                        txgs:
-                          start: 5
-                          end: 11
-                        ptr:
-                          Addr: 512
-                      - key: 6
-                        txgs:
-                          start: 3
-                          end: 12
-                        ptr:
-                          Addr: 768
-            - key: 9
-              txgs:
-                start: 6
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 6
-                          end: 22
-                        ptr:
-                          Addr: 1024
-                      - key: 12
-                        txgs:
-                          start: 42
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 64
-                              items:
-                                12: 12.0
-                                13: 13.0
-                                14: 14.0
-                                15: 15.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 3
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 0
+                txgs:
+                  start: 4
+                  end: 10
+                ptr: !Addr 256
+              - key: 3
+                txgs:
+                  start: 5
+                  end: 11
+                ptr: !Addr 512
+              - key: 6
+                txgs:
+                  start: 3
+                  end: 12
+                ptr: !Addr 768
+        - key: 9
+          txgs:
+            start: 6
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 6
+                  end: 22
+                ptr: !Addr 1024
+              - key: 12
+                txgs:
+                  start: 42
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 64
+                    items:
+                      12: 12.0
+                      13: 13.0
+                      14: 14.0
+                      15: 15.0
 "#);
 }
 
@@ -847,7 +772,6 @@ fn steal() {
     let mock = mock_dml();
     let dml = Arc::new(mock);
     let tree = Arc::new(Tree::<u32, MockDML, u32, f32>::from_str(dml, false, r#"
----
 limits:
   min_int_fanout: 2
   max_int_fanout: 5
@@ -861,87 +785,75 @@ root:
     txgs:
       start: 10
       end: 42
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 10
-                end: 11
-              ptr:
-                Addr: 0
-            - key: 9
-              txgs:
-                start: 21
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 9
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 12
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 15
-                      - key: 17
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 17
-                      - key: 19
-                        txgs:
-                          start: 21
-                          end: 22
-                        ptr:
-                          Addr: 19
-            - key: 21
-              txgs:
-                start: 39
-                end: 42
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 21
-                        txgs:
-                          start: 39
-                          end: 40
-                        ptr:
-                          Addr: 21
-                      - key: 24
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 48
-                              items:
-                                24: 24.0
-                                25: 25.0
-                                26: 26.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 10
+            end: 11
+          ptr: !Addr 0
+        - key: 9
+          txgs:
+            start: 21
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 9
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 12
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 15
+              - key: 17
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 17
+              - key: 19
+                txgs:
+                  start: 21
+                  end: 22
+                ptr: !Addr 19
+        - key: 21
+          txgs:
+            start: 39
+            end: 42
+          ptr: !Mem
+            Int:
+              children:
+              - key: 21
+                txgs:
+                  start: 39
+                  end: 40
+                ptr: !Addr 21
+              - key: 24
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Mem
+                  Leaf:
+                    credit: 48
+                    items:
+                      24: 24.0
+                      25: 25.0
+                      26: 26.0
 "#));
     let r2 = tree.clone().remove(26, TxgT::from(42), Credit::null())
         .now_or_never().unwrap();
     assert!(r2.is_ok());
     assert_eq!(format!("{}", &tree),
-r#"---
-limits:
+r#"limits:
   min_int_fanout: 2
   max_int_fanout: 5
   min_leaf_fanout: 2
@@ -954,79 +866,68 @@ root:
     txgs:
       start: 10
       end: 43
-    ptr:
-      Mem:
-        Int:
-          children:
-            - key: 0
-              txgs:
-                start: 10
-                end: 11
-              ptr:
-                Addr: 0
-            - key: 9
-              txgs:
-                start: 41
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 9
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 9
-                      - key: 12
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 12
-                      - key: 15
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 15
-                      - key: 17
-                        txgs:
-                          start: 41
-                          end: 42
-                        ptr:
-                          Addr: 17
-            - key: 19
-              txgs:
-                start: 21
-                end: 43
-              ptr:
-                Mem:
-                  Int:
-                    children:
-                      - key: 19
-                        txgs:
-                          start: 21
-                          end: 22
-                        ptr:
-                          Addr: 19
-                      - key: 21
-                        txgs:
-                          start: 39
-                          end: 40
-                        ptr:
-                          Addr: 21
-                      - key: 24
-                        txgs:
-                          start: 41
-                          end: 43
-                        ptr:
-                          Mem:
-                            Leaf:
-                              credit: 32
-                              items:
-                                24: 24.0
-                                25: 25.0
+    ptr: !Mem
+      Int:
+        children:
+        - key: 0
+          txgs:
+            start: 10
+            end: 11
+          ptr: !Addr 0
+        - key: 9
+          txgs:
+            start: 41
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 9
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 9
+              - key: 12
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 12
+              - key: 15
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 15
+              - key: 17
+                txgs:
+                  start: 41
+                  end: 42
+                ptr: !Addr 17
+        - key: 19
+          txgs:
+            start: 21
+            end: 43
+          ptr: !Mem
+            Int:
+              children:
+              - key: 19
+                txgs:
+                  start: 21
+                  end: 22
+                ptr: !Addr 19
+              - key: 21
+                txgs:
+                  start: 39
+                  end: 40
+                ptr: !Addr 21
+              - key: 24
+                txgs:
+                  start: 41
+                  end: 43
+                ptr: !Mem
+                  Leaf:
+                    credit: 32
+                    items:
+                      24: 24.0
+                      25: 25.0
 "#);
 }
 

--- a/bfffs-core/tests/functional/database.rs
+++ b/bfffs-core/tests/functional/database.rs
@@ -137,8 +137,8 @@ mod database {
         let mut buf = Vec::with_capacity(1024);
         db.dump_forest(&mut buf).await.unwrap();
         let forest = String::from_utf8(buf).unwrap();
-        let expected = r#"---
-limits:
+        let expected =
+r#"limits:
   min_int_fanout: 76
   max_int_fanout: 302
   min_leaf_fanout: 91
@@ -153,31 +153,28 @@ root:
     txgs:
       start: 0
       end: 1
-    ptr:
-      Addr: 2
-...
+    ptr: !Addr 2
 ---
-2:
-  Leaf:
-    credit: 0
-    items:
-      ? tree_id: 0
-        offset: 0
-      : Tree:
-          parent: ~
-          tod:
-            height: 1
-            _reserved: 0
-            limits:
-              min_int_fanout: 91
-              max_int_fanout: 364
-              min_leaf_fanout: 576
-              max_leaf_fanout: 2302
-              _max_size: 4194304
-            root: 1
-            txgs:
-              start: 0
-              end: 1
+2: !Leaf
+  credit: 0
+  items:
+    ? tree_id: 0
+      offset: 0
+    : !Tree
+      parent: null
+      tod:
+        height: 1
+        _reserved: 0
+        limits:
+          min_int_fanout: 91
+          max_int_fanout: 364
+          min_leaf_fanout: 576
+          max_leaf_fanout: 2302
+          _max_size: 4194304
+        root: 1
+        txgs:
+          start: 0
+          end: 1
 "#;
         pretty_assertions::assert_eq!(expected, forest);
     }

--- a/bfffs-core/tests/functional/fs.rs
+++ b/bfffs-core/tests/functional/fs.rs
@@ -855,8 +855,8 @@ mod fs {
         h.fs.dump_fs(&mut buf).await.unwrap();
 
         let fs_tree = String::from_utf8(buf).unwrap();
-        let expected = r#"---
-limits:
+        let expected =
+r#"limits:
   min_int_fanout: 91
   max_int_fanout: 364
   min_leaf_fanout: 576
@@ -869,38 +869,32 @@ root:
     txgs:
       start: 1
       end: 2
-    ptr:
-      Addr: 3
-...
+    ptr: !Addr 3
 ---
-3:
-  Leaf:
-    credit: 0
-    items:
-      1-0-706caad497db23:
-        DirEntry:
-          ino: 1
-          dtype: 4
-          name: ".."
-      1-0-9b56c722640a46:
-        DirEntry:
-          ino: 1
-          dtype: 4
-          name: "."
-      1-1-00000000000000:
-        Inode:
-          size: 0
-          bytes: 0
-          nlink: 1
-          flags: 0
-          atime: "1970-01-01T00:00:00Z"
-          mtime: "1970-01-01T00:00:00Z"
-          ctime: "1970-01-01T00:00:00Z"
-          birthtime: "1970-01-01T00:00:00Z"
-          uid: 0
-          gid: 0
-          perm: 493
-          file_type: Dir
+3: !Leaf
+  credit: 0
+  items:
+    1-0-706caad497db23: !DirEntry
+      ino: 1
+      dtype: 4
+      name: ..
+    1-0-9b56c722640a46: !DirEntry
+      ino: 1
+      dtype: 4
+      name: .
+    1-1-00000000000000: !Inode
+      size: 0
+      bytes: 0
+      nlink: 1
+      flags: 0
+      atime: 1970-01-01T00:00:00Z
+      mtime: 1970-01-01T00:00:00Z
+      ctime: 1970-01-01T00:00:00Z
+      birthtime: 1970-01-01T00:00:00Z
+      uid: 0
+      gid: 0
+      perm: 493
+      file_type: Dir
 "#;
         pretty_assertions::assert_eq!(expected, fs_tree);
     }

--- a/bfffs/tests/integration/bfffs/debug/dump.rs
+++ b/bfffs/tests/integration/bfffs/debug/dump.rs
@@ -56,8 +56,7 @@ async fn forest(harness: Harness) {
     txgs:
       start: 0
       end: 1
-    ptr:
-      Addr:",
+    ptr: !Addr",
         ));
 }
 #[rstest]
@@ -101,8 +100,7 @@ async fn tree(harness: Harness) {
     txgs:
       start: 0
       end: 1
-    ptr:
-      Addr: 1
+    ptr: !Addr 1
 ",
         ));
 }


### PR DESCRIPTION
Because serde_yaml is no longer maintained, and the version we were using also depended on an abandoned crate (yaml-rust). This changes the output format of the "bfffs debug dump" command.  But it does not change the on-disk format.