### PR TITLE
use enum_dispatch in bfffs-bench

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ task:
     # Use stable features
     - name: cargo test (stable)
       env:
-        VERSION: 1.71.0
+        VERSION: 1.77.0
       compute_engine_instance:
         image_project: freebsd-org-cloud-dev
         image: freebsd-13-3-release-amd64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "clap",
  "console-subscriber",
  "divbuf",
+ "enum_dispatch",
  "freebsd-libgeom",
  "function_name",
  "fuse3",

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -48,6 +48,7 @@ lalrpop = "0.19.7"
 [dev-dependencies]
 assert_cmd = "2.0"
 divbuf = { git = "https://github.com/asomers/divbuf.git", rev = "deb99e3"}
+enum_dispatch = "0.3.12"
 freebsd-libgeom = "0.2.2"
 function_name = "0.3.0"
 mockall = "0.12.0"

--- a/bfffs/benches/bfffs-bench/fs_create.rs
+++ b/bfffs/benches/bfffs-bench/fs_create.rs
@@ -1,7 +1,6 @@
 #! vim: tw=80
 use std::time::Duration;
 
-use async_trait::async_trait;
 use bfffs::Bfffs;
 use clap::{crate_version, Parser};
 
@@ -38,7 +37,6 @@ pub struct FsCreate {
     count: usize,
 }
 
-#[async_trait]
 impl Benchmark for FsCreate {
     async fn setup(&mut self, harness: &Harness) {
         self.bfffs = Some(Bfffs::new(&harness.sockpath).await.unwrap());

--- a/bfffs/benches/bfffs-bench/fs_destroy.rs
+++ b/bfffs/benches/bfffs-bench/fs_destroy.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use assert_cmd::prelude::*;
-use async_trait::async_trait;
 use clap::{crate_version, Parser};
 use si_scale::helpers::bibytes;
 
@@ -50,7 +49,6 @@ pub struct FsDestroy {
     properties: Option<String>,
 }
 
-#[async_trait]
 impl Benchmark for FsDestroy {
     async fn setup(&mut self, harness: &Harness) {
         const BSIZE: usize = 1 << 17;


### PR DESCRIPTION
The next version of fuse3 eliminates async-trait in favor of native async trait functions.  So eliminating async-trait from bfffs-bench lets us eliminate that dependency alltogether.  But native async functions in traits cannot be made into trait objects.  So we need to use enum_dispatch (which is already used by bfffs-core) instead.