### PR TITLE
Replace the memoffset::offset_of! macro with std::mem::offset_of!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,6 @@ dependencies = [
  "futures",
  "lazy_static",
  "libc",
- "memoffset",
  "tokio",
  "tracing-subscriber",
 ]

--- a/bfffs-fio/Cargo.toml
+++ b/bfffs-fio/Cargo.toml
@@ -16,7 +16,6 @@ console-subscriber = "0.2.0"
 futures = "0.3.0"
 lazy_static = "1.0"
 libc = "0.2.44"
-memoffset = "0.8.0"
 tokio = { version = "1.27.0", features = ["rt", "rt-multi-thread", "sync", "time", "tracing"] }
 
 [dependencies.tracing-subscriber]

--- a/bfffs-fio/src/lib.rs
+++ b/bfffs-fio/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::hash_map::HashMap,
     ffi::{CStr, OsStr},
-    mem,
+    mem::{self, offset_of},
     os::unix::ffi::OsStrExt,
     pin::Pin,
     ptr,
@@ -21,7 +21,6 @@ use futures::{
     stream::{futures_unordered::FuturesUnordered, StreamExt},
 };
 use lazy_static::lazy_static;
-use memoffset::offset_of;
 use tokio::{
     runtime::{Builder, Runtime},
     task::JoinError,


### PR DESCRIPTION
Available since 1.77.0