### PR TITLE
Remove the workaround for lalrpop bug 892

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,9 +16,7 @@ task:
     # Use bleeding edge features: Rust nightly and FreeBSD fspacectl
     - name: cargo test (nightly)
       env:
-        # Pin the nightly compiler version due to
-        # https://github.com/rust-lang/rust/issues/125474
-        VERSION: nightly-2024-05-21-x86_64-unknown-freebsd
+        VERSION: nightly
         CARGO_ARGS: --all-features
       compute_engine_instance:
         image_project: freebsd-org-cloud-dev

--- a/bfffs-core/src/cache/lru.rs
+++ b/bfffs-core/src/cache/lru.rs
@@ -72,7 +72,7 @@ impl LruCache {
                 v.mru = None;
                 v.lru = mru;
                 v.buf.make_ref().downcast::<T>().unwrap()
-            }).map(|cacheref| {
+            }).inspect(|_cacheref| {
                 self.store.get_mut(&v_mru.unwrap()).unwrap().lru = v_lru;
                 if let Some(lru) = &v_lru {
                     self.store.get_mut(lru).unwrap().mru = v_mru;
@@ -84,7 +84,6 @@ impl LruCache {
                     self.store.get_mut(mru).unwrap().mru = Some(*key);
                 }
                 self.mru = Some(*key);
-                cacheref
             })
         }
     }

--- a/bfffs/build.rs
+++ b/bfffs/build.rs
@@ -3,9 +3,5 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/pool_create_parser.lalrpop");
 
-    // Workaround a lalrpop bug
-    // https://github.com/lalrpop/lalrpop/issues/892
-    println!("cargo::rustc-check-cfg=cfg(rustfmt)");
-
     lalrpop::process_root().unwrap();
 }


### PR DESCRIPTION
As explained on that issue, the bug has been fixed by the latest nightly compiler.

https://github.com/lalrpop/lalrpop/issues/892