### PR TITLE
Add a Reason for the Faulted status

### DIFF
--- a/bfffs-core/src/pool.rs
+++ b/bfffs-core/src/pool.rs
@@ -868,7 +868,8 @@ mod pool {
         #[rstest]
         #[case(Online, vec![Online, Online])]
         #[case(Rebuilding, vec![Online, Rebuilding])]
-        #[case(Faulted, vec![Rebuilding, Faulted])]
+        #[case(Faulted(FaultedReason::InsufficientRedundancy),
+            vec![Rebuilding, Faulted(FaultedReason::InsufficientRedundancy)])]
         #[case(Degraded(nonzero!(1u8)),
             vec![Online, Degraded(nonzero!(1u8))])]
         #[case(Degraded(nonzero!(3u8)),

--- a/bfffs-core/tests/functional/mirror.rs
+++ b/bfffs-core/tests/functional/mirror.rs
@@ -7,7 +7,7 @@ use std::{
 use bfffs_core::{
     label::*,
     mirror::{Manager, Mirror},
-    vdev::Health,
+    vdev::{FaultedReason, Health},
     Error,
     LbaT,
     Uuid,
@@ -52,7 +52,8 @@ mod fault {
         harness.0.fault(uuid).unwrap();
         let stat = harness.0.status();
         assert_eq!(stat.health, Health::Degraded(nonzero!(1u8)));
-        assert_eq!(stat.leaves[2].health, Health::Faulted);
+        assert_eq!(stat.leaves[2].health,
+                   Health::Faulted(FaultedReason::User));
     }
 
     #[tokio::test]
@@ -70,8 +71,10 @@ mod fault {
 
         vdev.fault(uuid).unwrap();
         let stat = vdev.status();
-        assert_eq!(stat.health, Health::Faulted);
-        assert_eq!(stat.leaves[0].health, Health::Faulted);
+        assert_eq!(stat.health,
+                   Health::Faulted(FaultedReason::InsufficientRedundancy));
+        assert_eq!(stat.leaves[0].health,
+                   Health::Faulted(FaultedReason::User));
     }
 
     #[rstest]
@@ -81,7 +84,8 @@ mod fault {
         harness.0.fault(uuid).unwrap();
         let stat = harness.0.status();
         assert_eq!(stat.health, Health::Degraded(nonzero!(1u8)));
-        assert_eq!(stat.leaves[2].health, Health::Faulted);
+        assert_eq!(stat.leaves[2].health,
+                   Health::Faulted(FaultedReason::User));
     }
 }
 

--- a/bfffs-core/tests/functional/pool.rs
+++ b/bfffs-core/tests/functional/pool.rs
@@ -2,7 +2,7 @@
 use bfffs_core::{
     label::*,
     pool::*,
-    vdev::Health,
+    vdev::{FaultedReason, Health},
     Error,
     TxgT
 };
@@ -35,7 +35,8 @@ mod fault {
         harness.pool.fault(uuid).await.unwrap();
 
         let stat = harness.pool.status();
-        assert_eq!(stat.health, Health::Faulted);
+        assert_eq!(stat.health,
+                   Health::Faulted(FaultedReason::InsufficientRedundancy));
     }
 
     #[rstest]

--- a/bfffs-core/tests/functional/raid/null_raid.rs
+++ b/bfffs-core/tests/functional/raid/null_raid.rs
@@ -3,7 +3,7 @@
 use bfffs_core::{
     label::*,
     mirror::Mirror,
-    vdev::Health,
+    vdev::{FaultedReason, Health},
     raid::{Manager, NullRaid, VdevRaidApi},
     Uuid,
     Error
@@ -63,7 +63,8 @@ mod fault {
         let status = h.vdev.status();
         assert_eq!(status.health, Health::Degraded(nonzero!(1u8)));
         assert_eq!(status.mirrors[0].health, Health::Degraded(nonzero!(1u8)));
-        assert_eq!(status.mirrors[0].leaves[0].health, Health::Faulted);
+        assert_eq!(status.mirrors[0].leaves[0].health,
+                   Health::Faulted(FaultedReason::User));
     }
 
     #[rstest(h, case(harness(2)))]
@@ -75,7 +76,8 @@ mod fault {
         let status = h.vdev.status();
         assert_eq!(status.health, Health::Degraded(nonzero!(1u8)));
         assert_eq!(status.mirrors[0].health, Health::Degraded(nonzero!(1u8)));
-        assert_eq!(status.mirrors[0].leaves[0].health, Health::Faulted);
+        assert_eq!(status.mirrors[0].leaves[0].health,
+                   Health::Faulted(FaultedReason::User));
     }
 
     // Attempt to fault the entire RAID device

--- a/bfffs-core/tests/functional/raid/vdev_raid.rs
+++ b/bfffs-core/tests/functional/raid/vdev_raid.rs
@@ -25,7 +25,7 @@ use bfffs_core::{
     LbaT,
     label::*,
     mirror::Mirror,
-    vdev::{Health, Vdev},
+    vdev::{FaultedReason, Health, Vdev},
     raid::{Manager, VdevRaid, VdevRaidApi},
     Uuid
 };
@@ -319,7 +319,8 @@ mod fault {
         let status = h.vdev.status();
         assert_eq!(status.health, Health::Degraded(nonzero!(1u8)));
         assert_eq!(status.mirrors[0].health, Health::Degraded(nonzero!(1u8)));
-        assert_eq!(status.mirrors[0].leaves[0].health, Health::Faulted);
+        assert_eq!(status.mirrors[0].leaves[0].health,
+                   Health::Faulted(FaultedReason::User));
     }
 
     /// Fault a disk which is the only child of a mirror
@@ -333,7 +334,8 @@ mod fault {
 
         let status = h.vdev.status();
         assert_eq!(status.health, Health::Degraded(nonzero!(1u8)));
-        assert_eq!(status.mirrors[0].health, Health::Faulted);
+        assert_eq!(status.mirrors[0].health,
+                   Health::Faulted(FaultedReason::User));
 
         // Ensure that basic vdev methods work on an array that's degraded like
         // this:
@@ -354,7 +356,8 @@ mod fault {
         let status = h.vdev.status();
         assert_eq!(status.health, Health::Degraded(nonzero!(1u8)));
         assert_eq!(status.mirrors[0].health, Health::Degraded(nonzero!(1u8)));
-        assert_eq!(status.mirrors[0].leaves[0].health, Health::Faulted);
+        assert_eq!(status.mirrors[0].leaves[0].health,
+                   Health::Faulted(FaultedReason::User));
     }
 
     #[rstest(h, case(harness(3, 1, 1)))]
@@ -367,7 +370,8 @@ mod fault {
 
         let status = h.vdev.status();
         assert_eq!(status.health, Health::Degraded(nonzero!(1u8)));
-        assert_eq!(status.mirrors[0].health, Health::Faulted);
+        assert_eq!(status.mirrors[0].health,
+                   Health::Faulted(FaultedReason::User));
     }
 
     #[rstest(h, case(harness(3, 1, 1)))]
@@ -381,7 +385,8 @@ mod fault {
 
         let status = h.vdev.status();
         assert_eq!(status.health, Health::Degraded(nonzero!(1u8)));
-        assert_eq!(status.mirrors[0].health, Health::Faulted);
+        assert_eq!(status.mirrors[0].health,
+                   Health::Faulted(FaultedReason::User));
     }
 
     // Attempt to fault the entire RAID device

--- a/bfffs/src/bin/bfffs/main.rs
+++ b/bfffs/src/bin/bfffs/main.rs
@@ -15,7 +15,6 @@ use bfffs_core::{
     database::{self, Database, TreeID},
     property::{Property, PropertyName, PropertySource},
     rpc,
-    vdev::Health,
 };
 use clap::{crate_version, ArgAction, Parser};
 use futures::{future, TryFutureExt, TryStreamExt};
@@ -884,9 +883,7 @@ mod pool {
                     indent += 2;
                 }
                 for mirror in cl.mirrors.iter() {
-                    if mirror.leaves.len() > 1 ||
-                        mirror.health == Health::Faulted
-                    {
+                    if mirror.leaves.len() > 1 || mirror.health.is_faulted() {
                         if self.uuid {
                             table.add_row(row!(
                                 format!("{:indent$}mirror", ""),
@@ -923,9 +920,7 @@ mod pool {
                             ));
                         }
                     }
-                    if mirror.leaves.len() > 1 ||
-                        mirror.health == Health::Faulted
-                    {
+                    if mirror.leaves.len() > 1 || mirror.health.is_faulted() {
                         indent -= 2;
                     }
                 }

--- a/bfffs/tests/integration/bfffs/pool/fault.rs
+++ b/bfffs/tests/integration/bfffs/pool/fault.rs
@@ -127,10 +127,10 @@ async fn by_path() {
             " NAME                                                    HEALTH 
  FaultPool                                               Degraded(1) 
    mirror                                                Degraded(1) 
-     {:51} Faulted 
+     {:51} Faulted(administratively) 
      {:51} Online 
 ",
-            "",
+            files.paths[0].display(),
             files.paths[1].display()
         ));
 }
@@ -168,10 +168,10 @@ async fn by_uuid() {
             " NAME                                                    HEALTH 
  FaultPool                                               Degraded(1) 
    mirror                                                Degraded(1) 
-     {:51} Faulted 
+     {:51} Faulted(administratively) 
      {:51} Online 
 ",
-            "",
+            files.paths[0].display(),
             files.paths[1].display()
         ));
 }


### PR DESCRIPTION
A vdev can be Faulted for:
* Removed (disk is missing)
* User (administratively faulted)
* InsufficientRedundancy

This change also adds fault-awareness to the Mirror and VdevRaid layers. Previously, faulting one of those was equivalent to making it Removed. Now, it will remember that it is Faulted::User.