### PR TITLE
Fewer allocations

### DIFF
--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -31,7 +31,6 @@ use std::{
     pin::Pin,
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc,
         RwLock,
         RwLockWriteGuard
     },
@@ -218,9 +217,9 @@ impl<'a> FreeSpaceMap {
         self.dirty.clear();
     }
 
-    fn deserialize(vdev: Arc<dyn VdevRaidApi>, buf: DivBuf, zones: ZoneT)
+    fn deserialize(vdev: Box<dyn VdevRaidApi>, buf: DivBuf, zones: ZoneT)
         -> Pin<Box<
-                dyn Future<Output=Result<(Self, Arc<dyn VdevRaidApi>)>>
+                dyn Future<Output=Result<(Self, Box<dyn VdevRaidApi>)>>
                 + Send
             >>
     {
@@ -475,8 +474,8 @@ impl<'a> FreeSpaceMap {
     }
 
     /// Open a FreeSpaceMap from an already-formatted `VdevRaid`.
-    async fn open(vdev: Arc<dyn VdevRaidApi>)
-        -> Result<(Self, Arc<dyn VdevRaidApi + 'static>)>
+    async fn open(vdev: Box<dyn VdevRaidApi>)
+        -> Result<(Self, Box<dyn VdevRaidApi + 'static>)>
     {
         let total_zones = vdev.zones();
         // NB: it would be slightly faster to created it with the correct
@@ -773,9 +772,7 @@ pub struct Cluster {
     fsm: RwLock<FreeSpaceMap>,
 
     /// Underlying vdev (which may or may not use RAID)
-    // The Arc is necessary in order for some methods to return futures with
-    // 'static lifetimes
-    vdev: Arc<dyn VdevRaidApi>
+    vdev: Box<dyn VdevRaidApi>
 }
 
 #[cfg_attr(test, automock)]
@@ -813,7 +810,7 @@ impl Cluster {
     /// Create a new `Cluster` from unused files or devices
     ///
     /// * `raids`:              Already labeled raid vdev
-    pub fn create(vdev: Arc<dyn VdevRaidApi>) -> Self
+    pub fn create(vdev: Box<dyn VdevRaidApi>) -> Self
     {
         let total_zones = vdev.zones();
         let fsm = FreeSpaceMap::new(total_zones);
@@ -835,10 +832,7 @@ impl Cluster {
 
     /// Mark a child device as faulted.
     pub fn fault(&mut self, uuid: Uuid) -> Result<()> {
-        match Arc::get_mut(&mut self.vdev) {
-            Some(vdev) => vdev.fault(uuid),
-            None => Err(Error::EAGAIN)
-        }
+        self.vdev.fault(uuid)
     }
 
     /// Find the first closed zone whose index is greater than or equal to `zid`
@@ -931,7 +925,7 @@ impl Cluster {
 
     /// Construct a new `Cluster` from an already constructed
     /// [`VdevRaidApi`](trait.VdevRaidApi.html)
-    fn new(args: (FreeSpaceMap, Arc<dyn VdevRaidApi>)) -> Self {
+    fn new(args: (FreeSpaceMap, Box<dyn VdevRaidApi>)) -> Self {
         let (fsm, vdev) = args;
         let allocated_space = fsm.allocated_total().into();
         Cluster{allocated_space, fsm: RwLock::new(fsm), vdev}
@@ -942,7 +936,7 @@ impl Cluster {
     ///
     /// Returns a new `Cluster` and a `LabelReader` that may be used to
     /// construct other vdevs stacked on top.
-    pub async fn open(vdev_raid: Arc<dyn VdevRaidApi>) -> Result<Self>
+    pub async fn open(vdev_raid: Box<dyn VdevRaidApi>) -> Result<Self>
     {
         FreeSpaceMap::open(vdev_raid).await
             .map(Cluster::new)
@@ -959,7 +953,7 @@ impl Cluster {
     /// Asynchronously read from the cluster
     pub fn read(&self, buf: IoVecMut, lba: LbaT) -> BoxVdevFut
     {
-        self.vdev.clone().read_at(buf, lba)
+        self.vdev.read_at(buf, lba)
     }
 
     /// Asynchronously read a contiguous portion of the cluster.
@@ -1114,7 +1108,10 @@ mod cluster {
     use itertools::Itertools;
     use mockall::{Sequence, predicate::*};
     use pretty_assertions::assert_eq;
-    use std::iter;
+    use std::{
+        iter,
+        sync::Arc
+    };
 
     #[tokio::test]
     async fn free_and_erase_full_zone() {
@@ -1156,7 +1153,7 @@ mod cluster {
             .return_once(|_| Box::pin(future::ok(())));
 
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
 
         let dbs = DivBufShared::from(vec![0u8; 4096]);
         let db0 = dbs.try_const().unwrap();
@@ -1216,7 +1213,7 @@ mod cluster {
             .return_once(|_| Box::pin(future::ok(())));
 
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
 
         let dbs0 = DivBufShared::from(vec![0u8; 4096]);
         let dbs1 = DivBufShared::from(vec![0u8; 8192]);
@@ -1278,7 +1275,7 @@ mod cluster {
             .return_once(|_, _, _| Box::pin(future::ok(())));
 
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
 
         let dbs0 = DivBufShared::from(vec![0u8; 4096]);
         let dbs1 = DivBufShared::from(vec![0u8; 8192]);
@@ -1320,7 +1317,7 @@ mod cluster {
             .with(eq(0))
             .return_const((1, 1000));
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
         drop(cluster.free(900, 200));
     }
 
@@ -1337,7 +1334,7 @@ mod cluster {
             .with(eq(0))
             .return_const((1, 1000));
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
         drop(cluster.free(1000, 10));
     }
 
@@ -1409,7 +1406,7 @@ mod cluster {
         vr.expect_zone_limits()
             .with(eq(5))
             .return_const((504, 596));
-        let (fsm, _mock_vr) = FreeSpaceMap::open(Arc::new(vr))
+        let (fsm, _mock_vr) = FreeSpaceMap::open(Box::new(vr))
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1473,7 +1470,7 @@ mod cluster {
                  (100 * i + 4, 100 * i + 96)
              });
 
-        let (fsm, _mock_vr) = FreeSpaceMap::open(Arc::new(vr))
+        let (fsm, _mock_vr) = FreeSpaceMap::open(Box::new(vr))
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -1509,7 +1506,7 @@ mod cluster {
                 Box::pin(future::ok(()))
             });
 
-        let r = FreeSpaceMap::open(Arc::new(vr)).now_or_never().unwrap();
+        let r = FreeSpaceMap::open(Box::new(vr)).now_or_never().unwrap();
         assert_eq!(Error::EINTEGRITY, r.err().unwrap());
     }
 
@@ -1536,7 +1533,7 @@ mod cluster {
         fsm.finish_zone(3, TxgT::from(3));
         fsm.open_zone(4, 4, 5, 0, TxgT::from(0)).unwrap();
         fsm.finish_zone(4, TxgT::from(0));
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
         assert_eq!(cluster.find_closed_zone(0).unwrap(),
             ClosedZone{zid: 0, start: 0, freed_blocks: 1, total_blocks: 1,
                        txgs: TxgT::from(0)..TxgT::from(1)});
@@ -1571,7 +1568,7 @@ mod cluster {
             ).once()
             .return_once(|_, _, _| Box::pin(future::ok(())));
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
 
         let dbs = DivBufShared::from(vec![0u8; 4096]);
         let db0 = dbs.try_const().unwrap();
@@ -1621,7 +1618,7 @@ mod cluster {
             .in_sequence(&mut seq)
             .return_once(|| Box::pin(future::ok(())));
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
         cluster.fsm.write().unwrap().clear_dirty_zones();
 
         let dbs = DivBufShared::from(vec![0u8; 4096]);
@@ -1648,7 +1645,7 @@ mod cluster {
             .with(eq(0))
             .return_const((0, 1));
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
 
         let dbs = DivBufShared::from(vec![0u8; 8192]);
         let result = cluster.write(dbs.try_const().unwrap(), TxgT::from(0));
@@ -1676,7 +1673,7 @@ mod cluster {
                 *zone == 0
             ).returning(|_, _, _| Box::pin(future::ok(())));
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Arc::new(Cluster::new((fsm, Arc::new(vr))));
+        let cluster = Arc::new(Cluster::new((fsm, Box::new(vr))));
 
         let buf = vec![0u8; BYTES_PER_LBA];
         (0..16).map(|_| {
@@ -1701,7 +1698,7 @@ mod cluster {
             .with(eq(0))
             .return_const((0, 0));
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
 
         let dbs = DivBufShared::from(vec![0u8; 4096]);
         let result = cluster.write(dbs.try_const().unwrap(), TxgT::from(0));
@@ -1729,7 +1726,7 @@ mod cluster {
             ).once()
             .return_once(|_, _, _| Box::pin(future::ok(())));
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
 
         let dbs = DivBufShared::from(vec![0u8; 4096]);
         let db0 = dbs.try_const().unwrap();
@@ -1767,7 +1764,7 @@ mod cluster {
             ).once()
             .return_once(|_, _, _| Box::pin(future::ok(())));
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
 
         let dbs = DivBufShared::from(vec![0u8; 4096]);
         let db0 = dbs.try_const().unwrap();
@@ -1824,7 +1821,7 @@ mod cluster {
             ).once()
             .return_once(|_, _, _| Box::pin(future::ok(())));
         let fsm = FreeSpaceMap::new(vr.zones());
-        let cluster = Cluster::new((fsm, Arc::new(vr)));
+        let cluster = Cluster::new((fsm, Box::new(vr)));
 
         let dbs = DivBufShared::from(vec![0u8; 8192]);
         let db0 = dbs.try_const().unwrap();

--- a/bfffs-core/src/mirror.rs
+++ b/bfffs-core/src/mirror.rs
@@ -223,7 +223,7 @@ impl Child {
         self.as_present().map(|vb| vb.size())
     }
 
-    fn sync_all(&self) -> Option<BoxVdevFut> {
+    fn sync_all(&self) -> Option<VdevBlockFut> {
         self.as_present().map(|vb| vb.sync_all())
     }
 

--- a/bfffs-core/src/raid/mod.rs
+++ b/bfffs-core/src/raid/mod.rs
@@ -229,7 +229,7 @@ mock!{
         fn fault(&mut self, uuid: Uuid) -> Result<()>;
         fn flush_zone(&self, zone: ZoneT) -> (LbaT, BoxVdevFut);
         fn open_zone(&self, zone: ZoneT) -> BoxVdevFut;
-        fn read_at(self: Arc<Self>, buf: IoVecMut, lba: LbaT) -> BoxVdevFut;
+        fn read_at(&self, buf: IoVecMut, lba: LbaT) -> BoxVdevFut;
         fn read_long(&self, len: LbaT, lba: LbaT)
             -> Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send>>;
         fn read_spacemap(&self, buf: IoVecMut, idx: u32) -> BoxVdevFut;

--- a/bfffs-core/src/raid/mod.rs
+++ b/bfffs-core/src/raid/mod.rs
@@ -96,7 +96,7 @@ impl Manager {
     /// Import a RAID device that is already known to exist
     #[cfg(not(test))]
     pub fn import(&mut self, uuid: Uuid)
-        -> impl Future<Output=Result<(Box<dyn VdevRaidApi>, LabelReader)>>
+        -> impl Future<Output=Result<(RaidImpl, LabelReader)>>
     {
         let rl = match self.raids.remove(&uuid) {
             Some(rl) => rl,
@@ -139,6 +139,15 @@ impl Manager {
     }
 }
 
+#[enum_dispatch::enum_dispatch(Vdev)]
+#[enum_dispatch::enum_dispatch(VdevRaidApi)]
+pub enum RaidImpl {
+    Null(NullRaid),
+    Raid(VdevRaid),
+    #[cfg(test)]
+    Mock(MockVdevRaid),
+}
+
 /// Return value of [`VdevRaidApi::status`]
 #[derive(Clone, Debug)]
 pub struct Status {
@@ -163,15 +172,15 @@ pub struct Status {
 ///                         inoperable.
 /// * `mirrors`:            Already labeled Mirror devices
 pub fn create(chunksize: Option<NonZeroU64>, disks_per_stripe: i16,
-    redundancy: i16, mut mirrors: Vec<Mirror>) -> Box<dyn VdevRaidApi>
+    redundancy: i16, mut mirrors: Vec<Mirror>) -> RaidImpl
 {
     if mirrors.len() == 1 {
         assert_eq!(disks_per_stripe, 1);
         assert_eq!(redundancy, 0);
-        Box::new(NullRaid::create(mirrors.pop().unwrap()))
+        NullRaid::create(mirrors.pop().unwrap()).into()
     } else {
-        Box::new(VdevRaid::create(chunksize, disks_per_stripe, redundancy,
-                                  mirrors))
+        VdevRaid::create(chunksize, disks_per_stripe, redundancy, mirrors)
+            .into()
     }
 }
 
@@ -185,7 +194,7 @@ pub fn create(chunksize: Option<NonZeroU64>, disks_per_stripe: i16,
 ///                 associated `LabelReader`.  The labels of each will be
 ///                 verified.
 fn open(uuid: Option<Uuid>, combined: Vec<(Mirror, LabelReader)>)
-    -> (Box<dyn VdevRaidApi>, LabelReader)
+    -> (RaidImpl, LabelReader)
 {
     let mut label_pair = None;
     let all_mirrors = combined.into_iter()
@@ -201,12 +210,8 @@ fn open(uuid: Option<Uuid>, combined: Vec<(Mirror, LabelReader)>)
     }).collect::<BTreeMap<Uuid, Mirror>>();
     let (label, label_reader) = label_pair.unwrap();
     let vdev = match label {
-        Label::Raid(l) => {
-            Box::new(VdevRaid::open(l, all_mirrors)) as Box<dyn VdevRaidApi>
-        },
-        Label::NullRaid(l) => {
-            Box::new(NullRaid::open(l, all_mirrors)) as Box<dyn VdevRaidApi>
-        },
+        Label::Raid(l) => VdevRaid::open(l, all_mirrors).into(),
+        Label::NullRaid(l) => NullRaid::open(l, all_mirrors).into(),
     };
     (vdev, label_reader)
 }

--- a/bfffs-core/src/raid/null_raid.rs
+++ b/bfffs-core/src/raid/null_raid.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::BTreeMap,
     pin::Pin,
-    sync::Arc
 };
 
 use async_trait::async_trait;
@@ -123,7 +122,7 @@ impl VdevRaidApi for NullRaid {
         Box::pin(self.mirror.open_zone(limits.0))
     }
 
-    fn read_at(self: Arc<Self>, buf: IoVecMut, lba: LbaT) -> BoxVdevFut {
+    fn read_at(&self, buf: IoVecMut, lba: LbaT) -> BoxVdevFut {
         Box::pin(self.mirror.read_at(buf, lba))
     }
 

--- a/bfffs-core/src/raid/vdev_raid/tests.rs
+++ b/bfffs-core/src/raid/vdev_raid/tests.rs
@@ -1101,7 +1101,7 @@ mod fault {
                                       mirrors.into_boxed_slice());
         assert_eq!(1, vdev_raid.faulted_children());
         vdev_raid.fault(m0_uuid).unwrap();
-        assert!(matches!(vdev_raid.children[0], Child::Faulted(_)));
+        assert!(matches!(vdev_raid.inner.children[0], Child::Faulted(_)));
         assert_eq!(1, vdev_raid.faulted_children());
     }
 
@@ -1127,7 +1127,7 @@ mod fault {
                                       LayoutAlgorithm::PrimeS,
                                       mirrors.into_boxed_slice());
         vdev_raid.fault(m0_uuid).unwrap();
-        assert!(matches!(vdev_raid.children[0], Child::Faulted(_)));
+        assert!(matches!(vdev_raid.inner.children[0], Child::Faulted(_)));
         assert_eq!(1, vdev_raid.faulted_children());
     }
 }

--- a/bfffs-core/src/raid/vdev_raid_api.rs
+++ b/bfffs-core/src/raid/vdev_raid_api.rs
@@ -1,8 +1,5 @@
 // vim: tw=80
-use std::pin::Pin;
-
 use async_trait::async_trait;
-use divbuf::DivBufShared;
 use futures::Future;
 
 use crate::{
@@ -15,6 +12,7 @@ use crate::{
 /// The public interface for all RAID Vdevs.  All Vdevs that slot beneath a
 /// cluster must implement this API.
 #[async_trait]
+#[enum_dispatch::enum_dispatch]
 pub trait VdevRaidApi : Vdev + Send + Sync + 'static {
     /// Asynchronously erase a zone on a RAID device
     ///
@@ -58,7 +56,7 @@ pub trait VdevRaidApi : Vdev + Send + Sync + 'static {
     /// Read an LBA range including all parity.  Return an iterator that will
     /// yield every possible reconstruction of the data.
     fn read_long(&self, len: LbaT, lba: LbaT)
-        -> Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send>>;
+        -> std::pin::Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=divbuf::DivBufShared> + Send>>> + Send>>;
 
     /// Read one of the spacemaps from disk.
     ///

--- a/bfffs-core/src/raid/vdev_raid_api.rs
+++ b/bfffs-core/src/raid/vdev_raid_api.rs
@@ -1,8 +1,5 @@
 // vim: tw=80
-use std::{
-    pin::Pin,
-    sync::Arc
-};
+use std::pin::Pin;
 
 use async_trait::async_trait;
 use divbuf::DivBufShared;
@@ -56,9 +53,7 @@ pub trait VdevRaidApi : Vdev + Send + Sync + 'static {
     /// immediately return EINTEGRITY, under the assumption that this method
     /// should only be called after a normal read already returned such an
     /// error.
-    // We can't use &Arc<Self> because that isn't object-safe.  But we could use
-    // it if we eliminate this trait and just use an enum instead.
-    fn read_at(self: Arc<Self>, buf: IoVecMut, lba: LbaT) -> BoxVdevFut;
+    fn read_at(&self, buf: IoVecMut, lba: LbaT) -> BoxVdevFut;
 
     /// Read an LBA range including all parity.  Return an iterator that will
     /// yield every possible reconstruction of the data.

--- a/bfffs-core/src/vdev.rs
+++ b/bfffs-core/src/vdev.rs
@@ -9,6 +9,9 @@ use serde_derive::{Deserialize, Serialize};
 use futures::Future;
 use crate::types::*;
 
+// This looks like a layering violation, but it's required for enum_dispatch.
+use crate::raid::RaidImpl;
+
 /// The reason why a vdev is faulted.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub enum FaultedReason {
@@ -87,6 +90,7 @@ pub type BoxVdevFut = Pin<Box<dyn Future<Output = Result<()>> + Send + Sync>>;
 /// The main datapath interface to any `Vdev` is `read_at` and `write_at`.
 /// However, those methods are not technically part of the trait, because they
 /// have different return values at different levels.
+#[enum_dispatch::enum_dispatch]
 pub trait Vdev {
     /// Return the zone number at which the given LBA resides
     ///

--- a/bfffs-core/src/vdev_block.rs
+++ b/bfffs-core/src/vdev_block.rs
@@ -1042,10 +1042,10 @@ impl VdevBlock {
 
     /// Asynchronously sync the underlying device, ensuring that all data
     /// reaches stable storage
-    pub fn sync_all(&self) -> BoxVdevFut {
+    pub fn sync_all(&self) -> VdevBlockFut {
         let (sender, receiver) = oneshot::channel::<Result<()>>();
         let block_op = BlockOp::sync_all(sender);
-        Box::pin(self.new_fut(block_op, receiver))
+        self.new_fut(block_op, receiver)
     }
 
     pub fn uuid(&self) -> Uuid {

--- a/bfffs-core/tests/torture/vdev_raid.rs
+++ b/bfffs-core/tests/torture/vdev_raid.rs
@@ -31,7 +31,7 @@ use bfffs_core::{
 };
 
 struct Harness {
-    vdev: Arc<dyn VdevRaidApi>,
+    vdev: Box<dyn VdevRaidApi>,
     _tempdir: TempDir,
     paths: Vec<PathBuf>,
     k: i16,
@@ -74,7 +74,7 @@ fn mkbuf(offs: LbaT, len: usize) -> Vec<u8> {
 }
 
 async fn do_test(
-    vdev: Arc<dyn VdevRaidApi>,
+    vdev: Box<dyn VdevRaidApi>,
     chunksize: LbaT,
     k: i16,
     f: i16,

--- a/bfffs-core/tests/torture/vdev_raid.rs
+++ b/bfffs-core/tests/torture/vdev_raid.rs
@@ -7,7 +7,6 @@ use std::{
     mem,
     num::NonZeroU64,
     path::PathBuf,
-    sync::Arc
 };
 
 use std::os::unix::fs::FileExt;
@@ -27,11 +26,12 @@ use bfffs_core::{
     LbaT,
     label::LabelWriter,
     mirror::Mirror,
-    raid::{self, Manager, VdevRaidApi},
+    raid::{self, Manager, RaidImpl, VdevRaidApi},
+    vdev::Vdev,
 };
 
 struct Harness {
-    vdev: Box<dyn VdevRaidApi>,
+    vdev: RaidImpl,
     _tempdir: TempDir,
     paths: Vec<PathBuf>,
     k: i16,
@@ -74,7 +74,7 @@ fn mkbuf(offs: LbaT, len: usize) -> Vec<u8> {
 }
 
 async fn do_test(
-    vdev: Box<dyn VdevRaidApi>,
+    vdev: RaidImpl,
     chunksize: LbaT,
     k: i16,
     f: i16,
@@ -136,7 +136,7 @@ async fn do_test(
         let dbs = DivBufShared::from(vec![0; read_bytes]);
         let rbuf = dbs.try_mut().unwrap();
         assert!(ofs + read_lbas < zl.1, "This test is not yet zone-aware");
-        vdev.clone().read_at(rbuf, ofs).await.unwrap();
+        vdev.read_at(rbuf, ofs).await.unwrap();
         assert_bufeq!(&dbs.try_const().unwrap()[..], &expect_buf[..]);
         nread += read_bytes;
         ofs += read_lbas;


### PR DESCRIPTION
* Remove an allocation from VdevBlock::sync_all
* Use enum_dispatch for VdevRaidApi
  - Removes vtable lookups from Cluster methods
  - Moves a clone from Cluster::read into VdevRaid::read_at (and eliminates it when VdevRaid is not in use)
  - Removes allocations from raid constructors
  - Reduces clones in VdevRaid::read_spacemap