### PR TITLE
Less Boxing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_enums"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1899bfcfd9340ceea3533ea157360ba8fa864354eccbceab58e1006ecab35393"
+dependencies = [
+ "derive_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +299,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "atomic_enum",
+ "auto_enums",
  "bincode",
  "bitfield",
  "blosc",
@@ -787,6 +800,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61bb5a1014ce6dfc2a378578509abe775a5aa06bff584a547555d9efdb81b926"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1599,14 +1623,12 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a978c8292954bcb9347a4e28772c0a0621166a1598fc1be28ac0076a4bb810e"
+version = "0.12.1"
+source = "git+https://github.com/asomers/mockall.git?rev=803873a#803873a5c815817b13538d97754db644365ebd48"
 dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "lazy_static",
  "mockall_derive",
  "predicates",
  "predicates-tree",
@@ -1614,9 +1636,8 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2765371d0978ba4ace4ebef047baa62fc068b431e468444b5610dd441c639b"
+version = "0.12.1"
+source = "git+https://github.com/asomers/mockall.git?rev=803873a#803873a5c815817b13538d97754db644365ebd48"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ resolver = "2"
 [patch.crates-io]
 atomic_enum = { git = "https://github.com/brain0/atomic_enum.git", rev = "baea45a" }
 fuse3 = { git = "https://github.com/Sherlock-Holo/fuse3.git", rev = "bf4a341"}
+mockall = { git = "https://github.com/asomers/mockall.git", rev = "803873a" }

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -14,6 +14,7 @@ nightly = [ "mockall/nightly" ]
 [dependencies]
 async-trait = "0.1.43"
 atomic_enum = "0.3.0"
+auto_enums = "0.8.5"
 bincode = { version = "1.3.3", features = ["i128"] }
 bitfield = "0.13.1"
 blosc = "0.2.0"
@@ -62,7 +63,7 @@ glob = "0.3.1"
 histogram = "0.6"
 itertools = "0.11.0"
 mdconfig = "0.2.0"
-mockall = "0.12.0"
+mockall = "0.12.1"
 nonzero_ext = "0.3.0"
 nix = { version = "0.29.0", default-features = false, features = ["user"] }
 num_cpus = "1.8"

--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -49,11 +49,11 @@ mod htable {
         fs_tree::{FSKey, FSValue, HTItem, HTValue},
         types::*
     };
+    use auto_enums::auto_enum;
     use futures::{Future, FutureExt, TryFutureExt, future};
     use std::{
         ffi::OsString,
         mem,
-        pin::Pin
     };
     use super::{ReadOnlyFilesystem, ReadWriteFilesystem};
 
@@ -71,12 +71,13 @@ mod htable {
     }
 
     impl ReadFilesystem<'_> {
+        #[auto_enum(Future)]
         fn get(&self, k: FSKey)
-            -> Pin<Box<dyn Future<Output=Result<Option<FSValue>>> + Send>>
+            -> impl Future<Output=Result<Option<FSValue>>> + Send
         {
             match self {
-                ReadFilesystem::ReadOnly(ds) => Box::pin(ds.get(k)),
-                ReadFilesystem::ReadWrite(ds) => Box::pin(ds.get(k))
+                ReadFilesystem::ReadOnly(ds) => ds.get(k),
+                ReadFilesystem::ReadWrite(ds) => ds.get(k)
             }
         }
     }

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -64,9 +64,9 @@ pub struct IDML {
 #[cfg_attr(test, allow(unused))]
 impl<'a> IDML {
     pub fn borrow_credit(&self, size: usize)
-        -> Pin<Box<dyn Future<Output=Credit> + Send>>
+        -> impl Future<Output=Credit> + Send
     {
-        self.writeback.borrow(size).boxed()
+        self.writeback.borrow(size)
     }
 
     /// Get the maximum size of bytes in the cache


### PR DESCRIPTION
Remove Box::pin from some functions that didn't actually need it.

Use the auto_enums crate to avoid a Box::pin in many functions that return a Future or Iterator.  But not all:

* Recursive functions must still Box
* auto_enums doesn't work on expressions or closures in stable Rust
* Trait methods must still Box (for now; this might change)

Fixes #292