### PR TITLE
Div ceil

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,9 +477,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cast"

--- a/bfffs-core/examples/fanout.rs
+++ b/bfffs-core/examples/fanout.rs
@@ -59,7 +59,7 @@ impl Stats {
                     0
                 }
             };
-            let asize = div_roundup(lsize, BYTES_PER_LBA) * BYTES_PER_LBA;
+            let asize = lsize.div_ceil(BYTES_PER_LBA) * BYTES_PER_LBA;
             (padding * *count as usize, asize * *count as usize)
         }).fold((0, 0), |accum, (padding, total)| {
             (accum.0 + padding, accum.1 + total)
@@ -77,7 +77,7 @@ impl Stats {
         let guard = self.put_counts.lock().unwrap();
         guard.iter().fold(0, |total, (lsize, count)| {
             let lsize = *lsize as usize;
-            let asize = div_roundup(lsize, BYTES_PER_LBA) * BYTES_PER_LBA;
+            let asize = lsize.div_ceil(BYTES_PER_LBA) * BYTES_PER_LBA;
             total + asize as u64 * *count
         })
     }
@@ -92,7 +92,7 @@ struct FakeDDML {
 
 impl FakeDDML {
     fn next_drp(&self, z: Compression, lsize: u32, csize: u32) -> DRP {
-        let lbas = div_roundup(lsize as usize, BYTES_PER_LBA) as u64;
+        let lbas = (lsize as usize).div_ceil(BYTES_PER_LBA) as u64;
         let lba = self.next_lba.fetch_add(lbas, Ordering::Relaxed);
         let pba = PBA::new(0, lba);
         let checksum = thread_rng().gen::<u64>();

--- a/bfffs-core/src/cache/lru.rs
+++ b/bfffs-core/src/cache/lru.rs
@@ -166,12 +166,8 @@ use super::*;
 use crate::types::*;
 use divbuf::{DivBuf, DivBufShared};
 
-// pet kcov
 #[test]
 fn debug() {
-    let cache = LruCache::with_capacity(100);
-    format!("{cache:?}");
-    assert_eq!(100, cache.capacity());
     let dbs = DivBufShared::from(Vec::new());
     let entry = LruEntry{buf: Box::new(dbs), lru: None, mru: None};
     assert_eq!("LruEntry { lru: None, mru: None }", format!("{entry:?}"));

--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -1085,17 +1085,6 @@ impl Manager {
 #[cfg(test)]
 mod t {
 
-mod open_zone {
-    use super::super::*;
-
-    // pet kcov
-    #[test]
-    fn debug() {
-        let oz = OpenZone{start: 0, allocated_blocks: 0};
-        format!("{oz:?}");
-    }
-}
-
 mod cluster {
     use super::super::*;
     use crate::vdev::*;
@@ -1836,13 +1825,6 @@ mod cluster {
 mod free_space_map {
     use pretty_assertions::assert_eq;
     use super::super::*;
-
-    // pet kcov
-    #[test]
-    fn debug() {
-        let fsm = FreeSpaceMap::new(10);
-        format!("{fsm:?}");
-    }
 
     #[test]
     fn allocated_total_all_empty() {

--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -476,7 +476,7 @@ impl<'a> FreeSpaceMap {
         let total_zones = vdev.zones();
         // NB: it would be slightly faster to created it with the correct
         // capacity and uninitialized.
-        let blocks = div_roundup(total_zones as usize, SPACEMAP_ZONES_PER_LBA);
+        let blocks = (total_zones as usize).div_ceil(SPACEMAP_ZONES_PER_LBA);
         let dbs = DivBufShared::from(vec![0u8; blocks * BYTES_PER_LBA]);
         let dbm = dbs.try_mut().unwrap();
         vdev.read_spacemap(dbm, 0)
@@ -1004,7 +1004,7 @@ impl Cluster {
         //    that.
         // 3) If that doesn't work, return ENOSPC
         // 4) write to the vdev
-        let space = div_roundup(buf.len(), BYTES_PER_LBA) as LbaT;
+        let space = buf.len().div_ceil(BYTES_PER_LBA) as LbaT;
 
         let mut wg = self.fsm.write().unwrap();
         let (alloc_result, nearly_full_zones) = wg.try_allocate(space);

--- a/bfffs-core/src/database/database.rs
+++ b/bfffs-core/src/database/database.rs
@@ -860,13 +860,6 @@ mod database {
     use mockall::{Sequence, predicate::*};
     use std::ops::RangeFull;
 
-    // pet kcov
-    #[test]
-    fn debug() {
-        let label = Label{forest: TreeOnDisk::default()};
-        format!("{label:?}");
-    }
-
     // await_holding_lock is ok, because the tests don't share reactors
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
@@ -1126,14 +1119,4 @@ mod database {
     }
 }
 
-mod syncer_msg {
-    use super::super::*;
-
-    //pet kcov
-    #[test]
-    fn debug() {
-        let sm = SyncerMsg::Shutdown;
-        format!("{sm:?}");
-    }
-}
 }

--- a/bfffs-core/src/ddml/mod.rs
+++ b/bfffs-core/src/ddml/mod.rs
@@ -67,7 +67,7 @@ impl DRP {
 
     /// Return the storage space actually allocated for this record
     pub fn asize(&self) -> LbaT {
-        div_roundup(self.csize as usize, BYTES_PER_LBA) as LbaT
+        (self.csize as usize).div_ceil(BYTES_PER_LBA) as LbaT
     }
 
     /// Transform this DRP into one that has the same compression function as

--- a/bfffs-core/src/dml.rs
+++ b/bfffs-core/src/dml.rs
@@ -193,12 +193,6 @@ mod t {
         assert_eq!(compression, Compression::None);
     }
 
-    // pet grcov
-    #[test]
-    fn default() {
-        assert_eq!(Compression::None, Compression::default())
-    }
-
     #[test]
     fn shuffle() {
         assert_eq!(Compression::None.shuffle(), None);

--- a/bfffs-core/src/dml.rs
+++ b/bfffs-core/src/dml.rs
@@ -54,8 +54,8 @@ impl Compression {
             let buffer = ctx.compress(&input[..]);
             let v: Vec<u8> = buffer.into();
             let dbs = DivBufShared::from(v);
-            let compressed_lbas = div_roundup(dbs.len(), BYTES_PER_LBA);
-            let uncompressed_lbas = div_roundup(lsize, BYTES_PER_LBA);
+            let compressed_lbas = dbs.len().div_ceil(BYTES_PER_LBA);
+            let uncompressed_lbas = lsize.div_ceil(BYTES_PER_LBA);
             if compressed_lbas < uncompressed_lbas {
                 (dbs.try_const().unwrap(), self)
             } else {

--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -311,7 +311,7 @@ impl Uio {
 
     /// Across how many records will this UIO be spread?
     fn nrecs(&self, offset0: usize, rs: usize) -> usize {
-        div_roundup(offset0 + self.len(), rs) - (offset0 / rs)
+        (offset0 + self.len()).div_ceil(rs) - (offset0 / rs)
     }
 }
 

--- a/bfffs-core/src/fs_tree.rs
+++ b/bfffs-core/src/fs_tree.rs
@@ -1240,20 +1240,6 @@ use crate::idml::IDML;
 use pretty_assertions::assert_eq;
 use super::*;
 
-// pet kcov
-#[test]
-fn debug() {
-    assert_eq!("DirEntry(0)", format!("{:?}", ObjKey::DirEntry(0)));
-    assert_eq!("Extent(0)", format!("{:?}", ObjKey::Extent(0)));
-    assert_eq!("ExtAttr(0)", format!("{:?}", ObjKey::ExtAttr(0)));
-    assert_eq!("Property(Atime)",
-        format!("{:?}", ObjKey::Property(PropertyName::Atime)));
-    assert_eq!("FSKey { object: 0x42, objtype: DirEntry, offset: 0x42 }",
-        format!("{:?}", FSKey::new(0x42, ObjKey::DirEntry(66))));
-    assert_eq!("FSKey { object: 0x42, objtype: Unknown, offset: 0x0 }",
-        format!("{:?}", FSKey::compose(0x42, 254, 0)));
-}
-
 #[test]
 fn fskey_typical_size() {
     let ok = ObjKey::Extent(0);

--- a/bfffs-core/src/idml/idml.rs
+++ b/bfffs-core/src/idml/idml.rs
@@ -780,22 +780,6 @@ mod t {
         ddml
     }
 
-    // pet kcov
-    #[test]
-    fn ridtentry_debug() {
-        let drp = DRP::random(Compression::None, 4096);
-        let ridt_entry = RidtEntry::new(drp);
-        format!("{ridt_entry:?}");
-
-        let label = Label{
-            alloct:     TreeOnDisk::default(),
-            next_rid:   0,
-            ridt:       TreeOnDisk::default(),
-            txg:        TxgT(0)
-        };
-        format!("{label:?}");
-    }
-
     #[test]
     fn ridtentry_typical_size() {
         let typical = RidtEntry::new(DRP::default());

--- a/bfffs-core/src/label.rs
+++ b/bfffs-core/src/label.rs
@@ -47,7 +47,7 @@ pub const SPACEMAP_ZONES_PER_LBA: usize = 255;
 
 /// How many LBAs should be reserved for each spacemap?
 pub fn spacemap_space(nzones: u64) -> LbaT {
-    div_roundup(nzones, SPACEMAP_ZONES_PER_LBA as u64)
+    nzones.div_ceil(SPACEMAP_ZONES_PER_LBA as u64)
 }
 
 /// Used to read successive structs out of the label

--- a/bfffs-core/src/pool.rs
+++ b/bfffs-core/src/pool.rs
@@ -466,7 +466,7 @@ impl Pool {
     {
         let cluster = self.choose_cluster();
         let cidx = cluster as usize;
-        let space = div_roundup(buf.len(), BYTES_PER_LBA) as LbaT;
+        let space = buf.len().div_ceil(BYTES_PER_LBA) as LbaT;
         let stats2 = self.stats.clone();
         match self.clusters[cidx].write(buf, txg) {
             Ok((lba, wfut)) => {

--- a/bfffs-core/src/pool.rs
+++ b/bfffs-core/src/pool.rs
@@ -528,20 +528,6 @@ impl Future for Write {
 #[cfg(test)]
 mod t {
 
-mod label {
-    use super::super::*;
-
-    // pet kcov
-    #[test]
-    fn debug() {
-        let label = Label{name: "Foo".to_owned(),
-            uuid: Uuid::new_v4(),
-            children: vec![]
-        };
-        format!("{label:?}");
-    }
-}
-
 mod pool {
     use super::super::*;
     use futures::future;

--- a/bfffs-core/src/raid/null_raid.rs
+++ b/bfffs-core/src/raid/null_raid.rs
@@ -196,21 +196,3 @@ impl VdevRaidApi for NullRaid {
         Box::pin(self.mirror.write_spacemap(sglist, idx, block))
     }
 }
-
-// LCOV_EXCL_START
-#[cfg(test)]
-mod t {
-
-use super::*;
-// pet kcov
-#[test]
-fn debug() {
-    let label = Label {
-        uuid: Uuid::new_v4(),
-        child: Uuid::new_v4()
-    };
-    format!("{label:?}");
-}
-
-}
-// LCOV_EXCL_STOP

--- a/bfffs-core/src/raid/prime_s.rs
+++ b/bfffs-core/src/raid/prime_s.rs
@@ -595,13 +595,6 @@ mod tests {
         PrimeS::new(9, 5, 1);
     }
 
-    // pet kcov
-    #[test]
-    fn debug() {
-        let locator = PrimeS::new(7, 4, 2);
-        format!("{locator:?}");
-    }
-
     // Exhaustive placement test for a small array
     // declust.rb's output:
     // D0.0   D0.1   D0.2   C0.0   C0.1   D1.2   C1.0

--- a/bfffs-core/src/raid/prime_s.rs
+++ b/bfffs-core/src/raid/prime_s.rs
@@ -11,7 +11,6 @@
 //! Computer Architecture News. Vol. 26. No. 3. IEEE Computer Society, 1998.
 
 use fixedbitset::FixedBitSet;
-use crate::util::div_roundup;
 use std::{
     fmt::Debug,
     iter::FusedIterator,
@@ -339,7 +338,7 @@ impl Locator for PrimeS {
     fn parallel_read_count(&self, consecutive_data_chunks: usize) -> usize {
         // As given in page 5 of Alvarez et al's PRIME paper:
         // τ(ο) ≤ ⌈ο/n⌉ + 1
-        div_roundup(consecutive_data_chunks, self.n as usize) + 1
+        consecutive_data_chunks.div_ceil(self.n as usize) + 1
     }
 
     fn protection(&self) -> i16 {

--- a/bfffs-core/src/raid/vdev_raid/tests.rs
+++ b/bfffs-core/src/raid/vdev_raid/tests.rs
@@ -174,20 +174,6 @@ mod stripe_buffer {
     }
 }
 
-// pet kcov
-#[test]
-fn debug() {
-    let label = Label {
-        uuid: Uuid::new_v4(),
-        chunksize: 1,
-        disks_per_stripe: 2,
-        redundancy: 1,
-        layout_algorithm: LayoutAlgorithm::PrimeS,
-        children: vec![Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()]
-    };
-    format!("{label:?}");
-}
-
 /// A mock Mirror device with some basic expectations
 fn mock_mirror() -> Mirror{
     let zl0 = (1, 60_000);

--- a/bfffs-core/src/tree/mod.rs
+++ b/bfffs-core/src/tree/mod.rs
@@ -100,18 +100,3 @@ impl<A: Addr> TypicalSize for TreeOnDisk<A> {
 }
 
 impl<A: Addr> Value for TreeOnDisk<A> { }
-
-// LCOV_EXCL_START
-#[cfg(test)]
-mod t {
-    use super::*;
-
-    // pet kcov
-    #[test]
-    fn debug() {
-        let cr = CreditRequirements{insert: 0, range_delete: 0, remove: 0};
-        let tod = TreeOnDisk::<RID>::default();
-        format!("{cr:?} {tod:?}");
-    }
-}
-// LCOV_EXCL_STOP

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -4,7 +4,6 @@
 use crate::{
     dml::{Cacheable, CacheRef, DML},
     types::*,
-    util::*,
     writeback::Credit
 };
 use divbuf::{DivBuf, DivBufShared};
@@ -1272,7 +1271,7 @@ impl<A: Addr, K: Key, V: Value> NodeData<A, K, V> {
             // Divide evenly, but make the left node slightly larger, on the
             // assumption that we're more likely to insert into the right node
             // than the left one.
-            div_roundup(self.len(), 2)
+            self.len().div_ceil(2)
         };
         match self {
             NodeData::Leaf(leaf) => {

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -1525,23 +1525,6 @@ use divbuf::*;
 use pretty_assertions::assert_eq;
 use super::*;
 
-// pet kcov
-#[test]
-fn debug() {
-    let ld = LeafData {
-        credit: Credit::null(),
-        items: BTreeMap::<u32, u32>::new()
-    };
-    let items: BTreeMap<u32, u32> = BTreeMap::new();
-    let node: Node<DRP, u32, u32> = leaf_node!(items);
-    format!("{ld:?} {node:?}");
-
-    let mut children: Vec<IntElem<u32, u32, u32>> = Vec::new();
-    let txgs = TxgT(1)..TxgT(3);
-    children.push(IntElem::new(0, txgs, TreePtr::Addr(4)));
-    format!("{:?}", NodeData::Int(IntData{children}));
-}
-
 #[test]
 fn arc_node_eq() {
     let items: BTreeMap<u32, u32> = BTreeMap::new();

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -597,10 +597,6 @@ impl<'de, K: Key, V: Value> Deserialize<'de> for LeafData<K, V> {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
         where D: Deserializer<'de>
     {
-        #[derive(Deserialize)]
-        #[serde(field_identifier, rename_all = "lowercase")]
-        enum Field { Credit, Items }
-
         struct LeafDataVisitor<K: Key, V: Value> {
             _k: PhantomData<K>,
             _v: PhantomData<V>
@@ -629,6 +625,10 @@ impl<'de, K: Key, V: Value> Deserialize<'de> for LeafData<K, V> {
                 -> std::result::Result<Self::Value, SV::Error>
                 where SV: de::MapAccess<'de>
             {
+                #[derive(Deserialize)]
+                #[serde(field_identifier, rename_all = "lowercase")]
+                enum Field { Credit, Items }
+
                 // The only supported serializer that uses a Map is YAML, for
                 // unit tests and Tree::dump, where we do serialize Credit.
                 let mut credit = Credit::null();

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -691,7 +691,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
                 2 * (split_size / elem_size)
             };
             debug_assert!(max_fanout <= usize::from(u16::MAX));
-            let min_fanout = div_roundup(max_fanout as u16, spread);
+            let min_fanout = (max_fanout as u16).div_ceil(spread);
             (min_fanout, max_fanout as u16)
         };
 

--- a/bfffs-core/src/types.rs
+++ b/bfffs-core/src/types.rs
@@ -18,18 +18,6 @@ use std::{
     str::FromStr,
 };
 
-
-/// "Private" trait; only exists to ensure that div_roundup will fail to compile
-/// when used with signed numbers.  It would be nice to use a negative trait
-/// bound like "+ !Neg", but Rust doesn't support negative trait bounds.
-#[doc(hidden)]
-pub trait RoundupAble {}
-impl RoundupAble for u8 {}
-impl RoundupAble for u16 {}
-impl RoundupAble for u32 {}
-impl RoundupAble for u64 {}
-impl RoundupAble for usize {}
-
 /// Objects that implement this trait have a typical size when serialized with
 /// bincode
 pub trait TypicalSize {

--- a/bfffs-core/src/vdev_block.rs
+++ b/bfffs-core/src/vdev_block.rs
@@ -1694,7 +1694,6 @@ mod t {
             }
         }
 
-        // pet kcov
         #[test]
         #[allow(clippy::eq_op)]
         fn partial_eq() {
@@ -1713,36 +1712,6 @@ mod t {
     mod cmd {
         use super::*;
 
-        // pet kcov
-        #[test]
-        fn debug() {
-            let dbs = DivBufShared::from(vec![0u8]);
-            {
-                let read_at = Cmd::ReadAt(dbs.try_mut().unwrap());
-                format!("{read_at:?}");
-            }
-            {
-                let readv_at = Cmd::ReadvAt(vec![dbs.try_mut().unwrap()]);
-                format!("{readv_at:?}");
-            }
-            {
-                let read_spacemap = Cmd::ReadSpacemap(dbs.try_mut().unwrap());
-                format!("{read_spacemap:?}");
-            }
-            let write_at = Cmd::WriteAt(dbs.try_const().unwrap());
-            let writev_at = Cmd::WritevAt(vec![dbs.try_const().unwrap()]);
-            let erase_zone = Cmd::EraseZone(0);
-            let finish_zone = Cmd::FinishZone(0);
-            let sync_all = Cmd::SyncAll;
-            let label_writer = LabelWriter::new(0);
-            let write_label = Cmd::WriteLabel(label_writer);
-            let write_spacemap = Cmd::WriteSpacemap(
-                vec![dbs.try_const().unwrap()]);
-            format!("{write_at:?} {writev_at:?} {erase_zone:?} {finish_zone:?}\
- {sync_all:?} {write_label:?} {write_spacemap:?}");
-        }
-
-        // pet kcov
         #[test]
         fn partial_cmp() {
             let c0 = Cmd::SyncAll;

--- a/bfffs-core/src/vdev_file.rs
+++ b/bfffs-core/src/vdev_file.rs
@@ -176,7 +176,7 @@ impl<'fd> Vdev for VdevFile<'fd> {
     }
 
     fn zones(&self) -> ZoneT {
-        div_roundup(self.size, self.lbas_per_zone) as ZoneT
+        self.size.div_ceil(self.lbas_per_zone) as ZoneT
     }
 }
 
@@ -335,7 +335,7 @@ impl<'fd> VdevFile<'fd> {
         let erase_method = AtomicEraseMethod::initial(f.as_raw_fd())?;
         let size = Self::devlen(f, sectorsize)? / BYTES_PER_LBA as u64;
         let lbas_per_zone = VdevFile::DEFAULT_LBAS_PER_ZONE;
-        let nzones = div_roundup(size, lbas_per_zone);
+        let nzones = size.div_ceil(lbas_per_zone);
         let spacemap_space = spacemap_space(nzones);
         Ok(VdevFile {
             fd: f.as_fd(),
@@ -442,7 +442,7 @@ impl<'fd> VdevFile<'fd> {
     ///                     zones.
     pub fn set(&mut self, size: LbaT, lbas_per_zone: LbaT) {
         self.size = size;
-        let nzones = div_roundup(size, lbas_per_zone);
+        let nzones = size.div_ceil(lbas_per_zone);
         self.spacemap_space = spacemap_space(nzones);
         self.lbas_per_zone = lbas_per_zone;
     }

--- a/bfffs-core/src/writeback/writeback.rs
+++ b/bfffs-core/src/writeback/writeback.rs
@@ -304,13 +304,6 @@ mod t {
 use super::*;
 use futures_test::task::noop_context;
 
-/// pet grcov
-#[test]
-fn debug() {
-    let wb = WriteBack::with_capacity(1000);
-    format!("{wb:?}");
-}
-
 /// A borrower must sleep, but abandons his loan application (drops his future)
 /// before being awakened.  This might happen in production if we ever support
 /// I/O cancellation.

--- a/bfffs-core/tests/functional/raid/vdev_raid.rs
+++ b/bfffs-core/tests/functional/raid/vdev_raid.rs
@@ -405,7 +405,7 @@ mod fault {
 mod io {
     use super::*;
 
-    use bfffs_core::{IoVec, IoVecMut, ZoneT, div_roundup};
+    use bfffs_core::{IoVec, IoVecMut, ZoneT};
 
     #[template]
     #[rstest(h,
@@ -681,7 +681,7 @@ mod io {
     #[awt]
     async fn write_read_three_rows(#[future] h: Harness) {
         let rows = 3;
-        let stripes = div_roundup((rows * h.n) as usize, h.k as usize);
+        let stripes = ((rows * h.n) as usize).div_ceil(h.k as usize);
         write_read_n_stripes(h.vdev, h.chunksize, h.k, h.f, stripes).await;
     }
 

--- a/bfffs-core/tests/functional/vdev_file.rs
+++ b/bfffs-core/tests/functional/vdev_file.rs
@@ -49,12 +49,6 @@ mod basic {
         Harness{file, vdev, path: pb, _tempdir: tempdir}
     }
 
-    // pet kcov
-    #[rstest]
-    fn debug(harness: Harness) {
-        format!("{:?}", harness.vdev);
-    }
-
     /// erase_zone on a plain file should succeed.  If fspacectl is supported,
     /// that region of the file should be zeroed.  Otherwise, nothing should
     /// happen.


### PR DESCRIPTION
- Use the builtin div_ceil method instead of defining div_roundup
- Eliminate "pet kcov" test functions
- Fix an unused struct definition, detected by the latest rustc
- Update the bytes dependency