### PR TITLE
Less boxing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,6 @@ dependencies = [
 name = "bfffs-core"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "atomic_enum",
  "auto_enums",
  "bincode",

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 nightly = [ "mockall/nightly" ]
 
 [dependencies]
-async-trait = "0.1.43"
 atomic_enum = "0.3.0"
 auto_enums = "0.8.5"
 bincode = { version = "1.3.3", features = ["i128"] }

--- a/bfffs-core/src/mirror.rs
+++ b/bfffs-core/src/mirror.rs
@@ -574,6 +574,7 @@ impl Mirror {
         self.uuid
     }
 
+    // TODO: can we eliminate this box?
     pub fn write_at(&self, buf: IoVec, lba: LbaT) -> BoxVdevFut
     {
         let fut = self.children.iter().filter_map(|blockdev| {

--- a/bfffs-core/src/raid/declust.rs
+++ b/bfffs-core/src/raid/declust.rs
@@ -100,7 +100,7 @@ pub trait Locator : Clone + Send + Sync {
     /// - `start`:  The first `ChunkId` whose location will be returned
     /// - `end`:    The first `ChunkId` beyond the end of the iterator
     fn iter(&self, start: ChunkId, end: ChunkId)
-        -> Box<dyn Iterator<Item=(ChunkId, Chunkloc)>>;
+        -> impl Iterator<Item=(ChunkId, Chunkloc)>;
 
     /// Inverse of `id2loc`.
     ///

--- a/bfffs-core/src/raid/mod.rs
+++ b/bfffs-core/src/raid/mod.rs
@@ -5,7 +5,6 @@
 //! This provides vdevs which slot between `cluster` and `mirror` and
 //! provide RAID-like functionality.
 
-#[cfg(test)] use async_trait::async_trait;
 use crate::{
     label::*,
     types::*,
@@ -229,7 +228,6 @@ mock!{
         fn zone_limits(&self, zone: ZoneT) -> (LbaT, LbaT);
         fn zones(&self) -> ZoneT;
     }
-    #[async_trait]
     impl VdevRaidApi for VdevRaid {
         fn erase_zone(&self, zone: ZoneT) -> BoxVdevFut;
         fn finish_zone(&self, zone: ZoneT) -> BoxVdevFut;

--- a/bfffs-core/src/raid/null_raid.rs
+++ b/bfffs-core/src/raid/null_raid.rs
@@ -5,7 +5,6 @@ use std::{
     pin::Pin,
 };
 
-use async_trait::async_trait;
 use crate::{
     BYTES_PER_LBA,
     ZERO_REGION,
@@ -93,7 +92,6 @@ impl Vdev for NullRaid {
     }
 }
 
-#[async_trait]
 impl VdevRaidApi for NullRaid {
     fn erase_zone(&self, zone: ZoneT) -> BoxVdevFut {
         let limits = self.mirror.zone_limits(zone);

--- a/bfffs-core/src/raid/prime_s.rs
+++ b/bfffs-core/src/raid/prime_s.rs
@@ -286,8 +286,9 @@ impl Locator for PrimeS {
     }
 
     fn iter(&self, start: ChunkId, end: ChunkId)
-        -> Box<dyn Iterator<Item=(ChunkId, Chunkloc)>> {
-        Box::new(PrimeSIter::new(self, start, end))
+        -> impl Iterator<Item=(ChunkId, Chunkloc)>
+    {
+        PrimeSIter::new(self, start, end)
     }
 
     fn loc2id(&self, chunkloc: Chunkloc) -> ChunkId {

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -1,6 +1,5 @@
 // vim: tw=80
 
-use async_trait::async_trait;
 use crate::{
     label::*,
     types::*,
@@ -1947,7 +1946,6 @@ impl Vdev for VdevRaid {
     }
 }
 
-#[async_trait]
 impl VdevRaidApi for VdevRaid {
     fn erase_zone(&self, zone: ZoneT) -> BoxVdevFut {
         assert!(!self.stripe_buffers.read().unwrap().contains_key(&zone),

--- a/bfffs-core/src/raid/vdev_raid_api.rs
+++ b/bfffs-core/src/raid/vdev_raid_api.rs
@@ -1,5 +1,4 @@
 // vim: tw=80
-use async_trait::async_trait;
 use futures::Future;
 
 use crate::{
@@ -11,7 +10,6 @@ use crate::{
 
 /// The public interface for all RAID Vdevs.  All Vdevs that slot beneath a
 /// cluster must implement this API.
-#[async_trait]
 #[enum_dispatch::enum_dispatch]
 pub trait VdevRaidApi : Vdev + Send + Sync + 'static {
     /// Asynchronously erase a zone on a RAID device


### PR DESCRIPTION
- Use native async trait functions
- Change the return type of Cluster::free to ()
- Less boxing in VdevRaid by defining some enums