### PR TITLE
DRY: Use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,76 @@ lto = true
 members = ["bfffs-core", "bfffs-fio", "bfffs", "isa-l"]
 resolver = "2"
 
+[workspace.dependencies]
+bincode = "1.3.3"
+cfg-if = "1.0"
+divbuf = { git = "https://github.com/asomers/divbuf.git", rev = "deb99e3"}
+enum_dispatch = "0.3.12"
+assert_cmd = "2.0"
+atomic_enum = "0.3.0"
+auto_enums = "0.8.5"
+bitfield = "0.13.1"
+blosc = "0.2.0"
+byteorder = "1.4.0"
+bytes = "1.5.0"
+clap = "4.1"
+console-subscriber = { version = "0.2.0", default-features = false }
+criterion = "0.5"
+dashmap = "5.5"
+downcast = "0.11.0"
+enum-primitive-derive = "0.3.0"
+fixedbitset = "0.4.0"
+freebsd-libgeom = "0.2.2"
+function_name = "0.3.0"
+fuse3 = { version = "0.7.2", default-features = false }
+futures = "0.3.30"
+futures-locks = "0.7.0"
+futures-test = "0.3.30"
+glob = "0.3.1"
+hexdump = "0.1.2"
+histogram = "0.6"
+itertools = "0.11.0"
+lalrpop = "0.20.0"
+lalrpop-util = "0.20.0"
+libc = "0.2.155"
+mdconfig = "0.2.0"
+metrohash = "1.0.2"
+mockall = "0.13.0"
+mockall_double = "0.3.1"
+nix = { version = "0.29.0", default-features = false }
+nonzero_ext = "0.3.0"
+num-traits = "0.2.14"
+num_cpus = "1.8"
+num_enum = "0.7.0"
+permutohedron = "0.2"
+pin-project = "1.1.0"
+predicates = "3.0.0"
+pretty_assertions = "1.3"
+prettydiff = { version = "0.7.0", default-features = false }
+prettytable = { version = "0.10.0", default-features = false }
+rand = "0.8.5"
+rand_xorshift = "0.3"
+regex = "1.7.3"
+rstest = "0.19.0"
+rstest_reuse = "0.6.0"
+serde = "1.0.196"
+serde_derive = "1.0.196"
+serde_yaml_ng = "0.10.0"
+si-scale = "0.1.5"
+sysctl = "0.5"
+tabular = "0.2.0"
+tempfile = "3.8"
+test-log = { version = "0.2.13", default-features = false }
+thiserror = "1.0.32"
+time = { version = "0.3.0", default-features = false }
+tokio = { version = "1.36.0", default-features = false }
+tokio-file = "0.10.0"
+tokio-seqpacket = "0.5.4"
+tracing = { version = "0.1.40", default-features = false }
+tracing-futures = "0.2.4"
+tracing-subscriber = { version = "0.3.17", default-features = false }
+uuid = { version = "1.6.1", default-features = false }
+
 [patch.crates-io]
 atomic_enum = { git = "https://github.com/brain0/atomic_enum.git", rev = "baea45a" }
 fuse3 = { git = "https://github.com/Sherlock-Holo/fuse3.git", rev = "bf4a341"}

--- a/bfffs-core/Cargo.toml
+++ b/bfffs-core/Cargo.toml
@@ -12,77 +12,69 @@ doctest = false
 nightly = [ "mockall/nightly" ]
 
 [dependencies]
-atomic_enum = "0.3.0"
-auto_enums = "0.8.5"
-bincode = { version = "1.3.3", features = ["i128"] }
-bitfield = "0.13.1"
-blosc = "0.2.0"
-byteorder = "1.4.0"
-cfg-if = "1.0"
-divbuf = { git = "https://github.com/asomers/divbuf.git", rev = "deb99e3"}
-downcast = "0.11.0"
-enum_dispatch = "0.3.12"
-enum-primitive-derive = "0.3.0"
-fixedbitset = "0.4.0"
-futures = "0.3.30"
-futures-locks = "0.7.0"
-itertools = "0.11.0"
-hexdump = "0.1.2"
+atomic_enum = { workspace = true }
+auto_enums = { workspace = true }
+bincode = { workspace = true, features = ["i128"] }
+bitfield = { workspace = true }
+blosc = { workspace = true }
+byteorder = { workspace = true }
+cfg-if.workspace = true
+divbuf.workspace = true
+downcast = { workspace = true }
+enum_dispatch.workspace = true
+enum-primitive-derive = { workspace = true }
+fixedbitset = { workspace = true }
+futures = { workspace = true }
+futures-locks = { workspace = true }
+itertools = { workspace = true }
+hexdump = { workspace = true }
 isa-l = { path = "../isa-l" }
-libc = "0.2.155"
-metrohash = "1.0.2"
-mockall_double = "0.3.1"
-nix = { version = "0.29.0", default-features = false, features = ["feature", "fs", "ioctl", "mount", "time"] }
-num_enum = "0.7.0"
-num-traits = "0.2.14"
-pin-project = "1.1.0"
-serde = "1.0.196"
-serde_derive = "1.0.196"
-serde_yaml_ng = "0.10.0"
-thiserror = "1.0.32"
-time = { version = "0.3.0", features = [ "formatting" ] }
-tokio = { version = "1.36.0", features = ["rt", "sync", "time"] }
-tokio-file = "0.10.0"
-tracing = "0.1.40"
-tracing-futures = "0.2.4"
-uuid = { version = "1.6.1", features = ["v4", "std"], default-features = false }
-
-[dev-dependencies.clap]
-version = "4.1"
-default-features = true
-features=  [ "derive", "wrap_help" ]
+libc = { workspace = true }
+metrohash = { workspace = true }
+mockall_double = { workspace = true }
+nix = { workspace = true, features = ["feature", "fs", "ioctl", "mount", "time"] }
+num_enum = { workspace = true }
+num-traits = { workspace = true }
+pin-project = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_yaml_ng = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true, features = ["formatting"] }
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
+tokio-file = { workspace = true }
+tracing = { workspace = true }
+tracing-futures = { workspace = true }
+uuid = { workspace = true, features = ["v4", "std"] }
 
 [dev-dependencies]
-dashmap = "5.5"
-criterion = "0.5"
-function_name = "0.3.0"
-futures-test = "0.3.30"
-glob = "0.3.1"
-histogram = "0.6"
-itertools = "0.11.0"
-mdconfig = "0.2.0"
-mockall = "0.13.0"
-nonzero_ext = "0.3.0"
-nix = { version = "0.29.0", default-features = false, features = ["user"] }
-num_cpus = "1.8"
-permutohedron = "0.2"
-pretty_assertions = "1.3"
-prettydiff = { version = "0.7.0", default-features = false, features = ["prettytable-rs"] }
-rand = "0.8.5"
-rand_xorshift = "0.3"
-rstest = "0.19.0"
-rstest_reuse = "0.6.0"
-tempfile = "3.8"
-test-log = { version = "0.2.13", default-features = false, features = ["trace"] }
-tokio = { version = "1.36.0", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
-
-[dev-dependencies.tracing-subscriber]
-version = "0.3.17"
-default-features = false
-features = [ "ansi", "env-filter", "fmt", "tracing-log" ]
+clap = { workspace = true, features = ["derive", "wrap_help"] }
+dashmap = { workspace = true }
+criterion = { workspace = true }
+function_name = { workspace = true }
+futures-test = { workspace = true }
+glob = { workspace = true }
+histogram = { workspace = true }
+itertools = { workspace = true }
+mdconfig = { workspace = true }
+mockall = { workspace = true }
+nonzero_ext = { workspace = true }
+nix = { workspace = true, features = ["user"] }
+num_cpus = { workspace = true }
+permutohedron = { workspace = true }
+pretty_assertions = { workspace = true }
+prettydiff = { workspace = true, features = ["prettytable-rs"] }
+rand = { workspace = true }
+rand_xorshift = { workspace = true }
+rstest = { workspace = true }
+rstest_reuse = { workspace = true }
+tempfile = { workspace = true }
+test-log = { workspace = true, features = ["trace"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "fmt", "tracing-log"] }
 
 [build-dependencies]
-nix = { version = "0.29.0", default-features = false, features = ["feature"] }
+nix = { workspace = true, features = ["feature"] }
 
 
 [[test]]

--- a/bfffs-fio/Cargo.toml
+++ b/bfffs-fio/Cargo.toml
@@ -9,15 +9,11 @@ license = "GPL-2.0"
 
 [dependencies]
 bfffs-core = { path = "../bfffs-core" }
-console-subscriber = "0.2.0"
-futures = "0.3.30"
-libc = "0.2.155"
-tokio = { version = "1.36.0", features = ["rt", "rt-multi-thread", "sync", "time", "tracing"] }
-
-[dependencies.tracing-subscriber]
-version = "0.3.17"
-default-features = false
-features = [ "ansi", "env-filter", "fmt", "tracing-log" ]
+console-subscriber = { workspace = true }
+futures = { workspace = true }
+libc = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "tracing"] }
+tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "fmt", "tracing-log"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -13,52 +13,44 @@ name = "bfffsd"
 required-features = ["fuse"]
 
 [dependencies]
-bincode = "1.3.3"
+bincode.workspace = true
 bfffs-core = { path = "../bfffs-core" }
-bytes = "1.5.0"
-cfg-if = "1.0"
-console-subscriber = { default-features = false, version = "0.2.0" }
-fuse3 = { version = "0.7.2", optional = true, features = ["tokio-runtime"], default-features = false }
-futures = "0.3.30"
-lalrpop-util = { version = "0.20.0", features = ["lexer", "std"] }
-libc = "0.2.155"
-nix = { version = "0.29.0", default-features = false, features = ["user"] }
-prettytable = { version = "0.10.0", default-features = false }
-si-scale = "0.1.5"
-tabular = "0.2.0"
-thiserror = "1.0.32"
-time = { version = "0.3.0", default-features = false }
-tokio = { version = "1.36.0", features = ["rt-multi-thread"], default-features = false }
-tokio-seqpacket = "0.5.4"
-tracing = { default-features = false, version = "0.1.40" }
-
-[dependencies.clap]
-version = "4.1"
-default-features = true
-features=  [ "cargo", "derive", "wrap_help"]
-
-[dependencies.tracing-subscriber]
-version = "0.3.17"
-default-features = false
-features = [ "ansi", "env-filter", "fmt", "tracing-log" ]
+bytes = { workspace = true }
+cfg-if.workspace = true
+console-subscriber = { workspace = true }
+fuse3 = { workspace = true, features = ["tokio-runtime"], optional = true }
+futures = { workspace = true }
+lalrpop-util = { workspace = true, features = ["lexer", "std"] }
+libc = { workspace = true }
+nix = { workspace = true, features = ["user"] }
+prettytable = { workspace = true }
+si-scale = { workspace = true }
+tabular = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio-seqpacket = { workspace = true }
+tracing = { workspace = true }
+clap = { workspace = true, features = ["cargo", "derive", "wrap_help"] }
+tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "fmt", "tracing-log"] }
 
 [build-dependencies]
-lalrpop = "0.20.0"
+lalrpop = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = "2.0"
-divbuf = { git = "https://github.com/asomers/divbuf.git", rev = "deb99e3"}
-enum_dispatch = "0.3.12"
-freebsd-libgeom = "0.2.2"
-function_name = "0.3.0"
-mockall = "0.13.0"
-nix = { version = "0.29.0", default-features = false, features = ["mount", "process", "signal", "user"] }
-predicates = "3.0.0"
-pretty_assertions = "1.3"
-regex = "1.7.3"
-rstest = "0.19.0"
-sysctl = "0.5"
-tempfile = "3.8"
+assert_cmd = { workspace = true }
+divbuf.workspace = true
+enum_dispatch.workspace = true
+freebsd-libgeom = { workspace = true }
+function_name = { workspace = true }
+mockall = { workspace = true }
+nix = { workspace = true, features = ["mount", "process", "signal", "user"] }
+predicates = { workspace = true }
+pretty_assertions = { workspace = true }
+regex = { workspace = true }
+rstest = { workspace = true }
+sysctl = { workspace = true }
+tempfile = { workspace = true }
 
 [[test]]
 name = "integration"


### PR DESCRIPTION
This way dependencies' versions need only be specified in one location.