### PR TITLE
Cleanup some obsolete Clippy allow statements

### DIFF
--- a/bfffs-core/src/cleaner.rs
+++ b/bfffs-core/src/cleaner.rs
@@ -160,7 +160,7 @@ use super::*;
 use tokio::runtime;
 
 /// Clean in the background
-#[allow(clippy::async_yields_async)]
+#[allow(clippy::async_yields_async)]    // Not awaiting handle is deliberate
 #[test]
 fn background() {
     let mut idml = IDML::default();

--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -377,7 +377,7 @@ impl<'a> FreeSpaceMap {
     }
 
     /// Find the next closed zone including or after `start`
-    #[allow(clippy::if_same_then_else)]
+    #[allow(clippy::if_same_then_else)] // Code looks better this way
     fn find_closed_zone(&'a self, start: ZoneT) -> Option<ClosedZone>
     {
         if start as usize >= self.zones.len() {

--- a/bfffs-core/src/controller.rs
+++ b/bfffs-core/src/controller.rs
@@ -343,8 +343,6 @@ impl Controller {
     /// # Arguments
     ///
     /// - `name`    -   Name of the file system to create, including pool name
-    // Clippy false positive.
-    #[allow(clippy::unnecessary_to_owned)]
     #[tracing::instrument(skip(self))]
     pub fn new_fs(&self, name: &str)
         -> impl Future<Output = Result<Arc<Fs>>> + Send

--- a/bfffs-core/src/database/database.rs
+++ b/bfffs-core/src/database/database.rs
@@ -63,7 +63,6 @@ struct Syncer {
 
 impl Syncer {
     // Clippy false positive: the async block is needed for lifetime reasons
-    #[allow(clippy::redundant_async_block)]
     fn kick(&self) -> impl Future<Output=Result<()>> {
         let mut tx2 = self.tx.clone();
         async move {

--- a/bfffs-core/src/dataset/dataset_mock.rs
+++ b/bfffs-core/src/dataset/dataset_mock.rs
@@ -33,7 +33,9 @@ mock! {
             -> Pin<Box<dyn Future<Output=Result<Option<V>>> + Send>>;
         fn get_blob(&self, rid: RID)
             -> Pin<Box<dyn Future<Output=Result<Box<DivBuf>>> + Send>>;
-        #[allow(clippy::multiple_bound_locations)]  // False positive
+        // False positive, probably related to Mockall.
+        // https://github.com/rust-lang/rust-clippy/issues/12552
+        #[allow(clippy::multiple_bound_locations)]
         fn range<R, T>(&self, range: R) -> RangeQuery<K, T, V>
             where K: Borrow<T>,
                   R: RangeBounds<T> + 'static,

--- a/bfffs-core/src/fs_tree.rs
+++ b/bfffs-core/src/fs_tree.rs
@@ -308,7 +308,6 @@ pub trait HTItem: TryFrom<FSValue, Error=()> + Clone + Send + Sized + 'static {
 
     /// Create a bucket of `HTItem`s from a vector of `Self`.  Used for putting
     /// the bucket back into the Tree.
-    #[allow(clippy::wrong_self_convention)]
     fn into_bucket(selves: Vec<Self>) -> FSValue;
 
     /// Turn self into a regular `FSValue`, suitable for inserting into the Tree

--- a/bfffs-core/src/lib.rs
+++ b/bfffs-core/src/lib.rs
@@ -2,11 +2,6 @@
 
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
 
-// Disable the range_plus_one lint until this bug is fixed.  It generates many
-// false positive in the Tree code.
-// https://github.com/rust-lang-nursery/rust-clippy/issues/3307
-#![allow(clippy::range_plus_one)]
-
 // I don't find this lint very helpful
 #![allow(clippy::type_complexity)]
 
@@ -17,9 +12,6 @@
 // I suppose I should probably fix this some day, but I just don't like the look
 // of e.g. "Idml" as opposed to "IDML".
 #![allow(clippy::upper_case_acronyms)]
-
-// False positive https://github.com/rust-lang/rust-clippy/issues/10498
-#![allow(clippy::let_with_type_underscore)]
 
 // error: reached the type-length limit while instantiating std::pin::Pin...
 #![type_length_limit="3790758"]

--- a/bfffs-core/src/pool.rs
+++ b/bfffs-core/src/pool.rs
@@ -258,7 +258,6 @@ impl Pool {
 
     /// Construct a new `Pool` from some already constructed
     /// [`Cluster`](struct.Cluster.html)s.
-    #[allow(clippy::new_ret_no_self)]
     fn new(name: String, uuid: Uuid, clusters: Vec<Cluster>) -> Self
     {
         let size = clusters.iter()
@@ -309,7 +308,6 @@ impl Pool {
     /// * `(None, Some(x))`    - No closed zone this call.  Repeat the call,
     ///                          supplying `x`
     /// * `(None, None)`       - No more closed zones in this pool.
-    #[allow(clippy::collapsible_if)]
     pub fn find_closed_zone(&self, clust: ClusterT, zid: ZoneT)
         -> (Option<ClosedZone>, Option<(ClusterT, ZoneT)>)
     {
@@ -694,9 +692,6 @@ mod pool {
         assert_eq!(pool.used(), 84);
     }
 
-    // optimum_queue_depth is always a smallish integer, so exact equality
-    // testing is ok.
-    #[allow(clippy::float_cmp)]
     #[test]
     fn new() {
         let clusters = vec![

--- a/bfffs-core/src/raid/codec.rs
+++ b/bfffs-core/src/raid/codec.rs
@@ -5,7 +5,6 @@
 
 use crate::types::SGList;
 use fixedbitset::FixedBitSet;
-use std::borrow::BorrowMut;
 use super::sgcursor::*;
 
 /// An encoder/decoder for Reed-Solomon Erasure coding in GF(2^8), oriented

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -1642,7 +1642,7 @@ impl VdevRaid {
     }
 
     /// Write two or more whole stripes
-    #[allow(clippy::needless_range_loop)]
+    #[allow(clippy::needless_range_loop)]   // Code looks better this way
     fn write_at_multi(&self, mut buf: IoVec, lba: LbaT) -> BoxVdevFut {
         let col_len = self.chunksize as usize * BYTES_PER_LBA;
         let f = self.inner.codec.protection() as usize;

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -1534,7 +1534,6 @@ fn arc_node_eq() {
     assert!(!node.eq(&dbs));
 }
 
-#[allow(clippy::eq_op)]
 #[test]
 fn treeptr_eq() {
     assert_eq!(TreePtr::Addr::<u32, u32, u32>(0),

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -52,8 +52,7 @@ use tracing_futures::Instrument;
 #[cfg(test)] mod tests;
 
 /// Are there any elements in common between the two Ranges?
-#[allow(clippy::if_same_then_else)]
-#[allow(clippy::needless_bool)]
+#[allow(clippy::needless_bool)] // Code looks better this way
 fn ranges_overlap<R, T, U>(x: &R, y: &Range<U>) -> bool
     where U: Borrow<T> + PartialOrd,
           R: RangeBounds<T>,
@@ -828,7 +827,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
 
     /// Fix an Int node in danger of being underfull, returning the parent guard
     /// back to the caller
-    #[allow(clippy::collapsible_if, clippy::collapsible_else_if)]
+    #[allow(clippy::collapsible_else_if)]   // Code looks better this way
     fn fix_int<Q>(
         &self,
         parent: TreeWriteGuard<A, K, V>,
@@ -1870,7 +1869,6 @@ impl<A, D, K, V> Tree<A, D, K, V>
         })
     }
 
-    #[allow(clippy::unnecessary_unwrap)]
     fn range_delete_pass2_r<R, T>(
         self: Arc<Self>,
         guard: TreeWriteGuard<A, K, V>,
@@ -2182,8 +2180,6 @@ impl<A, D, K, V> Tree<A, D, K, V>
         self.root.write()
     }
 
-    // Clippy has a false positive on `node`
-    #[allow(clippy::needless_pass_by_value)]
     fn write_leaf(
         dml: Arc<D>,
         compressor: Compression,

--- a/bfffs-core/src/tree/tree/tests/mod.rs
+++ b/bfffs-core/src/tree/tree/tests/mod.rs
@@ -57,7 +57,7 @@ impl Value for NeedsDcloneV {
 
 type NeedsDcloneNode = Arc<Node<u32, u32, NeedsDcloneV>>;
 
-#[allow(clippy::reversed_empty_ranges)]
+#[allow(clippy::reversed_empty_ranges)] // Deliberate
 #[test]
 fn ranges_overlap_test() {
     // x is empty

--- a/bfffs-core/src/util.rs
+++ b/bfffs-core/src/util.rs
@@ -229,7 +229,7 @@ fn test_zero_sglist() {
     assert_eq!(sg1.len(), 2);
 }
 
-#[allow(clippy::reversed_empty_ranges)]
+#[allow(clippy::reversed_empty_ranges)] // Deliberate
 #[test]
 fn range_bounds_is_empty() {
     use std::ops::RangeFull;

--- a/bfffs-core/src/vdev_block.rs
+++ b/bfffs-core/src/vdev_block.rs
@@ -1692,7 +1692,6 @@ mod t {
         }
 
         #[test]
-        #[allow(clippy::eq_op)]
         fn partial_eq() {
             let (tx0, _rx) = oneshot::channel();
             let (tx1, _rx) = oneshot::channel();
@@ -2658,7 +2657,6 @@ mod t {
 
             /// Just like VdevBlock::writev_at, VdevBlock::write_spacemap will
             /// ensure that all iovecs are a multiple of blocksize in size.
-            #[allow(clippy::async_yields_async)]
             #[rstest]
             #[tokio::test]
             async fn pad_small_tail(leaf: MockVdevFile) {
@@ -2820,7 +2818,6 @@ mod t {
 
             /// VdevBlock::writev_at will zero-pad an operation's tail, if need
             /// be, up to a multiple of an LBA.
-            #[allow(clippy::async_yields_async)]
             #[rstest]
             #[tokio::test]
             async fn pad_small_tail(leaf: MockVdevFile) {

--- a/bfffs-core/src/vdev_file.rs
+++ b/bfffs-core/src/vdev_file.rs
@@ -394,7 +394,6 @@ impl<'fd> VdevFile<'fd> {
     ///
     /// * `sglist   Scatter-gather list of buffers to receive data
     /// * `lba`     LBA to read from
-    #[allow(clippy::transmute_ptr_to_ptr)]  // Clippy false positive
     pub fn readv_at(&'fd self, mut sglist: SGListMut, lba: LbaT)
         -> VdevFileFut<'fd>
     {

--- a/bfffs-core/tests/functional/fs.rs
+++ b/bfffs-core/tests/functional/fs.rs
@@ -1,8 +1,4 @@
 // vim: tw=80
-// Some conversions are only necessary for one of FreeBSD 11 or 12.  After libc
-// makes the switchover, delete this line and clean them up.
-#![allow(clippy::useless_conversion)]
-
 // Constructs a real filesystem and tests the common FS routines, without
 // mounting
 mod fs {

--- a/bfffs-core/tests/functional/vdev_file.rs
+++ b/bfffs-core/tests/functional/vdev_file.rs
@@ -1,5 +1,4 @@
 // vim: tw=80
-#![allow(clippy::redundant_clone)]   // False positive
 
 mod basic {
     use bfffs_core::{

--- a/bfffs/src/bin/bfffs/main.rs
+++ b/bfffs/src/bin/bfffs/main.rs
@@ -660,7 +660,6 @@ mod pool {
 
     use lalrpop_util::lalrpop_mod;
     lalrpop_mod!(
-        #[allow(dead_code)]
         pub pool_create_parser
     );
     use pool_create_parser::PoolParser;

--- a/bfffs/src/bin/bfffsd/fs.rs
+++ b/bfffs/src/bin/bfffsd/fs.rs
@@ -229,7 +229,6 @@ impl FuseFs {
         (ns, name)
     }
 
-    #[allow(clippy::if_same_then_else)]
     fn uncache_name(&self, parent_ino: u64, name: &OsStr) {
         let name_key = (parent_ino, name.to_owned());
         // TODO: handle multiply linked files

--- a/bfffs/src/bin/bfffsd/fs/tests.rs
+++ b/bfffs/src/bin/bfffsd/fs/tests.rs
@@ -2445,7 +2445,6 @@ mod readdir {
     /// rust-fuse
     // libc's ino type could be either u32 or u64, depending on which
     // version of freebsd we're targeting.
-    #[allow(clippy::useless_conversion)]
     #[test]
     fn all_file_types() {
         let fh = 0xdeadbeef;
@@ -2632,7 +2631,6 @@ mod readdir {
     /// A directory containing nothing but "." and ".."
     // libc's ino type could be either u32 or u64, depending on which
     // version of freebsd we're targeting.
-    #[allow(clippy::useless_conversion)]
     #[test]
     fn empty() {
         let fh = 0xdeadbeef;
@@ -2704,7 +2702,6 @@ mod readdir {
     /// and drop the stream.  Nothing bad should happen.
     // libc's ino type could be either u32 or u64, depending on which
     // version of freebsd we're targeting.
-    #[allow(clippy::useless_conversion)]
     #[test]
     fn out_of_space() {
         let fh = 0xdeadbeef;


### PR DESCRIPTION
Some of these were Clippy bugs that have been fixed.  Some were just stylistic lints that have been demoted, and some no long apply due to code refactors.