### PR TITLE
Suppress a clippy::literal_string_with_formatting_args warning

### DIFF
--- a/bfffs/src/bin/bfffs/main.rs
+++ b/bfffs/src/bin/bfffs/main.rs
@@ -350,6 +350,7 @@ mod fs {
                 }
                 buf.flush().unwrap();
             } else {
+                #[allow(clippy::literal_string_with_formatting_args)]
                 let row_spec = vec!["{:<}"; self.fields.len()].join(" ");
                 let mut table = tabular::Table::new(&row_spec);
                 let mut hrow = tabular::Row::new();
@@ -473,6 +474,7 @@ mod fs {
                 }
                 buf.flush().unwrap();
             } else {
+                #[allow(clippy::literal_string_with_formatting_args)]
                 let row_spec = vec!["{:<}"; self.properties.len()];
                 let mut table = tabular::Table::new(&row_spec.join(" "));
                 let mut hrow = tabular::Row::new();


### PR DESCRIPTION
The tabular crate takes arguments that look like println! formatting strings, but technically aren't.