### PR TITLE
Clippy cleanup

### DIFF
--- a/bfffs-core/src/lib.rs
+++ b/bfffs-core/src/lib.rs
@@ -2,6 +2,9 @@
 
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
 
+// This lint wrongly triggers for argument lists.
+#![allow(clippy::doc_overindented_list_items)]
+
 // I don't find this lint very helpful
 #![allow(clippy::type_complexity)]
 

--- a/bfffs-core/src/mirror.rs
+++ b/bfffs-core/src/mirror.rs
@@ -658,7 +658,7 @@ pub struct ReadAt {
 impl Future for ReadAt {
     type Output = Result<()>;
 
-    fn poll<'a>(mut self: Pin<&mut Self>, cx: &mut Context<'a>) -> Poll<Self::Output>
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output>
     {
         let mut pinned = self.as_mut().project();
         if pinned.fut.is_none() {
@@ -697,7 +697,7 @@ pub struct ReadSpacemap {
 impl Future for ReadSpacemap {
     type Output = Result<()>;
 
-    fn poll<'a>(mut self: Pin<&mut Self>, cx: &mut Context<'a>) -> Poll<Self::Output>
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output>
     {
         let mut pinned = self.as_mut().project();
         if pinned.fut.is_none() {
@@ -736,7 +736,7 @@ pub struct ReadvAt {
 impl Future for ReadvAt {
     type Output = Result<()>;
 
-    fn poll<'a>(mut self: Pin<&mut Self>, cx: &mut Context<'a>) -> Poll<Self::Output>
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output>
     {
         let mut pinned = self.as_mut().project();
         if pinned.fut.is_none() {

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -211,7 +211,7 @@ enum ChildReadFut {
 impl Future for ChildReadFut {
     type Output = Result<()>;
 
-    fn poll<'a>(self: Pin<&mut Self>, cx: &mut Context<'a>) -> Poll<Self::Output>
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output>
     {
         match self.project() {
             ChildReadFutProj::ReadAt(f) => f.poll(cx),
@@ -231,7 +231,7 @@ enum ChildWriteFut {
 impl Future for ChildWriteFut {
     type Output = Result<()>;
 
-    fn poll<'a>(self: Pin<&mut Self>, cx: &mut Context<'a>) -> Poll<Self::Output>
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output>
     {
         match self.project() {
             ChildWriteFutProj::WriteAt(f) => f.poll(cx),
@@ -417,7 +417,7 @@ pub struct ReadSpacemap {
 impl Future for ReadSpacemap {
     type Output = Result<()>;
 
-    fn poll<'a>(mut self: Pin<&mut Self>, cx: &mut Context<'a>) -> Poll<Self::Output>
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output>
     {
         let mut pinned = self.as_mut().project();
         if pinned.fut.is_none() {

--- a/bfffs/Cargo.toml
+++ b/bfffs/Cargo.toml
@@ -12,6 +12,9 @@ fuse = ["fuse3"]
 name = "bfffsd"
 required-features = ["fuse"]
 
+[lints.clippy]
+doc_overindented_list_items = "allow"
+
 [dependencies]
 bincode.workspace = true
 bfffs-core = { path = "../bfffs-core" }

--- a/isa-l/src/lib.rs
+++ b/isa-l/src/lib.rs
@@ -1,4 +1,5 @@
 // vim: tw=80
+#![allow(clippy::doc_overindented_list_items)]
 mod ffi;
 
 use std::{


### PR DESCRIPTION
* Fix needless_lifetime warnings
* Suppress doc_overindented_list_items, which frequently fires for argument lists.  Wrongly, IMHO.