### PR TITLE
Suppress the unstable_name_collisions lint

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ task:
         CARGO_ARGS: --all-features
       compute_engine_instance:
         image_project: freebsd-org-cloud-dev
-        image: freebsd-14-1-release-amd64-ufs
+        image: freebsd-14-2-release-amd64-ufs
         platform: freebsd
         cpu: 4
         disk: 40
@@ -30,7 +30,7 @@ task:
         VERSION: 1.80.0
       compute_engine_instance:
         image_project: freebsd-org-cloud-dev
-        image: freebsd-13-3-release-amd64
+        image: freebsd-13-5-release-amd64
         platform: freebsd
         cpu: 4
         disk: 40
@@ -76,7 +76,7 @@ lint_task:
     VERSION: nightly
     CARGO_ARGS: --all-features
   freebsd_instance:
-    image: freebsd-13-3-release-amd64
+    image: freebsd-13-5-release-amd64
   << : *SETUP
   cargo_cache:
     folder: $HOME/.cargo/registry

--- a/bfffs-core/src/lib.rs
+++ b/bfffs-core/src/lib.rs
@@ -16,6 +16,13 @@
 // of e.g. "Idml" as opposed to "IDML".
 #![allow(clippy::upper_case_acronyms)]
 
+// There isn't yet a good way to handle this warning except by suppressing it.
+// Maybe one of these two RFCs will help.  Until then, ignore then warning, and
+// deal with the breakage (on nightly) when it happens.
+// https://github.com/rust-lang/rfcs/pull/3240
+// https://github.com/rust-lang/rfcs/pull/3624
+#![allow(unstable_name_collisions)]
+
 // error: reached the type-length limit while instantiating std::pin::Pin...
 #![type_length_limit="3790758"]
 // error: trait bounds overflowed in Database::sync_transaction_priv


### PR DESCRIPTION
There isn't yet a good way to deal with this lint other than by simply suppressing it.
