### PR TITLE
Fix the tests with cargo's new -Zbuild-dir feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,13 +104,14 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.11"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d6b683edf8d1119fe420a94f8a7e389239666aa72e65495d91c00462510151"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
 dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
+ "libc",
  "predicates",
  "predicates-core",
  "predicates-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bincode = "1.3.3"
 cfg-if = "1.0"
 divbuf = { version = "0.4.0", features = ["experimental"] }
 enum_dispatch = "0.3.12"
-assert_cmd = "2.0"
+assert_cmd = "2.0.17"
 atomic_enum = "0.3.0"
 auto_enums = "0.8.5"
 bitfield = "0.13.1"
@@ -53,7 +53,7 @@ num_cpus = "1.8"
 num_enum = "0.7.0"
 permutohedron = "0.2"
 pin-project = "1.1.0"
-predicates = "3.0.0"
+predicates = "3.0.1"
 pretty_assertions = "1.3"
 prettydiff = { version = "0.7.0", default-features = false }
 prettytable-rs = { version = "0.10.0", default-features = false }

--- a/bfffs/tests/integration/bfffs/fs/create.rs
+++ b/bfffs/tests/integration/bfffs/fs/create.rs
@@ -37,7 +37,7 @@ fn harness() -> Harness {
         .success();
 
     let sockpath = tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg("mypool")

--- a/bfffs/tests/integration/bfffs/fs/destroy.rs
+++ b/bfffs/tests/integration/bfffs/fs/destroy.rs
@@ -42,7 +42,7 @@ fn harness() -> Harness {
         .success();
 
     let sockpath = tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg("mypool")

--- a/bfffs/tests/integration/bfffs/fs/get.rs
+++ b/bfffs/tests/integration/bfffs/fs/get.rs
@@ -36,7 +36,7 @@ fn harness<S: AsRef<str>>(dsnames: &[S]) -> Harness {
         .success();
 
     let sockpath = tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg("mypool")

--- a/bfffs/tests/integration/bfffs/fs/list.rs
+++ b/bfffs/tests/integration/bfffs/fs/list.rs
@@ -36,7 +36,7 @@ fn harness<S: AsRef<str>>(dsnames: &[S]) -> Harness {
         .success();
 
     let sockpath = tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg("mypool")

--- a/bfffs/tests/integration/bfffs/fs/mount.rs
+++ b/bfffs/tests/integration/bfffs/fs/mount.rs
@@ -50,7 +50,7 @@ fn harness() -> Harness {
         .success();
 
     let sockpath = tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg("mypool")

--- a/bfffs/tests/integration/bfffs/fs/set.rs
+++ b/bfffs/tests/integration/bfffs/fs/set.rs
@@ -36,7 +36,7 @@ fn harness() -> Harness {
         .success();
 
     let sockpath = tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg("mypool")

--- a/bfffs/tests/integration/bfffs/fs/unmount.rs
+++ b/bfffs/tests/integration/bfffs/fs/unmount.rs
@@ -47,7 +47,7 @@ fn harness() -> Harness {
         .success();
 
     let sockpath = tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg("mypool")

--- a/bfffs/tests/integration/bfffs/pool/clean.rs
+++ b/bfffs/tests/integration/bfffs/pool/clean.rs
@@ -37,7 +37,7 @@ fn harness() -> Harness {
         .success();
 
     let sockpath = tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg("mypool")

--- a/bfffs/tests/integration/bfffs/pool/fault.rs
+++ b/bfffs/tests/integration/bfffs/pool/fault.rs
@@ -50,7 +50,7 @@ struct Daemon {
 /// Start bfffsd and import the pool
 fn start_bfffsd(files: &Files) -> Daemon {
     let sockpath = files.tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg(POOLNAME)

--- a/bfffs/tests/integration/bfffs/pool/list.rs
+++ b/bfffs/tests/integration/bfffs/pool/list.rs
@@ -36,7 +36,7 @@ fn harness() -> Harness {
         .success();
 
     let sockpath = tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg("mypool")

--- a/bfffs/tests/integration/bfffs/pool/status.rs
+++ b/bfffs/tests/integration/bfffs/pool/status.rs
@@ -47,7 +47,7 @@ struct Daemon {
 /// Start bfffsd and import the pool
 fn start_bfffsd(files: &Files) -> Daemon {
     let sockpath = files.tempdir.path().join("bfffsd.sock");
-    let bfffsd: Bfffsd = Command::new(cargo_bin("bfffsd"))
+    let bfffsd: Bfffsd = Command::new(cargo_bin!("bfffsd"))
         .arg("--sock")
         .arg(sockpath.as_os_str())
         .arg(POOLNAME)

--- a/bfffs/tests/integration/util.rs
+++ b/bfffs/tests/integration/util.rs
@@ -4,15 +4,15 @@ use std::{
     time::{Duration, Instant},
 };
 
-use assert_cmd::prelude::*;
+use assert_cmd::cargo::cargo_bin;
 use thiserror::Error;
 
 pub fn bfffs() -> Command {
-    Command::cargo_bin("bfffs").unwrap()
+    Command::new(cargo_bin!("bfffs"))
 }
 
 pub fn bfffsd() -> Command {
-    Command::cargo_bin("bfffsd").unwrap()
+    Command::new(cargo_bin!("bfffsd"))
 }
 
 /// A wrapper for the bfffsd process that kills on Drop


### PR DESCRIPTION
Need to update assert_cmd to be able to find the location to the binaries when using Cargo's new -Zbuild-dir feature, which can put final binaries in a different directory than test binaries.