### PR TITLE
Update several dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,16 +798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,7 +1541,6 @@ dependencies = [
  "itertools 0.13.0",
  "lalrpop-util",
  "petgraph",
- "pico-args",
  "regex",
  "regex-syntax 0.8.3",
  "sha3",
@@ -1585,9 +1574,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -1694,21 +1683,21 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "mio-aio"
-version = "0.9.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94970d564990c83f7431efebf40f81b4b0d36b4e362fae869081d952530937ff"
+checksum = "81d051eaf8f4c7a8e7e58ef664d9789b54e452b8d78b66d14e79a1c5325050e7"
 dependencies = [
  "mio",
  "nix",
@@ -1872,15 +1861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,12 +1946,6 @@ checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -2083,13 +2057,11 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
- "ctor",
  "diff",
- "output_vt100",
  "yansi",
 ]
 
@@ -2774,31 +2746,29 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-file"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991bf4c368ae648279b4355fbdd066966ca255cd45c5041144be9f0d27f30833"
+checksum = "823c7b35baad28e570d05f095916ce6a4db8984827fee8039e4a095a308ff411"
 dependencies = [
  "futures",
- "mio",
  "mio-aio",
  "nix",
  "tokio",
@@ -2806,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3364,6 +3334,6 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ criterion = "0.5"
 dashmap = "5.5"
 downcast = "0.11.0"
 enum-primitive-derive = "0.3.0"
-fixedbitset = "0.4.0"
+fixedbitset = { version = "0.4.0", default-features = false }
 freebsd-libgeom = "0.2.2"
 function_name = "0.3.0"
 fuse3 = { version = "0.8.1", default-features = false }
@@ -39,8 +39,8 @@ glob = "0.3.1"
 hexdump = "0.1.2"
 histogram = "0.6"
 itertools = "0.13.0"
-lalrpop = "0.22.0"
-lalrpop-util = "0.22.0"
+lalrpop = { version = "0.22.0", default-features = false, features = ["lexer"] }
+lalrpop-util = { version = "0.22.0",default-features = false }
 libc = "0.2.158"
 mdconfig = "0.2.0"
 metrohash = "1.0.2"
@@ -54,7 +54,7 @@ num_enum = "0.7.0"
 permutohedron = "0.2"
 pin-project = "1.1.0"
 predicates = "3.0.1"
-pretty_assertions = "1.3"
+pretty_assertions = "1.4"
 prettydiff = { version = "0.7.0", default-features = false }
 prettytable-rs = { version = "0.10.0", default-features = false }
 rand = "0.8.5"
@@ -72,8 +72,8 @@ tempfile = "3.8"
 test-log = { version = "0.2.13", default-features = false }
 thiserror = "1.0.32"
 time = { version = "0.3.0", default-features = false }
-tokio = { version = "1.36.0", default-features = false }
-tokio-file = "0.10.0"
+tokio = { version = "1.39.1", default-features = false }
+tokio-file = "0.11.0"
 tokio-seqpacket = "0.5.4"
 tracing = { version = "0.1.40", default-features = false, features = ["attributes"] }
 tracing-futures = "0.2.4"


### PR DESCRIPTION
Omit unneeded features from lalrpop.  This slims its build, and eliminates the need to build multiple copies of lalrpop_util.

Remove default features from fixedbitset.  That's what lalrpop does, via petgraph.  This eliminates the need to build multiple copies.

Update pretty_assertions to 1.4.  This removes transitive dependencies on ctor and output_vt100

Update tokio-file to 0.11.0. This doesn't provide any direct benefits for bfffs, but it's good to dogfood the latest mio-aio and tokio-file releases.  And it lets us use mio-1.0 instead of an earlier verison.