### PR TITLE
Clippy cleanup

### DIFF
--- a/bfffs-core/src/database/database.rs
+++ b/bfffs-core/src/database/database.rs
@@ -727,8 +727,8 @@ impl Database {
             let inner2 = inner.clone();
             inner.idml.advance_transaction(move |txg| async move {
                 let guard = inner2.fs_trees.read().await;
-                guard.iter()
-                    .map(move |(_, itree)| {
+                guard.values()
+                    .map(move |itree| {
                         itree.clone().flush(txg)
                     }).collect::<FuturesUnordered<_>>()
                     .try_collect::<Vec<_>>().await?;

--- a/bfffs-core/src/fs.rs
+++ b/bfffs-core/src/fs.rs
@@ -2310,7 +2310,7 @@ impl Fs {
             Property::RecordSize(exp) =>
                 self.record_size.store(exp, Ordering::Relaxed),
             Property::Name(_) => panic!("Immutable property"),
-            _ => panic!("Setting property {:?} is TODO", prop),
+            _ => panic!("Setting property {prop:?} is TODO"),
         }
 
         // Update on-disk properties

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -2030,7 +2030,7 @@ impl VdevRaidApi for VdevRaid {
                         return Ok(());
                     }
                     Err(Error::ENOENT) => continue,
-                    Err(e) => panic!("Unexpected error from Mirror::fault: {:?}", e),
+                    Err(e) => panic!("Unexpected error from Mirror::fault: {e:?}"),
                 }
             }
         }
@@ -2109,8 +2109,7 @@ impl VdevRaidApi for VdevRaid {
             // Look for a StripeBuffer that contains part of the requested
             // range.  There should only be a few zones open at any one time, so
             // it's ok to search through them all.
-            let stripe_buffer = sb_ref.iter()
-                .map(|(_, sb)| sb)
+            let stripe_buffer = sb_ref.values()
                 .find(|&stripe_buffer| {
                     !stripe_buffer.is_empty() &&
                     lba < stripe_buffer.next_lba() &&

--- a/bfffs-core/src/vdev.rs
+++ b/bfffs-core/src/vdev.rs
@@ -60,7 +60,7 @@ impl fmt::Display for Health {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Self::Online => "Online".fmt(f),
-            Self::Degraded(n) => write!(f, "Degraded({})", n),
+            Self::Degraded(n) => write!(f, "Degraded({n})"),
             Self::Rebuilding => "Rebuilding".fmt(f),
             Self::Faulted(FaultedReason::Removed) => "Faulted(removed)".fmt(f),
             Self::Faulted(FaultedReason::User) => "Faulted(administratively)".fmt(f),

--- a/bfffs-core/src/vdev_file.rs
+++ b/bfffs-core/src/vdev_file.rs
@@ -186,6 +186,7 @@ impl<'fd> VdevFile<'fd> {
 
     fn candelete(fd: RawFd) -> io::Result<bool> {
         let mut arg = MaybeUninit::<diocgattr_arg>::uninit();
+        #[allow(dangerous_implicit_autorefs)]
         let r = unsafe {
             let p = arg.as_mut_ptr();
             (*p).name[0..16].copy_from_slice(b"GEOM::candelete\0");

--- a/bfffs-core/tests/functional/util.rs
+++ b/bfffs-core/tests/functional/util.rs
@@ -89,7 +89,7 @@ impl Gnop {
     pub fn error_prob(&self, prob: i32) {
         let r = Command::new("gnop")
             .args(["configure", "-r"])
-            .arg(format!("{}", prob))
+            .arg(format!("{prob}"))
             .arg(self.as_path())
             .status()
             .expect("Failed to execute command")

--- a/bfffs-fio/src/lib.rs
+++ b/bfffs-fio/src/lib.rs
@@ -213,6 +213,7 @@ pub extern "C" fn fio_bfffs_commit(_td: *mut thread_data) -> libc::c_int {
 ///
 /// Caller must ensure validity of the pointer arguments
 #[no_mangle]
+#[allow(dangerous_implicit_autorefs)]
 pub unsafe extern "C" fn fio_bfffs_event(
     td: *mut thread_data,
     event: libc::c_int,

--- a/bfffs/src/bin/bfffs/main.rs
+++ b/bfffs/src/bin/bfffs/main.rs
@@ -111,7 +111,7 @@ impl Dump {
     async fn dump_fsm(self) {
         let db = self.load_db().await;
         for s in db.dump_fsm().await.into_iter() {
-            println!("{}", s)
+            println!("{s}")
         }
     }
 
@@ -662,6 +662,8 @@ mod pool {
 
     use lalrpop_util::lalrpop_mod;
     lalrpop_mod!(
+        // See https://github.com/lalrpop/lalrpop/issues/1060
+        #[allow(clippy::uninlined_format_args)]
         pub pool_create_parser
     );
     use pool_create_parser::PoolParser;
@@ -1022,7 +1024,7 @@ async fn main() {
         }
     };
     if let Err(e) = r {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
* dangerous_implicit_autorefs: This lint is not helpful, IMHO, and the suggested remediation is just more confusing.

* clippy::iter_kv_map: very helpful.  I think it actually improved the code's efficiency.

* uninlined_Format_args: tricky, because some of the warnings came from code generated by lalrpop.