### PR TITLE
Fix deprecation warnings with the latest Rust and assert_cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,13 +104,12 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.17"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
 dependencies = [
  "anstyle",
  "bstr",
- "doc-comment",
  "libc",
  "predicates",
  "predicates-core",
@@ -877,12 +876,6 @@ name = "divbuf"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0809dcae8c7e9f3a1d7a70ea495427e09a2d494088b4276cb118b51d513c6af1"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downcast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bincode = "1.3.3"
 cfg-if = "1.0"
 divbuf = { version = "0.4.0", features = ["experimental"] }
 enum_dispatch = "0.3.12"
-assert_cmd = "2.0.17"
+assert_cmd = "2.1.0"
 atomic_enum = "0.3.0"
 auto_enums = "0.8.5"
 bitfield = "0.13.1"

--- a/bfffs/benches/bfffs-bench/mod.rs
+++ b/bfffs/benches/bfffs-bench/mod.rs
@@ -10,6 +10,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[macro_use]
+extern crate assert_cmd;
+
 use assert_cmd::prelude::*;
 use clap::{crate_version, Parser};
 use freebsd_libgeom as geom;

--- a/bfffs/tests/integration/bfffs/fs/create.rs
+++ b/bfffs/tests/integration/bfffs/fs/create.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use rstest::{fixture, rstest};
 use tempfile::{Builder, TempDir};
 

--- a/bfffs/tests/integration/bfffs/fs/destroy.rs
+++ b/bfffs/tests/integration/bfffs/fs/destroy.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use function_name::named;
 use rstest::{fixture, rstest};
 use tempfile::{Builder, TempDir};

--- a/bfffs/tests/integration/bfffs/fs/get.rs
+++ b/bfffs/tests/integration/bfffs/fs/get.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use rstest::rstest;
 use tempfile::{Builder, TempDir};
 

--- a/bfffs/tests/integration/bfffs/fs/list.rs
+++ b/bfffs/tests/integration/bfffs/fs/list.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use rstest::rstest;
 use tempfile::{Builder, TempDir};
 

--- a/bfffs/tests/integration/bfffs/fs/mount.rs
+++ b/bfffs/tests/integration/bfffs/fs/mount.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use function_name::named;
 use nix::mount::{unmount, MntFlags};
 use rstest::{fixture, rstest};

--- a/bfffs/tests/integration/bfffs/fs/set.rs
+++ b/bfffs/tests/integration/bfffs/fs/set.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use rstest::rstest;
 use tempfile::{Builder, TempDir};
 

--- a/bfffs/tests/integration/bfffs/fs/unmount.rs
+++ b/bfffs/tests/integration/bfffs/fs/unmount.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use function_name::named;
 use nix::{
     mount::{unmount, MntFlags},

--- a/bfffs/tests/integration/bfffs/pool/clean.rs
+++ b/bfffs/tests/integration/bfffs/pool/clean.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use rstest::{fixture, rstest};
 use tempfile::{Builder, TempDir};
 

--- a/bfffs/tests/integration/bfffs/pool/fault.rs
+++ b/bfffs/tests/integration/bfffs/pool/fault.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use ::bfffs::Bfffs;
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use tempfile::{Builder, TempDir};
 
 use super::super::super::*;

--- a/bfffs/tests/integration/bfffs/pool/list.rs
+++ b/bfffs/tests/integration/bfffs/pool/list.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use rstest::rstest;
 use tempfile::{Builder, TempDir};
 

--- a/bfffs/tests/integration/bfffs/pool/status.rs
+++ b/bfffs/tests/integration/bfffs/pool/status.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use ::bfffs::Bfffs;
-use assert_cmd::{cargo::cargo_bin, prelude::*};
+use assert_cmd::prelude::*;
 use regex::Regex;
 use tempfile::{Builder, TempDir};
 

--- a/bfffs/tests/integration/mod.rs
+++ b/bfffs/tests/integration/mod.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate assert_cmd;
+
 mod bfffs;
 mod bfffsd;
 mod util;

--- a/bfffs/tests/integration/util.rs
+++ b/bfffs/tests/integration/util.rs
@@ -4,7 +4,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use assert_cmd::cargo::cargo_bin;
 use thiserror::Error;
 
 pub fn bfffs() -> Command {


### PR DESCRIPTION
assert_cmd exports both a macro and a function with the same name from the same path.  It's impossible to `use` one without the other.  So Rust will warn about importing the deprecated one.  Work around this by using the dated `#[macro_use]` syntax instead.