### PR TITLE
Forestall seqpacket bugs on FreeBSD 15+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-seqpacket"
-version = "0.5.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e9d9516b9eb997f1fbdfa77c98be9a3e52ba36c84d48db5d81745042770bbf"
+checksum = "ab144b76e4ffb1d1a4e8b404073c922a243baebcc580cd75f415ae3ae9e42add"
 dependencies = [
  "filedesc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ thiserror = "1.0.32"
 time = { version = "0.3.0", default-features = false }
 tokio = { version = "1.39.1", default-features = false }
 tokio-file = "0.11.0"
-tokio-seqpacket = "0.5.4"
+tokio-seqpacket = "0.8.1"
 tracing = { version = "0.1.41", default-features = false, features = ["attributes"] }
 tracing-futures = "0.2.4"
 tracing-subscriber = { version = "0.3.20", default-features = false }


### PR DESCRIPTION
FreeBSD 15 reworked the Unix domain SOCK_SEQPACKET code.  The new code is more picky about MSG_EOR.  With older versions of tokio-seqpacket, that could lead to missing messages.  Upgrade tokio-seqpacket to forestall any such bugs.