### PR TITLE
Incremental mirror repair

### DIFF
--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -816,6 +816,13 @@ impl SpacemapOnDisk {
 #[derive(Debug)]
 #[cfg_attr(test, derive(Default))]
 pub struct RepairMirrorTask {
+    /// The last transaction synced to the vdev at the time the task was started
+    initial_txg: TxgT,
+
+    /// The minimum start transaction for any Open Zone in the system, as of the
+    /// time that `zones` was determined.
+    min_open_txg: Option<TxgT>,
+
     /// Index of the mirror child that we're repairing.
     mirror_idx: usize,
 
@@ -1059,13 +1066,20 @@ impl Cluster {
     {
         // next_txg needs to be low enough to encompass any zones that didn't
         // make it into zones, including those that might not yet be open.
-        let zs = self.repair_mirror_gather_zones(txgs, false);
+        let initial_txg = txgs.start;
+        let zs = self.order_zones_for_repair(txgs, false);
         let next_txg = if let Some(maxtxg) = zs.max_end_txg {
             maxtxg + 1
         } else {
             TxgT::from(0)
         };
-        RepairMirrorTask{ mirror_idx, zones: zs.zones, next_txg}
+        RepairMirrorTask{
+            initial_txg,
+            mirror_idx,
+            zones: zs.zones,
+            next_txg,
+            min_open_txg: zs.min_open_txg
+        }
     }
 
     /// Make an ordered list of every zone that might contain data in the
@@ -1076,7 +1090,7 @@ impl Cluster {
     /// - `txgs`              - Transaction range that needs to be repaired
     /// - `repair_open_zones` - Whether to include open zones in the list, or
     ///                         defer them for later.
-    fn repair_mirror_gather_zones(
+    fn order_zones_for_repair(
         &self,
         txgs: RangeFrom<TxgT>,
         repair_open_zones: bool) -> RepairMirrorZoneSpec
@@ -1094,13 +1108,19 @@ impl Cluster {
                 *zid
             )
         );
+
         let max_end_txg = zones.iter()
             .map(|zid| fsm.zones[*zid as usize].txgs.end)
             .max();
+
+        let min_open_txg = fsm.open_zone_ids()
+            .map(|zid| fsm.zones[*zid as usize].txgs.start)
+            .min();
+
         RepairMirrorZoneSpec {
             zones: zones.into(),
             max_end_txg,
-            min_open_txg: None  //TODO!
+            min_open_txg
         }
     }
 
@@ -1112,14 +1132,41 @@ impl Cluster {
         repair_open_zones: bool) -> Result<bool>
     {
         if let Some(zid) = task.zones.pop_front() {
-            let wp = {
+            let (wp, sync_txg) = {
                 let fsm = self.fsm.read().unwrap();
                 if fsm.is_dead(zid) || fsm.is_empty(zid) {
                     // This zone was alive when self was created.  It must've
                     // subsequently died.  Nothing to do here.
                     return Ok(true) ;
                 }
-                fsm.write_pointer(zid)
+                // Update the vdev's label if this is the last zone that starts
+                // with this txg.
+                let start_txg = fsm.zones[zid as usize].txgs.start;
+                let want_txg = if let Some(next_zid) = task.zones.front() {
+                    if start_txg < fsm.zones[*next_zid as usize].txgs.start {
+                        Some(fsm.zones[*next_zid as usize].txgs.start - 1)
+                    } else {
+                        None
+                    }
+                } else {
+                    Some(fsm.zones[zid as usize].txgs.end - 1)
+                };
+                // Limit the label update if there are any open zones that we
+                // haven't rebuilt yet.
+                let mut sync_txg = match (want_txg, task.min_open_txg) {
+                    (Some(x), Some(y)) if y > x => Some(x),
+                    (Some(_), Some(_)) => None,
+                    (Some(x), None) => Some(x),
+                    (None, _) => None
+                };
+                // Don't update the label if it wouldn't be higher than the txg
+                // already present on the label.
+                if let Some(stxg) = sync_txg {
+                    if task.initial_txg >= stxg {
+                        sync_txg = None;
+                    }
+                }
+                (fsm.write_pointer(zid), sync_txg)
             };
             if wp == Some(0) {
                 // It's unusual but not illegal for an open zone to have zero
@@ -1128,7 +1175,17 @@ impl Cluster {
                 let lbas = wp.and_then(NonZeroU64::new);
                 self.vdev.repair_mirror_zone(task.mirror_idx, zid, lbas).await?;
             }
-            // TODO: write a label, if we've finished resilvering a TXG
+            if let Some(sync_txg) = sync_txg {
+                // XXX this sync_all applies to the entire VdevRaid, not just
+                // the repairing device(s).  That's a performance bug.
+                self.vdev.sync_all().await?;
+                let lw = LabelWriter::new(0);
+                self.vdev.repair_label(lw, task.mirror_idx, sync_txg).await?;
+                self.vdev.sync_all().await?;
+                let lw = LabelWriter::new(1);
+                self.vdev.repair_label(lw, task.mirror_idx, sync_txg).await?;
+                self.vdev.sync_all().await?;
+            }
             Ok(true)
         } else {
             // We've finished repairing all zones that we knew needed to be
@@ -1136,13 +1193,14 @@ impl Cluster {
             // Generate a new list of zones, excluding all Zones that we've
             // already repaired.
             // Let the caller know whether there are more zones to repair
-            let zs = self.repair_mirror_gather_zones(task.next_txg..,
-                                                     repair_open_zones);
+            let zs = self.order_zones_for_repair(task.next_txg..,
+                                                 repair_open_zones);
             task.zones = zs.zones;
             if let Some(maxtxg) = zs.max_end_txg {
                 task.next_txg = maxtxg.checked_add(TxgT::from(1))
                     .expect("An open zone had an illegal end TXG");
             }
+            task.min_open_txg = zs.min_open_txg;
             Ok(!task.zones.is_empty())
         }
     }
@@ -2883,6 +2941,36 @@ mod repair_mirror {
     use rstest::rstest;
     use super::super::*;
 
+    fn expect_repair_both_labels(
+        vr: &mut MockVdevRaid,
+        seq: &mut Sequence,
+        m_idx: usize,
+        txg: TxgT)
+    {
+        vr.expect_sync_all()
+            .once()
+            .in_sequence(seq)
+            .return_once(|| Box::pin(future::ok(())));
+        vr.expect_repair_label()
+            .once()
+            .in_sequence(seq)
+            .with(always(), eq(m_idx), eq(txg))
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        vr.expect_sync_all()
+            .once()
+            .in_sequence(seq)
+            .return_once(|| Box::pin(future::ok(())));
+        vr.expect_repair_label()
+            .once()
+            .in_sequence(seq)
+            .with(always(), eq(m_idx), eq(txg))
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        vr.expect_sync_all()
+            .once()
+            .in_sequence(seq)
+            .return_once(|| Box::pin(future::ok(())));
+    }
+
     #[test]
     fn creation() {
         let mut vr = MockVdevRaid::default();
@@ -2977,6 +3065,10 @@ mod repair_mirror {
         vr.expect_zone_limits()
             .with(eq(2))
             .return_const((20, 30));
+        vr.expect_sync_all()
+            .returning(|| Box::pin(future::ok(())));
+        vr.expect_repair_label()
+            .returning(|_, _, _| Box::pin(future::ok(())));
         vr.expect_repair_mirror_zone()
             .with(eq(1), eq(0), eq(None))
             .return_once(|_, _, _| Box::pin(future::ok(())));
@@ -3110,10 +3202,7 @@ mod repair_mirror {
             .in_sequence(&mut seq)
             .return_once(|_, _, _| Box::pin(future::ok(())));
         // Then update its label, because no other zone has a lower one
-        vr.expect_repair_label()
-            .once()
-            .with(always(), eq(1), eq(TxgT::from(1)))
-            .return_once(|_, _, _| Box::pin(future::ok(())));
+        expect_repair_both_labels(&mut vr, &mut seq, 1, TxgT::from(1));
         // Then it should proceed to repair zone 1
         vr.expect_repair_mirror_zone()
             .once()
@@ -3131,13 +3220,13 @@ mod repair_mirror {
         let mut fsm = FreeSpaceMap::new(vr.zones());
         // Zone 0 will span TXG 1..3
         fsm.open_zone(0, 1, 1000, 100, TxgT::from(1)).unwrap();
-        fsm.finish_zone(0, TxgT::from(3));
+        fsm.finish_zone(0, TxgT::from(2));
         // Zone 1 will span TXG 2..4
         fsm.open_zone(1, 1000, 2000, 100, TxgT::from(2)).unwrap();
-        fsm.finish_zone(1, TxgT::from(4));
+        fsm.finish_zone(1, TxgT::from(3));
         // Zone 2 will span TXG 3..5
         fsm.open_zone(2, 1000, 2000, 100, TxgT::from(3)).unwrap();
-        fsm.finish_zone(2, TxgT::from(3));
+        fsm.finish_zone(2, TxgT::from(4));
         // Zone 3 will be open, and will span 2..
         fsm.open_zone(3, 1000, 2000, 100, TxgT::from(2)).unwrap();
 
@@ -3183,48 +3272,39 @@ mod repair_mirror {
             .return_once(|_, _, _| Box::pin(future::ok(())));
         // Then it should update the label to txg 2, the highest TXG not
         // included in any remaining Zone
-        vr.expect_repair_label()
-            .once()
-            .with(always(), eq(1), eq(TxgT::from(2)))
-            .return_once(|_, _, _| Box::pin(future::ok(())));
+        expect_repair_both_labels(&mut vr, &mut seq, 1, TxgT::from(2));
         // Then it should repair zone 2 and repair the label's TXG to 3
         vr.expect_repair_mirror_zone()
             .once()
-            .with(eq(2), eq(1), eq(None))
+            .with(eq(1), eq(2), eq(None))
             .in_sequence(&mut seq)
             .return_once(|_, _, _| Box::pin(future::ok(())));
-        vr.expect_repair_label()
-            .once()
-            .with(always(), eq(1), eq(TxgT::from(3)))
-            .return_once(|_, _, _| Box::pin(future::ok(())));
+        expect_repair_both_labels(&mut vr, &mut seq, 1, TxgT::from(3));
         // Then it should repair zone 3.
         vr.expect_repair_mirror_zone()
             .once()
-            .with(eq(3), eq(1), eq(None))
+            .with(eq(1), eq(3), eq(None))
             .in_sequence(&mut seq)
             .return_once(|_, _, _| Box::pin(future::ok(())));
         // Finally, it should update the label.  Since this is the last Zone,
         // open or closed, it should update the label to one less than this
         // Zone's end.  We can't set it to the end, because Zones' ends are
         // exclusive.
-        vr.expect_repair_label()
-            .once()
-            .with(always(), eq(1), eq(TxgT::from(5)))
-            .return_once(|_, _, _| Box::pin(future::ok(())));
+        expect_repair_both_labels(&mut vr, &mut seq, 1, TxgT::from(5));
 
         let mut fsm = FreeSpaceMap::new(vr.zones());
         // Zone 0 will span TXG 1..3
         fsm.open_zone(0, 1, 1000, 100, TxgT::from(1)).unwrap();
-        fsm.finish_zone(0, TxgT::from(3));
+        fsm.finish_zone(0, TxgT::from(2));
         // Zone 1 will span TXG 1..5
         fsm.open_zone(1, 1000, 2000, 100, TxgT::from(1)).unwrap();
-        fsm.finish_zone(1, TxgT::from(5));
+        fsm.finish_zone(1, TxgT::from(4));
         // Zone 2 will span TXG 3..5
         fsm.open_zone(2, 1000, 2000, 100, TxgT::from(3)).unwrap();
-        fsm.finish_zone(2, TxgT::from(5));
+        fsm.finish_zone(2, TxgT::from(4));
         // Zone 3 will span Txg 4..6
         fsm.open_zone(3, 2000, 3000, 150, TxgT::from(4)).unwrap();
-        fsm.finish_zone(3, TxgT::from(6));
+        fsm.finish_zone(3, TxgT::from(5));
 
         let cl = Cluster::new((fsm, vr.into()));
         let mut task = cl.repair_mirror(1, TxgT::from(0)..);
@@ -3261,18 +3341,15 @@ mod repair_mirror {
             .in_sequence(&mut seq)
             .return_once(|_, _, _| Box::pin(future::ok(())));
         // Finally it should repair the label to txg 4
-        vr.expect_repair_label()
-            .once()
-            .with(always(), eq(1), eq(TxgT::from(4)))
-            .return_once(|_, _, _| Box::pin(future::ok(())));
+        expect_repair_both_labels(&mut vr, &mut seq, 1, TxgT::from(4));
 
         let mut fsm = FreeSpaceMap::new(vr.zones());
-        // Zone 0 will span TXG 1..3
+        // Zone 0 will span TXG 1..4
         fsm.open_zone(0, 1, 1000, 100, TxgT::from(1)).unwrap();
         fsm.finish_zone(0, TxgT::from(3));
         // Zone 1 will span TXG 3..5
         fsm.open_zone(1, 1000, 2000, 100, TxgT::from(3)).unwrap();
-        fsm.finish_zone(1, TxgT::from(5));
+        fsm.finish_zone(1, TxgT::from(4));
 
         let cl = Cluster::new((fsm, vr.into()));
         let mut task = cl.repair_mirror(1, TxgT::from(3)..);

--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -1115,8 +1115,8 @@ impl Cluster {
             } else {
                 let lbas = wp.and_then(NonZeroU64::new);
                 self.vdev.repair_mirror_zone(task.mirror_idx, zid, lbas).await?;
-                // TODO: write a label, if we've finished resilvering a TXG
             }
+            // TODO: write a label, if we've finished resilvering a TXG
             Ok(true)
         } else {
             // We've finished repairing all zones that we knew needed to be
@@ -2866,7 +2866,7 @@ r#"FreeSpaceMap: 1 Zones: 0 Empty, 0 Open, 1 Closed, 0 Dead
 }
 
 mod repair_mirror {
-    use mockall::predicate::*;
+    use mockall::{predicate::*, Sequence};
     use nonzero_ext::nonzero;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
@@ -3072,6 +3072,201 @@ mod repair_mirror {
         assert_eq!(Ok(true), cl.repair_mirror_step(&mut task, true).await);
         assert_eq!(Ok(true), cl.repair_mirror_step(&mut task, true).await);
         assert_eq!(Ok(false), cl.repair_mirror_step(&mut task, true).await);
+    }
+
+    /// If there are open zones whose TXG range overlaps with the closed ones,
+    /// then don't repair the label
+    #[tokio::test]
+    async fn repair_label_with_open_zones() {
+        let mut seq = Sequence::new();
+        let mut vr = MockVdevRaid::default();
+        vr.expect_zones()
+            .return_const(4u32);
+        vr.expect_zone_limits()
+            .with(eq(0))
+            .return_const((1, 1000));
+        vr.expect_zone_limits()
+            .with(eq(1))
+            .return_const((1000, 2000));
+        vr.expect_zone_limits()
+            .with(eq(2))
+            .return_const((2000, 3000));
+
+        // First, Cluster should repair zone 0
+        vr.expect_repair_mirror_zone()
+            .once()
+            .with(eq(1), eq(0), eq(None))
+            .in_sequence(&mut seq)
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        // Then update its label, because no other zone has a lower one
+        vr.expect_repair_label()
+            .once()
+            .with(always(), eq(1), eq(TxgT::from(1)))
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        // Then it should proceed to repair zone 1
+        vr.expect_repair_mirror_zone()
+            .once()
+            .with(eq(1), eq(1), eq(None))
+            .in_sequence(&mut seq)
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        // But not update the label, because Zone 3 is open and starts at 2
+        // Finally, it should repair zone 2
+        vr.expect_repair_mirror_zone()
+            .once()
+            .with(eq(1), eq(2), eq(None))
+            .in_sequence(&mut seq)
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+
+        let mut fsm = FreeSpaceMap::new(vr.zones());
+        // Zone 0 will span TXG 1..3
+        fsm.open_zone(0, 1, 1000, 100, TxgT::from(1)).unwrap();
+        fsm.finish_zone(0, TxgT::from(3));
+        // Zone 1 will span TXG 2..4
+        fsm.open_zone(1, 1000, 2000, 100, TxgT::from(2)).unwrap();
+        fsm.finish_zone(1, TxgT::from(4));
+        // Zone 2 will span TXG 3..5
+        fsm.open_zone(2, 1000, 2000, 100, TxgT::from(3)).unwrap();
+        fsm.finish_zone(2, TxgT::from(3));
+        // Zone 3 will be open, and will span 2..
+        fsm.open_zone(3, 1000, 2000, 100, TxgT::from(2)).unwrap();
+
+        let cl = Cluster::new((fsm, vr.into()));
+        let mut task = cl.repair_mirror(1, TxgT::from(0)..);
+
+        while cl.repair_mirror_step(&mut task, false).await.unwrap() {}
+    }
+
+    /// Repair the mirror's label after repairing a zone, if the next zone has a
+    /// greater TXG, and open zones are not being skipped.
+    #[rstest]
+    #[case::incremental(false)]
+    #[case::finalize(true)]
+    #[tokio::test]
+    async fn repair_label_with_no_open_zones(#[case] finalize: bool) {
+        let mut seq = Sequence::new();
+        let mut vr = MockVdevRaid::default();
+        vr.expect_zones()
+            .return_const(4u32);
+        vr.expect_zone_limits()
+            .with(eq(0))
+            .return_const((1, 1000));
+        vr.expect_zone_limits()
+            .with(eq(1))
+            .return_const((1000, 2000));
+        vr.expect_zone_limits()
+            .with(eq(2))
+            .return_const((2000, 3000));
+
+        // First, Cluster should repair zone 0
+        vr.expect_repair_mirror_zone()
+            .once()
+            .with(eq(1), eq(0), eq(None))
+            .in_sequence(&mut seq)
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        // Then it should proceed to repair zone 1 without updating a label,
+        // because zones 0 and 1 share the same start txg
+        vr.expect_repair_mirror_zone()
+            .once()
+            .with(eq(1), eq(1), eq(None))
+            .in_sequence(&mut seq)
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        // Then it should update the label to txg 2, the highest TXG not
+        // included in any remaining Zone
+        vr.expect_repair_label()
+            .once()
+            .with(always(), eq(1), eq(TxgT::from(2)))
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        // Then it should repair zone 2 and repair the label's TXG to 3
+        vr.expect_repair_mirror_zone()
+            .once()
+            .with(eq(2), eq(1), eq(None))
+            .in_sequence(&mut seq)
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        vr.expect_repair_label()
+            .once()
+            .with(always(), eq(1), eq(TxgT::from(3)))
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        // Then it should repair zone 3.
+        vr.expect_repair_mirror_zone()
+            .once()
+            .with(eq(3), eq(1), eq(None))
+            .in_sequence(&mut seq)
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        // Finally, it should update the label.  Since this is the last Zone,
+        // open or closed, it should update the label to one less than this
+        // Zone's end.  We can't set it to the end, because Zones' ends are
+        // exclusive.
+        vr.expect_repair_label()
+            .once()
+            .with(always(), eq(1), eq(TxgT::from(5)))
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+
+        let mut fsm = FreeSpaceMap::new(vr.zones());
+        // Zone 0 will span TXG 1..3
+        fsm.open_zone(0, 1, 1000, 100, TxgT::from(1)).unwrap();
+        fsm.finish_zone(0, TxgT::from(3));
+        // Zone 1 will span TXG 1..5
+        fsm.open_zone(1, 1000, 2000, 100, TxgT::from(1)).unwrap();
+        fsm.finish_zone(1, TxgT::from(5));
+        // Zone 2 will span TXG 3..5
+        fsm.open_zone(2, 1000, 2000, 100, TxgT::from(3)).unwrap();
+        fsm.finish_zone(2, TxgT::from(5));
+        // Zone 3 will span Txg 4..6
+        fsm.open_zone(3, 2000, 3000, 150, TxgT::from(4)).unwrap();
+        fsm.finish_zone(3, TxgT::from(6));
+
+        let cl = Cluster::new((fsm, vr.into()));
+        let mut task = cl.repair_mirror(1, TxgT::from(0)..);
+
+        while cl.repair_mirror_step(&mut task, finalize).await.unwrap() {}
+    }
+
+    /// Do not repair the label to a lower value than it started at
+    #[tokio::test]
+    async fn repair_label_below_initial_txg() {
+        let mut seq = Sequence::new();
+        let mut vr = MockVdevRaid::default();
+        vr.expect_zones()
+            .return_const(2u32);
+        vr.expect_zone_limits()
+            .with(eq(0))
+            .return_const((1, 1000));
+        vr.expect_zone_limits()
+            .with(eq(1))
+            .return_const((1000, 2000));
+
+        // First, Cluster should repair zone 0 because Zone 0's end txg is
+        // greater than the TXG that the repair job started at
+        vr.expect_repair_mirror_zone()
+            .once()
+            .with(eq(1), eq(0), eq(None))
+            .in_sequence(&mut seq)
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        // Then it should proceed to repair zone 1 without updating a label,
+        // because the disk is already starting at txg 3.
+        vr.expect_repair_mirror_zone()
+            .once()
+            .with(eq(1), eq(1), eq(None))
+            .in_sequence(&mut seq)
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        // Finally it should repair the label to txg 4
+        vr.expect_repair_label()
+            .once()
+            .with(always(), eq(1), eq(TxgT::from(4)))
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+
+        let mut fsm = FreeSpaceMap::new(vr.zones());
+        // Zone 0 will span TXG 1..3
+        fsm.open_zone(0, 1, 1000, 100, TxgT::from(1)).unwrap();
+        fsm.finish_zone(0, TxgT::from(3));
+        // Zone 1 will span TXG 3..5
+        fsm.open_zone(1, 1000, 2000, 100, TxgT::from(3)).unwrap();
+        fsm.finish_zone(1, TxgT::from(5));
+
+        let cl = Cluster::new((fsm, vr.into()));
+        let mut task = cl.repair_mirror(1, TxgT::from(3)..);
+
+        while cl.repair_mirror_step(&mut task, true).await.unwrap() {}
     }
 }
 }

--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -1115,6 +1115,7 @@ impl Cluster {
             } else {
                 let lbas = wp.and_then(NonZeroU64::new);
                 self.vdev.repair_mirror_zone(task.mirror_idx, zid, lbas).await?;
+                // TODO: write a label, if we've finished resilvering a TXG
             }
             Ok(true)
         } else {

--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -834,6 +834,22 @@ pub struct RepairMirrorTask {
     zones: VecDeque<ZoneT>,
 } 
 
+/// The specification for what zones need to be repaired and in what order
+#[derive(Debug)]
+struct RepairMirrorZoneSpec {
+    /// Ordered list of zone IDs to repair
+    zones:          VecDeque<ZoneT>,
+
+    /// The maximum transaction seen among `zones`, if any
+    /// It is guaranteed that there will never be any Zones with a maximum txg
+    /// lower than this in the Cluster, unless they're already included in
+    /// `zones`.
+    max_end_txg:  Option<TxgT>,
+
+    /// The lowest start txg of any Open Zone in the Cluster.
+    min_open_txg:   Option<TxgT>
+}
+
 /// A `Cluster` is BFFFS's equivalent of ZFS's top-level Vdev.  It is the
 /// highest level `Vdev` that has its own LBA space.
 pub struct Cluster {
@@ -1041,37 +1057,29 @@ impl Cluster {
     pub fn repair_mirror(&self, mirror_idx: usize, txgs: RangeFrom<TxgT>)
         -> RepairMirrorTask
     {
-        //RepairMirrorTask::new(self, mirror_idx, txgs)
         // next_txg needs to be low enough to encompass any zones that didn't
         // make it into zones, including those that might not yet be open.
-        let (zones, maxtxg) = self.repair_mirror_gather_zones(txgs, false);
-        let next_txg = if let Some(maxtxg) = maxtxg {
+        let zs = self.repair_mirror_gather_zones(txgs, false);
+        let next_txg = if let Some(maxtxg) = zs.max_end_txg {
             maxtxg + 1
         } else {
             TxgT::from(0)
         };
-        RepairMirrorTask{ mirror_idx, zones, next_txg}
-
-        // XXX what happens if a closed Zone gets erased at this point, before
-        // we repair it?
-        // XXX What happens if an open zone gets more data written to it at this
-        // point, before we repair it?
-        // XXX What happens if an empty zone gets opened and written to at this
-        // point, before we repair it?
-        // NB: one solution to the above problems would be to store the txg
-        // currently rebuilding in the Cluster, and:
-        //   - avoid erasing any zones while they are rebuilding,
-        //   - Iterate through the FSM progressively, moving one txg at a time,
-        //     each time we finish rebuilding one zone.
+        RepairMirrorTask{ mirror_idx, zones: zs.zones, next_txg}
     }
 
     /// Make an ordered list of every zone that might contain data in the
     /// specified transaction range.  Return that list, and also the highest
     /// transaction seen among these zones.
+    ///
+    /// # Arguments
+    /// - `txgs`              - Transaction range that needs to be repaired
+    /// - `repair_open_zones` - Whether to include open zones in the list, or
+    ///                         defer them for later.
     fn repair_mirror_gather_zones(
         &self,
         txgs: RangeFrom<TxgT>,
-        repair_open_zones: bool) -> (VecDeque<ZoneT>, Option<TxgT>)
+        repair_open_zones: bool) -> RepairMirrorZoneSpec
     {
         let fsm = self.fsm.read().unwrap();
         let mut zones: Vec<ZoneT> = fsm.contains(txgs)
@@ -1086,10 +1094,14 @@ impl Cluster {
                 *zid
             )
         );
-        let maxtxg = zones.iter()
+        let max_end_txg = zones.iter()
             .map(|zid| fsm.zones[*zid as usize].txgs.end)
             .max();
-        (zones.into(), maxtxg)
+        RepairMirrorZoneSpec {
+            zones: zones.into(),
+            max_end_txg,
+            min_open_txg: None  //TODO!
+        }
     }
 
     /// Try to repair one Zone.  Return true if there might be more Zones to
@@ -1124,11 +1136,10 @@ impl Cluster {
             // Generate a new list of zones, excluding all Zones that we've
             // already repaired.
             // Let the caller know whether there are more zones to repair
-            let (new_zones, maxtxg) =
-                self.repair_mirror_gather_zones(task.next_txg..,
-                                                repair_open_zones);
-            task.zones = new_zones;
-            if let Some(maxtxg) = maxtxg {
+            let zs = self.repair_mirror_gather_zones(task.next_txg..,
+                                                     repair_open_zones);
+            task.zones = zs.zones;
+            if let Some(maxtxg) = zs.max_end_txg {
                 task.next_txg = maxtxg.checked_add(TxgT::from(1))
                     .expect("An open zone had an illegal end TXG");
             }

--- a/bfffs-core/src/ddml/ddml.rs
+++ b/bfffs-core/src/ddml/ddml.rs
@@ -24,6 +24,7 @@ use std::{
     sync::{Arc, Mutex, Weak}
 };
 use super::{DRP, Status};
+use tokio::task::JoinHandle;
 use tracing::instrument;
 use tracing_futures::Instrument;
 
@@ -124,7 +125,11 @@ impl MirrorRepairTask {
         Ok(())
     }
 
-    pub fn spawn(pool: &Arc<RwLock<Pool>>, txg: TxgT, cl_idx: usize, m_idx: usize)
+    pub fn spawn(
+        pool: &Arc<RwLock<Pool>>,
+        txg: TxgT,
+        cl_idx: usize,
+        m_idx: usize) -> JoinHandle<()>
     {
         // Outline:
         // * Start a mirror rebuild on the Pool.
@@ -149,7 +154,7 @@ impl MirrorRepairTask {
                     tracing::warn!("MirrorRebuildTask failed: {}", e);
                 }
             }
-        });
+        })
     }
 }
 
@@ -160,9 +165,14 @@ pub struct DDML {
     // futures_lock::Mutex, because we will never need to block while holding
     // this lock.
     cache: Arc<Mutex<Cache>>,
+
+    /// A handle to every active MirrorRepairTask
+    mirror_repair_tasks: Vec<JoinHandle<()>>,
+
     // We'll never use Arc::clone, and very rarely use Arc::downgrade, so the
     // performance impact of the Arc should be minimal.
     pool: Arc<RwLock<Pool>>,
+
     pool_name: String
 }
 
@@ -220,7 +230,12 @@ impl DDML {
 
     fn new(pool: Pool, cache: Arc<Mutex<Cache>>) -> Self {
         let pool_name = pool.name().to_owned();
-        DDML{pool: Arc::new(RwLock::new(pool)), cache, pool_name}
+        DDML{
+            pool: Arc::new(RwLock::new(pool)),
+            cache,
+            pool_name,
+            mirror_repair_tasks: Default::default()
+        }
     }
 
     /// Get directly from disk, bypassing cache
@@ -232,6 +247,12 @@ impl DDML {
         self.pool.read()
         .then(move |pg| Self::read(pg, drp))
         .map_ok(move |(_, dbs)| Box::new(T::deserialize(dbs)))
+    }
+
+    /// Are there any active (not paused) repair tasks?
+    pub fn is_repairing(&mut self) -> bool {
+        self.mirror_repair_tasks.retain(|jh| !jh.is_finished());
+        !self.mirror_repair_tasks.is_empty()
     }
 
     /// List all closed zones in the `DDML` in no particular order
@@ -324,7 +345,7 @@ impl DDML {
     /// * `pool`:       An already constructed `Pool`
     pub fn open(pool: Pool, cache: Arc<Mutex<Cache>>) -> Self {
         let pool_status = pool.status();
-        let ddml = DDML::new(pool, cache);
+        let mut ddml = DDML::new(pool, cache);
         ddml.repair_all(pool_status);
         ddml
     }
@@ -398,11 +419,12 @@ impl DDML {
     }
 
     /// Begin a repair task for any vdev that needs it
-    fn repair_all(&self, pool_status: pool::Status) {
+    fn repair_all(&mut self, pool_status: pool::Status) {
         for (cl_idx, cl) in pool_status.clusters.iter().enumerate() {
             for (m_idx, m) in cl.mirrors.iter().enumerate() {
                 if let Some(rtxg) = m.rebuilding {
-                    MirrorRepairTask::spawn(&self.pool, rtxg, cl_idx, m_idx)
+                    let jh = MirrorRepairTask::spawn(&self.pool, rtxg, cl_idx, m_idx);
+                    self.mirror_repair_tasks.push(jh);
                 }
             }
         }

--- a/bfffs-core/src/ddml/ddml.rs
+++ b/bfffs-core/src/ddml/ddml.rs
@@ -94,6 +94,9 @@ impl MirrorRepairTask {
                 // TODO: write the label on the repairing device, if this
                 // step finished a transaction, and if there aren't any Open
                 // Zones with a start Txg lower than this one.
+                // Such label won't have any idml or database label components,
+                // but that's ok, because we'll only ever need it to resume
+                // repair, not to import the whole pool.
                 if !more {
                     break;
                 }

--- a/bfffs-core/src/ddml/ddml.rs
+++ b/bfffs-core/src/ddml/ddml.rs
@@ -306,6 +306,7 @@ impl DDML {
                                     return Ok((pg, dbs));
                                 }
                             }
+                            tracing::warn!("Unrecoverable checksum failure for drp {:?}", drp);
                             Err(Error::EINTEGRITY)
                         },
                         Err(e) => Err(e)

--- a/bfffs-core/src/ddml/ddml.rs
+++ b/bfffs-core/src/ddml/ddml.rs
@@ -91,12 +91,6 @@ impl MirrorRepairTask {
             if let Some(pool) = self.wpool.upgrade() {
                 let more = pool.read().await
                     .repair_mirror_step(&mut self.pool_task, false).await?;
-                // TODO: write the label on the repairing device, if this
-                // step finished a transaction, and if there aren't any Open
-                // Zones with a start Txg lower than this one.
-                // Such label won't have any idml or database label components,
-                // but that's ok, because we'll only ever need it to resume
-                // repair, not to import the whole pool.
                 if !more {
                     break;
                 }

--- a/bfffs-core/src/mirror.rs
+++ b/bfffs-core/src/mirror.rs
@@ -693,6 +693,11 @@ impl Mirror {
         Err(Error::ENOENT)
     }
 
+    /// Write a repairing label to every repairing child
+    pub fn repair_label(&self, mut labeller: LabelWriter, txg: TxgT) {
+        todo!()
+    }
+
     /// Return any fully rebuilt disks to service
     ///
     /// It is the caller's responsibility to ensure that all data has been fully
@@ -966,6 +971,8 @@ mock! {
             -> Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send>>;
         pub fn read_spacemap(&self, buf: IoVecMut, idx: u32) -> BoxVdevFut;
         pub fn readv_at(&self, bufs: SGListMut, lba: LbaT) -> BoxVdevFut;
+        pub fn repair_label(&self, labeller: LabelWriter, txg: TxgT)
+            -> BoxVdevFut;
         pub fn repair_zone(&self, zone: ZoneT, lbas: Option<NonZeroU64>) -> BoxVdevFut;
         pub fn restore(&mut self);
         pub fn status(&self) -> Status;

--- a/bfffs-core/src/mirror.rs
+++ b/bfffs-core/src/mirror.rs
@@ -260,6 +260,7 @@ impl Child {
         self.as_present().map(|vb| vb.write_label(labeller, txg))
     }
 
+    /// Repair a label of any child in the Rebuilding state
     fn repair_label(&self, labeller: LabelWriter, txg: TxgT)
         -> Option<VdevBlockFut>
     {

--- a/bfffs-core/src/mirror.rs
+++ b/bfffs-core/src/mirror.rs
@@ -462,7 +462,7 @@ impl Mirror {
                     assert_eq!(u, label.uuid,
                                "Opening disk from wrong mirror");
                 }
-                if label_pair.is_none() {
+                if label_pair.is_none() && vdev_block.txg() == highest_txg {
                     label_pair = Some((label, label_reader));
                 }
                 (vdev_block.uuid(), vdev_block)
@@ -1277,11 +1277,20 @@ mod t {
         }
 
         /// If one VdevBlock is out-of-date, it will be opened into the
-        /// Rebuilding state.
-        #[test]
-        fn out_of_date() {
+        /// Rebuilding state.  And the returned LabelReader will come from the
+        /// up-to-date child.  Create a third missing child, whose UUID is
+        /// different on the two labels, just to ensure that Mirror::open
+        /// returns the LabelReader from the more up-to-date VdevBlock.
+        #[rstest]
+        #[case(0)]
+        #[case(1)]
+        fn out_of_date(#[case] rebuilding_child_idx: usize) {
+            let healthy_child_idx = 1 - rebuilding_child_idx;
+
             let child_uuid0 = Uuid::new_v4();
             let child_uuid1 = Uuid::new_v4();
+            let child_uuid2 = [Uuid::new_v4(), Uuid::new_v4()];
+            let mirror_uuid = Uuid::new_v4();
             fn mock(child_uuid: &Uuid) -> VdevBlock {
                 let mut bd = VdevBlock::default();
                 bd.expect_uuid()
@@ -1292,33 +1301,45 @@ mod t {
                     .return_const(262_144u64);
                 bd
             }
-            let label = Label {
-                uuid: Uuid::new_v4(),
-                children: vec![child_uuid0, child_uuid1]
+            let label0 = Label {
+                uuid: mirror_uuid,
+                children: vec![child_uuid0, child_uuid1, child_uuid2[0]]
             };
-            let mut serialized = Vec::new();
-            let mut lw = LabelWriter::new(0);
-            lw.serialize(&label).unwrap();
-            for buf in lw.into_sglist().into_iter() {
-                serialized.extend(&buf[..]);
+            let label1 = Label {
+                uuid: mirror_uuid,
+                children: vec![child_uuid0, child_uuid1, child_uuid2[1]]
+            };
+            let mut serialized0 = Vec::new();
+            let mut serialized1 = Vec::new();
+            let mut lw0 = LabelWriter::new(0);
+            lw0.serialize(&label0).unwrap();
+            for buf in lw0.into_sglist().into_iter() {
+                serialized0.extend(&buf[..]);
             }
-            let mut bd0 = mock(&child_uuid0);
-            bd0.expect_txg()
+            let mut lw1 = LabelWriter::new(0);
+            lw1.serialize(&label1).unwrap();
+            for buf in lw1.into_sglist().into_iter() {
+                serialized1.extend(&buf[..]);
+            }
+            let mut bd = vec![mock(&child_uuid0), mock(&child_uuid1)];
+            bd[healthy_child_idx].expect_txg()
                 .return_const(TxgT::from(42u32));
-            let mut bd1 = mock(&child_uuid1);
-            bd1.expect_txg()
+            bd[rebuilding_child_idx].expect_txg()
                 .return_const(TxgT::from(41u32));
 
             let mut combined = Vec::new();
-            for bd in [bd0, bd1] {
-                let lr = LabelReader::new(serialized.clone()).unwrap();
-                combined.push((bd, lr));
-            }
-            let (mirror, _) = Mirror::open(Some(label.uuid), combined);
-            assert!(mirror.children[0].is_present());
+            let lr0 = LabelReader::new(serialized0.clone()).unwrap();
+            let lr1 = LabelReader::new(serialized1.clone()).unwrap();
+            combined.push((bd.pop().unwrap(), lr1));
+            combined.push((bd.pop().unwrap(), lr0));
+            let (mirror, _) = Mirror::open(Some(mirror_uuid), combined);
+            assert!(mirror.children[healthy_child_idx].is_present());
             assert_eq!(mirror.children[0].uuid(), child_uuid0);
-            assert!(mirror.children[1].is_rebuilding());
+            assert!(mirror.children[rebuilding_child_idx].is_rebuilding());
             assert_eq!(mirror.children[1].uuid(), child_uuid1);
+
+            assert_eq!(mirror.children[2].uuid(),
+                       child_uuid2[healthy_child_idx]);
         }
     }
 

--- a/bfffs-core/src/mirror.rs
+++ b/bfffs-core/src/mirror.rs
@@ -260,6 +260,12 @@ impl Child {
         self.as_present().map(|vb| vb.write_label(labeller, txg))
     }
 
+    fn repair_label(&self, labeller: LabelWriter, txg: TxgT)
+        -> Option<VdevBlockFut>
+    {
+        self.as_rebuilding().map(|vb| vb.write_label(labeller, txg))
+    }
+
     fn write_spacemap(&self, sglist: SGList, idx: u32, block: LbaT)
         -> Option<VdevBlockFut>
     {
@@ -693,11 +699,6 @@ impl Mirror {
         Err(Error::ENOENT)
     }
 
-    /// Write a repairing label to every repairing child
-    pub fn repair_label(&self, mut labeller: LabelWriter, txg: TxgT) {
-        todo!()
-    }
-
     /// Return any fully rebuilt disks to service
     ///
     /// It is the caller's responsibility to ensure that all data has been fully
@@ -771,7 +772,8 @@ impl Mirror {
         Box::pin(fut)
     }
 
-    pub fn write_label(&self, mut labeller: LabelWriter, txg: TxgT)
+    pub fn write_label(&self, mut labeller: LabelWriter, txg: TxgT,
+                       repairing: bool)
         -> BoxVdevFut
     {
         let children_uuids = self.children.iter().map(Child::uuid)
@@ -782,7 +784,11 @@ impl Mirror {
         };
         labeller.serialize(&label).unwrap();
         let fut = self.children.iter().filter_map(|bd| {
-           bd.write_label(labeller.clone(), txg)
+            if repairing {
+                bd.repair_label(labeller.clone(), txg)
+            } else {
+                bd.write_label(labeller.clone(), txg)
+            }
         }).collect::<FuturesUnordered<_>>()
         .try_collect::<Vec<_>>()
         .map_ok(drop);
@@ -971,15 +977,14 @@ mock! {
             -> Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send>>;
         pub fn read_spacemap(&self, buf: IoVecMut, idx: u32) -> BoxVdevFut;
         pub fn readv_at(&self, bufs: SGListMut, lba: LbaT) -> BoxVdevFut;
-        pub fn repair_label(&self, labeller: LabelWriter, txg: TxgT)
-            -> BoxVdevFut;
         pub fn repair_zone(&self, zone: ZoneT, lbas: Option<NonZeroU64>) -> BoxVdevFut;
         pub fn restore(&mut self);
         pub fn status(&self) -> Status;
         pub fn sync_all(&self) -> BoxVdevFut;
         pub fn uuid(&self) -> Uuid;
         pub fn write_at(&self, buf: IoVec, lba: LbaT) -> BoxVdevFut;
-        pub fn write_label(&self, labeller: LabelWriter, txg: TxgT)
+        pub fn write_label(&self, labeller: LabelWriter, txg: TxgT,
+                           repairing: bool)
             -> BoxVdevFut;
         pub fn write_spacemap(&self, sglist: SGList, idx: u32, block: LbaT)
             ->  BoxVdevFut;
@@ -2540,7 +2545,7 @@ mod t {
             let bd1 = mock();
             let mirror = Mirror::new(Uuid::new_v4(), vec![bd0, bd1]);
             let labeller = LabelWriter::new(0);
-            mirror.write_label(labeller, TxgT::from(1))
+            mirror.write_label(labeller, TxgT::from(1), false)
                 .now_or_never()
                 .unwrap()
                 .unwrap();
@@ -2558,7 +2563,28 @@ mod t {
             ];
             let mirror = Mirror::new(Uuid::new_v4(), children);
             let labeller = LabelWriter::new(0);
-            mirror.write_label(labeller, TxgT::from(1))
+            mirror.write_label(labeller, TxgT::from(1), false)
+                .now_or_never()
+                .unwrap()
+                .unwrap();
+        }
+
+        #[test]
+        fn repairing() {
+            let mut bd0 = mock_vdev_block();
+            bd0.expect_write_label()
+                .once()
+                .return_once(|_, _| Box::pin(future::ok::<(), Error>(())));
+            let mut bd1 = mock_vdev_block();
+            bd1.expect_write_label()
+                .never();
+            let children = vec![
+                Child::rebuilding(bd0),
+                Child::present(bd1)
+            ];
+            let mirror = Mirror::new(Uuid::new_v4(), children);
+            let labeller = LabelWriter::new(0);
+            mirror.write_label(labeller, TxgT::from(1), true)
                 .now_or_never()
                 .unwrap()
                 .unwrap();

--- a/bfffs-core/src/raid/mod.rs
+++ b/bfffs-core/src/raid/mod.rs
@@ -242,6 +242,8 @@ mock!{
             -> Pin<Box<dyn Future<Output=Result<Box<dyn Iterator<Item=DivBufShared> + Send>>> + Send>>;
         fn read_spacemap(&self, buf: IoVecMut, idx: u32) -> BoxVdevFut;
         fn reopen_zone(&self, zone: ZoneT, allocated: LbaT) -> BoxVdevFut;
+        fn repair_label(&self, labeller: LabelWriter, mirror_idx: usize,
+                        txg: TxgT) -> BoxVdevFut;
         fn repair_mirror_zone(&self, mirror_idx: usize, zone: ZoneT,
                           lbas: Option<NonZeroU64>) -> BoxVdevFut;
         fn repair_raid_zone(&self, zone: ZoneT) -> BoxVdevFut;

--- a/bfffs-core/src/raid/null_raid.rs
+++ b/bfffs-core/src/raid/null_raid.rs
@@ -69,6 +69,18 @@ impl NullRaid {
         let mirror = mirrors.into_iter().next().unwrap().1;
         NullRaid{uuid: label.uuid, mirror}
     }
+
+    fn write_label_priv(&self, mut labeller: LabelWriter, txg: TxgT,
+        repairing: bool) -> BoxVdevFut
+    {
+        let nullraid_label = Label {
+            uuid: self.uuid,
+            child: self.mirror.uuid()
+        };
+        let label = super::Label::NullRaid(nullraid_label);
+        labeller.serialize(&label).unwrap();
+        Box::pin(self.mirror.write_label(labeller, txg, repairing))
+    }
 }
 
 impl Vdev for NullRaid {
@@ -143,10 +155,10 @@ impl VdevRaidApi for NullRaid {
         Box::pin(future::ok(()))
     }
 
-    fn repair_label(&self, labeller: LabelWriter, mirror_idx: usize, txg: TxgT)
-        -> BoxVdevFut
+    fn repair_label(&self, labeller: LabelWriter, _mirror_idx: usize,
+        txg: TxgT) -> BoxVdevFut
     {
-        todo!()
+        self.write_label_priv(labeller, txg, true)
     }
 
     fn repair_mirror_zone(&self, mirror_idx: usize, zone: ZoneT,
@@ -201,15 +213,9 @@ impl VdevRaidApi for NullRaid {
         }
     }
 
-    fn write_label(&self, mut labeller: LabelWriter, txg: TxgT) -> BoxVdevFut
+    fn write_label(&self, labeller: LabelWriter, txg: TxgT) -> BoxVdevFut
     {
-        let nullraid_label = Label {
-            uuid: self.uuid,
-            child: self.mirror.uuid()
-        };
-        let label = super::Label::NullRaid(nullraid_label);
-        labeller.serialize(&label).unwrap();
-        Box::pin(self.mirror.write_label(labeller, txg, false))
+        self.write_label_priv(labeller, txg, false)
     }
 
     fn write_spacemap(&self, sglist: SGList, idx: u32, block: LbaT)

--- a/bfffs-core/src/raid/null_raid.rs
+++ b/bfffs-core/src/raid/null_raid.rs
@@ -143,6 +143,12 @@ impl VdevRaidApi for NullRaid {
         Box::pin(future::ok(()))
     }
 
+    fn repair_label(&self, labeller: LabelWriter, mirror_idx: usize, txg: TxgT)
+        -> BoxVdevFut
+    {
+        todo!()
+    }
+
     fn repair_mirror_zone(&self, mirror_idx: usize, zone: ZoneT,
                           lbas: Option<NonZeroU64>) -> BoxVdevFut
     {

--- a/bfffs-core/src/raid/null_raid.rs
+++ b/bfffs-core/src/raid/null_raid.rs
@@ -209,7 +209,7 @@ impl VdevRaidApi for NullRaid {
         };
         let label = super::Label::NullRaid(nullraid_label);
         labeller.serialize(&label).unwrap();
-        Box::pin(self.mirror.write_label(labeller, txg))
+        Box::pin(self.mirror.write_label(labeller, txg, false))
     }
 
     fn write_spacemap(&self, sglist: SGList, idx: u32, block: LbaT)

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -323,6 +323,18 @@ impl Child {
         }
     }
 
+    /// Repair the label on an underlying mirror device.  This method has
+    /// nothing to do with RAID repair.
+    fn repair_label(&self, labeller: LabelWriter, txg: TxgT) -> impl Future<Output=Result<()>> + Send + Sync
+    {
+        match self {
+            Child::Present(m) => Either::Left(
+                m.write_label(labeller, txg, true)
+            ),
+            _ => Either::Right(future::err(Error::ENXIO))
+        }
+    }
+
     fn repair_zone(&self, zone: ZoneT, lbas: Option<NonZeroU64>) -> impl Future<Output=Result<()>> + Send + Sync
     {
         match self {
@@ -1665,6 +1677,21 @@ impl VdevRaid {
         Ok(())
     }
 
+    fn serialize_label(&self, labeller: &mut LabelWriter) {
+        let children_uuids = self.inner.children.iter().map(|bd| bd.uuid())
+            .collect::<Vec<_>>();
+        let raid_label = Label {
+            uuid: self.uuid,
+            chunksize: self.chunksize,
+            disks_per_stripe: self.inner.locator.stripesize(),
+            redundancy: self.inner.locator.protection(),
+            layout_algorithm: self.layout_algorithm,
+            children: children_uuids
+        };
+        let label = super::Label::Raid(raid_label);
+        labeller.serialize(&label).unwrap();
+    }
+
     /// Write two or more whole stripes
     #[allow(clippy::needless_range_loop)]   // Code looks better this way
     fn write_at_multi(&self, mut buf: IoVec, lba: LbaT) -> BoxVdevFut {
@@ -2234,10 +2261,11 @@ impl VdevRaidApi for VdevRaid {
         self.open_zone_priv(zone, allocated)
     }
 
-    fn repair_label(&self, labeller: LabelWriter, mirror_idx: usize, txg: TxgT)
-        -> BoxVdevFut
+    fn repair_label(&self, mut labeller: LabelWriter, mirror_idx: usize,
+        txg: TxgT) -> BoxVdevFut
     {
-        todo!()
+        self.serialize_label(&mut labeller);
+        Box::pin(self.inner.children[mirror_idx].repair_label(labeller, txg))
     }
 
     fn repair_mirror_zone(&self, mirror_idx: usize, zone: ZoneT,
@@ -2415,18 +2443,7 @@ impl VdevRaidApi for VdevRaid {
 
     fn write_label(&self, mut labeller: LabelWriter, txg: TxgT) -> BoxVdevFut
     {
-        let children_uuids = self.inner.children.iter().map(|bd| bd.uuid())
-            .collect::<Vec<_>>();
-        let raid_label = Label {
-            uuid: self.uuid,
-            chunksize: self.chunksize,
-            disks_per_stripe: self.inner.locator.stripesize(),
-            redundancy: self.inner.locator.protection(),
-            layout_algorithm: self.layout_algorithm,
-            children: children_uuids
-        };
-        let label = super::Label::Raid(raid_label);
-        labeller.serialize(&label).unwrap();
+        self.serialize_label(&mut labeller);
         let fut = self.inner.children.iter().map(|bd| {
            bd.write_label(labeller.clone(), txg)
         }).collect::<FuturesUnordered<_>>()

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -2234,6 +2234,12 @@ impl VdevRaidApi for VdevRaid {
         self.open_zone_priv(zone, allocated)
     }
 
+    fn repair_label(&self, labeller: LabelWriter, mirror_idx: usize, txg: TxgT)
+        -> BoxVdevFut
+    {
+        todo!()
+    }
+
     fn repair_mirror_zone(&self, mirror_idx: usize, zone: ZoneT,
                           lbas: Option<NonZeroU64>) -> BoxVdevFut
     {

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -369,7 +369,7 @@ impl Child {
     }
 
     fn write_label(&self, labeller: LabelWriter, txg: TxgT) -> BoxVdevFut {
-        self.as_present().unwrap().write_label(labeller, txg)
+        self.as_present().unwrap().write_label(labeller, txg, false)
     }
 
     fn write_spacemap(&self, sglist: SGList, idx: u32, block: LbaT)

--- a/bfffs-core/src/raid/vdev_raid/tests.rs
+++ b/bfffs-core/src/raid/vdev_raid/tests.rs
@@ -2854,4 +2854,76 @@ mod zones {
         }
     }
 }
+mod label {
+    use super::*;
+
+    #[tokio::test]
+    async fn repair_label() {
+        let k = 3;
+        let f = 1;
+        const CHUNKSIZE: LbaT = 2;
+
+        let mut m0 = mock_mirror();
+        m0.expect_uuid().return_const(Uuid::new_v4());
+        let mut m1 = mock_mirror();
+        m1.expect_uuid().return_const(Uuid::new_v4());
+        m1.expect_write_label()
+            .with(always(), eq(TxgT::from(42)), eq(true))
+            .once()
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        let mut m2 = mock_mirror();
+        m2.expect_uuid().return_const(Uuid::new_v4());
+        let mirrors = vec![
+            Child::present(m0),
+            Child::present(m1),
+            Child::present(m2),
+        ];
+
+        let vdev_raid = VdevRaid::new(CHUNKSIZE, k, f,
+                                      Uuid::new_v4(),
+                                      LayoutAlgorithm::PrimeS,
+                                      mirrors.into_boxed_slice());
+        let labeller = LabelWriter::new(0);
+        vdev_raid.repair_label(labeller, 1, TxgT::from(42)).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn write_label() {
+        let k = 3;
+        let f = 1;
+        const CHUNKSIZE: LbaT = 2;
+
+        let mut m0 = mock_mirror();
+        m0.expect_uuid().return_const(Uuid::new_v4());
+        m0.expect_write_label()
+            .with(always(), eq(TxgT::from(42)), eq(false))
+            .once()
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        let mut m1 = mock_mirror();
+        m1.expect_uuid().return_const(Uuid::new_v4());
+        m1.expect_write_label()
+            .with(always(), eq(TxgT::from(42)), eq(false))
+            .once()
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        let mut m2 = mock_mirror();
+        m2.expect_uuid().return_const(Uuid::new_v4());
+        m2.expect_write_label()
+            .with(always(), eq(TxgT::from(42)), eq(false))
+            .once()
+            .return_once(|_, _, _| Box::pin(future::ok(())));
+        let mirrors = vec![
+            Child::present(m0),
+            Child::present(m1),
+            Child::present(m2),
+        ];
+
+        let vdev_raid = VdevRaid::new(CHUNKSIZE, k, f,
+                                      Uuid::new_v4(),
+                                      LayoutAlgorithm::PrimeS,
+                                      mirrors.into_boxed_slice());
+        let labeller = LabelWriter::new(0);
+        vdev_raid.write_label(labeller, TxgT::from(42)).await.unwrap();
+    }
+}
+
 // LCOV_EXCL_STOP

--- a/bfffs-core/src/raid/vdev_raid_api.rs
+++ b/bfffs-core/src/raid/vdev_raid_api.rs
@@ -78,6 +78,18 @@ pub trait VdevRaidApi : Vdev + Send + Sync + 'static {
     ///                        in this zone.
     fn reopen_zone(&self, zone: ZoneT, allocated: LbaT) -> BoxVdevFut;
 
+    /// Repair the label on a repairing child.
+    ///
+    /// But don't write new labels to any healthy child.
+    ///
+    /// `label_writer` should already contain the serialized labels of every
+    /// vdev stacked on top of this one.
+    ///
+    /// # Arguments
+    /// - `mirror_idx`:         Index of the raid child to repair
+    fn repair_label(&self, labeller: LabelWriter, mirror_idx: usize, txg: TxgT)
+        -> BoxVdevFut;
+
     /// Repair any degraded children by their Zone, using mirroring.
     // NB: we could save a Box here , because VdevRaid::repair_mirror_zone and
     // NullRaid::repair_mirror_zone do the exact same thing.

--- a/bfffs-core/tests/functional/ddml.rs
+++ b/bfffs-core/tests/functional/ddml.rs
@@ -32,7 +32,7 @@ fn ddml() -> DDML {
 /// The DDML can reconstruct a faulted mirrored disk.
 #[rstest]
 #[test_log::test(tokio::test)]
-async fn mirror_reconstruction(
+async fn repair_mirror(
         #[values(
             // non-raid
             (1, 1, 0),

--- a/bfffs-core/tests/functional/ddml.rs
+++ b/bfffs-core/tests/functional/ddml.rs
@@ -9,6 +9,7 @@ use bfffs_core::{
     LbaT
 };
 use divbuf::{DivBuf, DivBufShared};
+use function_name::named;
 use futures::TryFutureExt;
 use pretty_assertions::assert_eq;
 use rstest::{fixture, rstest};
@@ -17,8 +18,10 @@ use std::{
     io::Read,
     os::unix::fs::FileExt,
     path::PathBuf,
-    sync::{Arc, Mutex}
+    sync::{Arc, Mutex},
+    time::Duration
 };
+use tokio::time::sleep;
 
 #[fixture]
 fn ddml() -> DDML {
@@ -93,7 +96,7 @@ async fn repair_mirror(
 
     // Wait for the mirror repair task to finish
     while ddml.status().await.clusters[0].mirrors[0].rebuilding.is_some() {
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        sleep(Duration::from_millis(10)).await;
     }
 
     // Verify by reading all data back
@@ -111,6 +114,106 @@ async fn repair_mirror(
         ddml.evict(drp);
         let db: Box<DivBuf> = ddml.get::<DivBufShared, DivBuf>(drp).await.unwrap();
         assert_eq!(&db[..], &vec![i as u8; BYTES_PER_LBA][..]);
+    }
+}
+
+/// Incremental repair: we can stop a repair halfway through and restart it
+/// without losing work.
+#[named]
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn repair_mirror_incremental() {
+    crate::require_root!();
+    let zone_size = 32;
+    let ph = crate::PoolBuilder::new()
+        .mirror_size(2)
+        .disks(2)
+        .gnop(true)
+        .zone_size(zone_size)
+        .fsize(1 << 20)     // 1 MB
+        .build();
+    let paths = ph.paths.clone();
+    let pool_uuid = ph.pool.uuid();
+    let cache = Arc::new(Mutex::new(Cache::with_capacity(1_000_000_000)));
+    let ddml = DDML::create(ph.pool, cache.clone());
+
+    // Write initial label to all disks
+    let mut txg = TxgT::from(1);
+    ddml.flush(0).await.unwrap();
+    ddml.write_label(LabelWriter::new(0), txg).await.unwrap();
+    ddml.flush(1).await.unwrap();
+    ddml.write_label(LabelWriter::new(1), txg).await.unwrap();
+    ddml.sync_all(txg).await.unwrap();
+
+    // Fault one disk
+    let stat = ddml.status().await;
+    let leaf_uuid = stat.clusters[0].mirrors[0].leaves[0].uuid;
+    ddml.fault(leaf_uuid).await.unwrap();
+
+    // Tell gnop to fail after we've definitely written a full zone, even if
+    // VdevBlock doesn't accumulate anything.
+    let write_fail_count = zone_size + 4;
+
+    // Write enough data that even if VdevBlock accumulates all writes in a
+    // single zone, we'll still comfortably exceed write_fail_count
+    let minimum_writes_per_zone = 3;
+    let zone_count = write_fail_count / minimum_writes_per_zone * 2;
+    for _ in 0..zone_count {
+        for i in 0..zone_size {
+            let dbs = DivBufShared::from(vec![i as u8; BYTES_PER_LBA]);
+            ddml.put(dbs, Compression::None, txg).await.unwrap();
+        }
+        txg += 1;
+        ddml.flush(0).await.unwrap();
+        ddml.write_label(LabelWriter::new(0), txg).await.unwrap();
+        ddml.flush(1).await.unwrap();
+        ddml.write_label(LabelWriter::new(1), txg).await.unwrap();
+        ddml.sync_all(txg).await.unwrap();
+    }
+    let last_txg = txg;
+
+    // Drop the pool and inject errors.  probability 100 means that after
+    // `count` successful writes, all following writes will fail.
+    drop(ddml);
+    ph.gnops[0].write_error_prob(100, write_fail_count);
+
+    // Reimport the pool
+    let mut manager = bfffs_core::pool::Manager::default();
+    for path in paths.iter() {
+        manager.taste(path).await.unwrap();
+    }
+    let (pool, _) = manager.import(pool_uuid).await.unwrap();
+
+    // Create new DDML.  It will immediately begin repairing the mirror
+    let mut ddml = DDML::open(pool, cache.clone());
+
+    // Wait for the repair to get aborted when gnop starts to return errors
+    while ddml.is_repairing() {
+        sleep(Duration::from_millis(10)).await;
+    }
+
+    // Drop the pool once more
+    drop(ddml);
+
+    // Clear errors and verify that the label's TXG is intermediate
+    ph.gnops[0].write_error_prob(0, 0);
+    let mut bmanager = bfffs_core::vdev_block::Manager::default();
+    bmanager.taste(&paths[0]).await.unwrap();
+    let (vb, _) = bmanager.import(leaf_uuid).await.unwrap();
+    println!("Rebuilding halted at txg {:?} out of {:?}", vb.txg(), last_txg);
+    assert!(vb.txg() > TxgT::from(1));
+    assert!(vb.txg() < last_txg);
+    drop(vb);
+
+    // Reimport and wait for completion
+    let mut manager = bfffs_core::pool::Manager::default();
+    for path in paths.iter() {
+        manager.taste(path).await.unwrap();
+    }
+    let (pool, _) = manager.import(pool_uuid).await.unwrap();
+    let ddml = DDML::open(pool, cache);
+    while ddml.status().await.clusters[0].mirrors[0].rebuilding.is_some() {
+        sleep(Duration::from_millis(10)).await;
     }
 }
 

--- a/bfffs-core/tests/functional/mirror.rs
+++ b/bfffs-core/tests/functional/mirror.rs
@@ -104,7 +104,7 @@ mod open {
         let uuid = old_vdev.uuid();
         let label_writer = LabelWriter::new(0);
         let txg = TxgT::from(1);
-        old_vdev.write_label(label_writer, txg).await.unwrap();
+        old_vdev.write_label(label_writer, txg, false).await.unwrap();
         let old_status = old_vdev.status();
         drop(old_vdev);
 
@@ -154,7 +154,7 @@ mod persistence {
         let (old_vdev, _tempdir, paths) = harness;
         let uuid = old_vdev.uuid();
         let label_writer = LabelWriter::new(0);
-        old_vdev.write_label(label_writer, TxgT::from(1)).await.unwrap();
+        old_vdev.write_label(label_writer, TxgT::from(1), false).await.unwrap();
         drop(old_vdev);
 
         let mut manager = Manager::default();
@@ -169,7 +169,7 @@ mod persistence {
     #[tokio::test]
     async fn write_label(harness: Harness) {
         let label_writer = LabelWriter::new(0);
-        harness.0.write_label(label_writer, TxgT::from(1)).await.unwrap();
+        harness.0.write_label(label_writer, TxgT::from(1), false).await.unwrap();
 
         for path in harness.2 {
             let mut f = fs::File::open(path).unwrap();

--- a/bfffs-core/tests/functional/raid/vdev_raid.rs
+++ b/bfffs-core/tests/functional/raid/vdev_raid.rs
@@ -227,7 +227,7 @@ mod errors {
 
             let zl = h.vdev.zone_limits(0);
             h.vdev.write_at(wbuf0, 0, zl.0).await.unwrap();
-            h.gnops[0].error_prob(100);
+            h.gnops[0].read_error_prob(100);
             h.vdev.clone().read_at(rbuf, zl.0).await.unwrap();
             assert!(wbuf1[..] == dbsr.try_const().unwrap()[..],
                 "miscompare!");
@@ -256,7 +256,7 @@ mod errors {
             let rbuf = dbsr.try_mut().unwrap();
 
             h.vdev.write_spacemap(vec![wbuf0], idx, block).await.unwrap();
-            h.gnops[0].error_prob(100);
+            h.gnops[0].read_error_prob(100);
             h.vdev.clone().read_spacemap(rbuf, idx).await.unwrap();
             assert!(wbuf1[..] == dbsr.try_const().unwrap()[..],
                 "miscompare!");

--- a/bfffs-core/tests/functional/util.rs
+++ b/bfffs-core/tests/functional/util.rs
@@ -96,6 +96,22 @@ impl Gnop {
             .success();
         assert!(r, "Failed to configure gnop");
     }
+
+    /// Set the probability of failure on write, from 0 to 100 percent.  `count`
+    /// is the number of I/O requests to allow to succeed before the error
+    /// probability takes effect.
+    pub fn write_error_prob(&self, prob: i32, count: u64) {
+        let r = Command::new("gnop")
+            .args(["configure", "-w"])
+            .arg(format!("{prob}"))
+            .arg("-c")
+            .arg(format!("{count}"))
+            .arg(self.as_path())
+            .status()
+            .expect("Failed to execute command")
+            .success();
+        assert!(r, "Failed to configure gnop");
+    }
 }
 impl Drop for Gnop {
     fn drop(&mut self) {

--- a/bfffs-core/tests/functional/util.rs
+++ b/bfffs-core/tests/functional/util.rs
@@ -86,7 +86,7 @@ impl Gnop {
     }
 
     /// Set the probability of failure on read, from 0 to 100 percent.
-    pub fn error_prob(&self, prob: i32) {
+    pub fn read_error_prob(&self, prob: i32) {
         let r = Command::new("gnop")
             .args(["configure", "-r"])
             .arg(format!("{prob}"))


### PR DESCRIPTION
When repairing a mirror, update the disk's label incrementally.  That way, if the pool is exported or power is lost, the repair can resume from where it left off.