### PR TITLE
Better incremental rebuild performance

### DIFF
--- a/bfffs-core/src/cluster.rs
+++ b/bfffs-core/src/cluster.rs
@@ -1176,15 +1176,13 @@ impl Cluster {
                 self.vdev.repair_mirror_zone(task.mirror_idx, zid, lbas).await?;
             }
             if let Some(sync_txg) = sync_txg {
-                // XXX this sync_all applies to the entire VdevRaid, not just
-                // the repairing device(s).  That's a performance bug.
-                self.vdev.sync_all().await?;
+                self.vdev.sync_all(Some(task.mirror_idx)).await?;
                 let lw = LabelWriter::new(0);
                 self.vdev.repair_label(lw, task.mirror_idx, sync_txg).await?;
-                self.vdev.sync_all().await?;
+                self.vdev.sync_all(Some(task.mirror_idx)).await?;
                 let lw = LabelWriter::new(1);
                 self.vdev.repair_label(lw, task.mirror_idx, sync_txg).await?;
-                self.vdev.sync_all().await?;
+                self.vdev.sync_all(Some(task.mirror_idx)).await?;
             }
             Ok(true)
         } else {
@@ -1222,7 +1220,7 @@ impl Cluster {
     /// Sync the `Cluster`, ensuring that all data written so far reaches stable
     /// storage.
     pub fn sync_all(&self) -> BoxVdevFut {
-        self.vdev.sync_all()
+        self.vdev.sync_all(None)
     }
 
     /// How many blocks are currently in use?
@@ -1851,7 +1849,7 @@ mod cluster {
         vr.expect_sync_all()
             .once()
             .in_sequence(&mut seq)
-            .return_once(|| Box::pin(future::ok(())));
+            .return_once(|_| Box::pin(future::ok(())));
         let fsm = FreeSpaceMap::new(vr.zones());
         let cluster = Cluster::new((fsm, vr.into()));
         cluster.fsm.write().unwrap().clear_dirty_zones();
@@ -2950,7 +2948,7 @@ mod repair_mirror {
         vr.expect_sync_all()
             .once()
             .in_sequence(seq)
-            .return_once(|| Box::pin(future::ok(())));
+            .return_once(|_| Box::pin(future::ok(())));
         vr.expect_repair_label()
             .once()
             .in_sequence(seq)
@@ -2959,7 +2957,7 @@ mod repair_mirror {
         vr.expect_sync_all()
             .once()
             .in_sequence(seq)
-            .return_once(|| Box::pin(future::ok(())));
+            .return_once(|_| Box::pin(future::ok(())));
         vr.expect_repair_label()
             .once()
             .in_sequence(seq)
@@ -2968,7 +2966,7 @@ mod repair_mirror {
         vr.expect_sync_all()
             .once()
             .in_sequence(seq)
-            .return_once(|| Box::pin(future::ok(())));
+            .return_once(|_| Box::pin(future::ok(())));
     }
 
     #[test]
@@ -3066,7 +3064,7 @@ mod repair_mirror {
             .with(eq(2))
             .return_const((20, 30));
         vr.expect_sync_all()
-            .returning(|| Box::pin(future::ok(())));
+            .returning(|_| Box::pin(future::ok(())));
         vr.expect_repair_label()
             .returning(|_, _, _| Box::pin(future::ok(())));
         vr.expect_repair_mirror_zone()

--- a/bfffs-core/src/raid/mod.rs
+++ b/bfffs-core/src/raid/mod.rs
@@ -249,7 +249,7 @@ mock!{
         fn repair_raid_zone(&self, zone: ZoneT) -> BoxVdevFut;
         fn restore(&mut self, mirror_idx: usize) -> Result<()>;
         fn status(&self) -> Status;
-        fn sync_all(&self) -> BoxVdevFut;
+        fn sync_all(&self, mirror_idx: Option<usize>) -> BoxVdevFut;
         fn uuid(&self) -> Uuid;
         fn write_at(&self, buf: IoVec, zone: ZoneT, lba: LbaT) -> BoxVdevFut;
         fn write_label(&self, labeller: LabelWriter, txg: TxgT) -> BoxVdevFut;

--- a/bfffs-core/src/raid/null_raid.rs
+++ b/bfffs-core/src/raid/null_raid.rs
@@ -189,7 +189,10 @@ impl VdevRaidApi for NullRaid {
         }
     }
 
-    fn sync_all(&self) -> BoxVdevFut {
+    fn sync_all(&self, mirror_idx: Option<usize>) -> BoxVdevFut {
+        if let Some(idx) = mirror_idx {
+            debug_assert_eq!(idx, 0);
+        }
         self.mirror.sync_all()
     }
 

--- a/bfffs-core/src/raid/vdev_raid.rs
+++ b/bfffs-core/src/raid/vdev_raid.rs
@@ -2359,7 +2359,7 @@ impl VdevRaidApi for VdevRaid {
         }
     }
 
-    fn sync_all(&self) -> BoxVdevFut {
+    fn sync_all(&self, mirror_idx: Option<usize>) -> BoxVdevFut {
         // Don't flush zones ourselves; the Cluster layer must be in charge of
         // that, so it can update the spacemap.
         debug_assert!(
@@ -2369,10 +2369,15 @@ impl VdevRaidApi for VdevRaid {
             "Must call flush_zone before sync_all"
         );
         // TODO: handle errors on some devices
-        let fut = self.inner.children.iter()
-        .filter_map(|bd| bd.sync_all())
-        .collect::<FuturesUnordered<_>>()
-        .try_collect::<Vec<_>>()
+        let fut = if let Some(idx) = mirror_idx {
+            self.inner.children[idx].sync_all()
+                .into_iter()
+                .collect::<FuturesUnordered<_>>()
+        } else {
+            self.inner.children.iter()
+                .filter_map(|bd| bd.sync_all())
+                .collect::<FuturesUnordered<_>>()
+        }.try_collect::<Vec<_>>()
         .map_ok(drop);
         Box::pin(fut)
     }

--- a/bfffs-core/src/raid/vdev_raid/tests.rs
+++ b/bfffs-core/src/raid/vdev_raid/tests.rs
@@ -2577,7 +2577,7 @@ mod sync_all {
                                       Uuid::new_v4(),
                                       LayoutAlgorithm::PrimeS,
                                       mirrors.into_boxed_slice());
-        vdev_raid.sync_all().now_or_never().unwrap().unwrap();
+        vdev_raid.sync_all(None).now_or_never().unwrap().unwrap();
     }
 
     #[test]
@@ -2607,7 +2607,7 @@ mod sync_all {
                                       Uuid::new_v4(),
                                       LayoutAlgorithm::PrimeS,
                                       mirrors.into_boxed_slice());
-        vdev_raid.sync_all().now_or_never().unwrap().unwrap();
+        vdev_raid.sync_all(None).now_or_never().unwrap().unwrap();
     }
 
     // It's illegal to sync a VdevRaid without flushing its zones first
@@ -2651,7 +2651,7 @@ mod sync_all {
         vdev_raid.open_zone(1).now_or_never().unwrap().unwrap();
         vdev_raid.write_at(wbuf, 1, 120_000).now_or_never().unwrap().unwrap();
         // Don't flush zone 1 before syncing.  Syncing should panic
-        vdev_raid.sync_all().now_or_never().unwrap().unwrap();
+        vdev_raid.sync_all(None).now_or_never().unwrap().unwrap();
     }
 }
 

--- a/bfffs-core/src/raid/vdev_raid_api.rs
+++ b/bfffs-core/src/raid/vdev_raid_api.rs
@@ -111,7 +111,9 @@ pub trait VdevRaidApi : Vdev + Send + Sync + 'static {
 
     /// Asynchronously sync the underlying device, ensuring that all data
     /// reaches stable storage
-    fn sync_all(&self) -> BoxVdevFut;
+    ///
+    /// If `mirror_idx` is set, only that child will be synced.
+    fn sync_all(&self, mirror_idx: Option<usize>) -> BoxVdevFut;
 
     /// Return the UUID for this vdev.  It is the persistent, unique identifier
     /// for each vdev.


### PR DESCRIPTION
When rebuilding a mirror member, don't sync_all for all disks, only the repairing member.