### PR TITLE
Tree::range_delete: better efficiency

### DIFF
--- a/bfffs-core/src/dataset/dataset.rs
+++ b/bfffs-core/src/dataset/dataset.rs
@@ -75,11 +75,9 @@ impl<K: Key, V: Value> Dataset<K, V> {
     }
 
     #[instrument(skip(self, range, txg))]
-    fn range_delete<R, T>(&self, range: R, txg: TxgT, credit: Credit)
+    fn range_delete<R>(&self, range: R, txg: TxgT, credit: Credit)
         -> impl Future<Output=Result<()>> + Send
-        where K: Borrow<T>,
-              R: Debug + Clone + RangeBounds<T> + Send + 'static,
-              T: Debug + Ord + Clone + Send + 'static
+        where R: Debug + Clone + RangeBounds<K> + Send + 'static,
     {
         self.tree.clone().range_delete(range, txg, credit).in_current_span()
     }
@@ -179,11 +177,9 @@ impl<K: Key, V: Value> ReadWriteDataset<K, V> {
         }
     }
 
-    pub fn range_delete<R, T>(&self, range: R)
+    pub fn range_delete<R>(&self, range: R)
         -> impl Future<Output=Result<()>> + Send
-        where K: Borrow<T>,
-              R: Debug + Clone + RangeBounds<T> + Send + 'static,
-              T: Debug + Ord + Clone + Send + 'static
+        where R: Debug + Clone + RangeBounds<K> + Send + 'static,
     {
         let credit = self.credit.atomic_split(self.cr.range_delete);
         self.dataset.range_delete(range, self.txg, credit)

--- a/bfffs-core/src/tree/node.rs
+++ b/bfffs-core/src/tree/node.rs
@@ -494,31 +494,26 @@ impl<K: Key, V: Value> LeafData<K, V> {
     /// Like [`range_delete`](Self::range_delete), but for nodes that may be
     /// dirty yet unaccredited.
     #[tracing::instrument(skip(self, dml, range))]
-    pub fn range_delete_unaccredited<D, R, T>(
+    pub fn range_delete_unaccredited<D, R>(
         &mut self,
         dml: &D,
         txg: TxgT,
         range: R) -> impl Future<Output=Result<Credit>> + Send
         where D: DML + 'static,
-              K: Borrow<T>,
-              R: RangeBounds<T>,
-              T: Ord + Clone
+              R: RangeBounds<K>,
     {
-        // TODO: use BTreeMap::drain_filter, when that feature stabilizes.
-        // https://github.com/rust-lang/rust/issues/70530
-        let keys = self.items.range(range)
-            .map(|(k, _)| *k)
-            .collect::<Vec<K>>();
-        let l = keys.len();
         let fut = FuturesUnordered::new();
         let mut allocated_space = 0;
-        for k in keys.into_iter() {
-            let v = self.items.remove(k.borrow()).unwrap();
+        let mut l = 0;
+
+        for (_k, v) in self.items.extract_if(range, |_, _| true) {
+            l += 1;
             allocated_space += v.allocated_space();
             if V::NEEDS_FLUSH {
                 fut.push(v.ddrop::<D>(dml, txg));
             }
         }
+
         let kvs = mem::size_of::<(K, V)>();
         let credit = self.credit.split(allocated_space + l * kvs);
         self.assert_accredited();
@@ -528,12 +523,10 @@ impl<K: Key, V: Value> LeafData<K, V> {
 
     /// Delete all keys within the given range, possibly leaving an empty
     /// LeafNode.
-    pub fn range_delete<D, R, T>(&mut self, dml: &D, txg: TxgT, range: R) ->
+    pub fn range_delete<D, R>(&mut self, dml: &D, txg: TxgT, range: R) ->
         impl Future<Output=Result<Credit>> + Send
         where D: DML + 'static,
-              K: Borrow<T>,
-              R: RangeBounds<T>,
-              T: Ord + Clone
+              R: RangeBounds<K>,
     {
         self.assert_accredited();
         self.range_delete_unaccredited(dml, txg, range)

--- a/bfffs-core/src/tree/tree/mod.rs
+++ b/bfffs-core/src/tree/tree/mod.rs
@@ -1475,15 +1475,13 @@ impl<A, D, K, V> Tree<A, D, K, V>
     // [^EXODUS]: Carey, Michael J., et al. "Storage management for objects in
     // EXODUS." Object-oriented concepts, databases, and applications (1989):
     // 341-369
-    pub async fn range_delete<R, T>(
+    pub async fn range_delete<R>(
         self: Arc<Self>,
         range: R,
         txg: TxgT,
         credit: Credit
     ) -> Result<()>
-        where K: Borrow<T>,
-              R: Debug + Clone + RangeBounds<T> + Send + 'static,
-              T: Ord + Clone + 'static + Debug
+        where R: Debug + Clone + RangeBounds<K> + Send + 'static,
     {
         if range.is_empty() {
             self.dml.repay(credit);
@@ -1600,7 +1598,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
     /// `
     /// A HashSet indicating which nodes in the cut are in-danger, indexed by
     /// the Node's memory address.
-    fn range_delete_pass1<R, T>(
+    fn range_delete_pass1<R>(
         limits: Limits,
         dml: Arc<D>,
         height: u8,
@@ -1612,9 +1610,7 @@ impl<A, D, K, V> Tree<A, D, K, V>
     ) -> impl Future<Output=Result<
             (HashSet<usize>, bool, usize, Credit)
         >> + Send
-        where K: Borrow<T>,
-              R: Debug + Clone + RangeBounds<T> + Send + 'static,
-              T: Ord + Clone + 'static + Debug
+        where R: Debug + Clone + RangeBounds<K> + Send + 'static,
     {
         // Enough for two nodes on each of six levels of a tree
         const HASHSET_CAPACITY: usize = 12;


### PR DESCRIPTION
Use the new BTreeMap::extract_if function, introduced in Rust 1.91.0, in range_delete_unaccredited.  This eliminates an allocation, and potentially is more efficient within BTreeMap (subject to the standard library's implementation details).